### PR TITLE
links with markup are not clickable

### DIFF
--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -26,6 +26,12 @@ shared_examples_for "click_link" do
         @session.click_link('A link')
         @session.body.should include('Bar')
       end
+
+      it "should match text within markup" do
+        @session.click_link('With Markup')
+        @session.body.should include('Bar')
+      end
+
     end
 
     context "with title given" do

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -35,6 +35,7 @@
   <input type="text" checked="checked" id="checked_field">
   <a href="/redirect"><img src="http://www.foobar.sun/dummy_image.jpg" width="20" height="20" alt="very fine image" /></a>
   <a href="/with_simple_html"><img src="http://www.foobar.sun/dummy_image.jpg" width="20" height="20" alt="fine image" /></a>
+  <a href="/with_simple_html"><em>With Markup</em></a>
 </p>
 
 <div id="hidden" style="display: none;">


### PR DESCRIPTION
failing test with fixture demonstrating that links with markup are not clickable when finding by text
