### PR TITLE
node[:content] for select tags in lib/capybara/driver/rack_test_driver.rb

### DIFF
--- a/lib/capybara/driver/rack_test_driver.rb
+++ b/lib/capybara/driver/rack_test_driver.rb
@@ -20,6 +20,14 @@ class Capybara::Driver::RackTest < Capybara::Driver::Base
           option = native.xpath(".//option[@selected='selected']").first || native.xpath(".//option").first
           option[:value] || option.content if option
         end
+      # BJM: adds support for extracting the 'text' (ie content) of the selected option, instead of the value
+      when 'select' == tag_name && 'content' == attr_name
+        if native['multiple'] == 'multiple'
+          native.xpath(".//option[@selected='selected']").map { |option| option.content  }
+        else
+          option = native.xpath(".//option[@selected='selected']").first || native.xpath(".//option").first
+          option.content if option
+        end
       when 'input' == tag_name && 'checkbox' == type && 'checked' == attr_name
         native[attr_name] == 'checked' ? true : false
       else


### PR DESCRIPTION
Howdy - 

Noticed in the latest capybara that my select tags comparisons via cucumber-rails (step_definitions/web_steps.rb) started failing. 

With the updated code in rack_test_driver.rb, there was no easy way to produce the content of the selected option within a select field. node[:value] produces the value, but for testing purposes I needed to check the displayed text content, not the value, of the selected option. 

For example, within the cucumber-rails default web_steps.rb:
    field_value = (field.tag_name == 'textarea') ? field.text : field.value
But now I can now do:
    field_value = (field.tag_name == 'textarea') ? field.text : (field.tag_name == 'select') ? field[:content] : field.value

to allow checking the actual text content of the selected option, while still allowing the value to be checked as well. 

Hope it helps, great gem!
--Ben
