### PR TITLE
Allow the Rack handler to be configured via Capybara.server

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -62,14 +62,7 @@ module Capybara
           Capybara::Server.ports[@app.object_id] = @port
 
           Thread.new do
-            begin
-              require 'rack/handler/thin'
-              Thin::Logging.silent = true
-              Rack::Handler::Thin.run(Identify.new(@app), :Port => @port)
-            rescue LoadError
-              require 'rack/handler/webrick'
-              Rack::Handler::WEBrick.run(Identify.new(@app), :Port => @port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0))
-            end
+            Capybara.server.call(Identify.new(@app), @port)
           end
 
           Capybara.timeout(10) { if responsive? then true else sleep(0.5) and false end }

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -25,4 +25,22 @@ describe Capybara do
     end
   end
 
+  describe ".server" do
+    after do
+      Capybara.server {|app, port| Capybara.run_default_server(app, port)}
+    end
+
+    it "should default to a proc that calls run_default_server" do
+      mock_app = mock('app')
+      Capybara.should_receive(:run_default_server).with(mock_app, 8000)
+      Capybara.server.call(mock_app, 8000)
+    end
+
+    it "should return a custom server proc" do
+      server = lambda {|app, port|}
+      Capybara.server(&server)
+      Capybara.server.should == server
+    end
+  end
+
 end


### PR DESCRIPTION
Followup to discussion at http://github.com/jnicklas/capybara/commit/ac4a340d04831630629aa4a23d1d8e139f5a8d5f

For example, to use mongrel rather than thin or webrick:

```
Capybara.server do |app, port|
  require 'rack/handler/mongrel'
  Rack::Handler::Mongrel.run(app, :Port => port)
end
```
