### PR TITLE
HTML5 file uploads with attribute "multiple" were not testing correctly

### DIFF
--- a/lib/capybara/driver/rack_test_driver.rb
+++ b/lib/capybara/driver/rack_test_driver.rb
@@ -113,7 +113,7 @@ class Capybara::Driver::RackTest < Capybara::Driver::Base
     def params(button)
       params = {}
 
-      native.xpath(".//input[not(@disabled) and (not(@type) or (@type!='radio' and not(@type='file' and @multiple) and @type!='checkbox' and @type!='submit' and @type!='image'))]").map do |input|
+      native.xpath(".//input[not(@disabled) and (not(@type) or (@type!='radio' and @type!='file' and @type!='checkbox' and @type!='submit' and @type!='image'))]").map do |input|
         merge_param!(params, input['name'].to_s, input['value'].to_s)
       end
       native.xpath(".//textarea[not(@disabled)]").map do |textarea|

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -53,6 +53,12 @@ shared_examples_for "attach_file" do
         @session.click_button 'Upload'
         @session.body.should include('image/jpeg')
       end
+
+      it  "should not break when using HTML5 multiple file input" do
+        @session.attach_file "Multiple Documents", @test_file_path
+        @session.click_button('Upload Multiple')
+        @session.body.should include(File.read(@test_file_path))
+      end
     end
 
     context "with a locator that doesn't exist" do

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -87,6 +87,17 @@ class TestApp < Sinatra::Base
       'No file uploaded'
     end
   end
+
+  post '/upload_multiple' do
+    begin
+      buffer = []
+      buffer << "Content-type: #{params[:form][:multiple_documents][0][:type]}"
+      buffer << "File content: #{params[:form][:multiple_documents][0][:tempfile].read}"
+      buffer.join(' | ')
+    rescue
+      'No files uploaded'
+    end
+  end
 end
 
 if __FILE__ == $0

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -266,6 +266,22 @@
   <p>
 </form>
 
+<form action="/upload_multiple" method="post" enctype="multipart/form-data">
+  <p>
+    <label for="form_multiple_file_name">File Name</label>
+    <input type="file" name="form[multiple_file_name]" id="form_multiple_file_name"/>
+  </p>
+
+  <p>
+    <label for="form_multiple_documents">Multiple Documents</label>
+    <input type="file" name="form[multiple_documents][]" id="form_multiple_documents" multiple />
+  </p>
+
+  <p>
+    <input type="submit" value="Upload Multiple"/>
+  <p>
+</form>
+
 <form action="/redirect" method="post">
   <p>
     <input type="submit" value="Go FAR"/>


### PR DESCRIPTION
We need to exclude file inputs with multiple (HTML5) i.e. <input type='file' name='image[file][]' multiple /> from this check because it will cast the value to_s which totally kills file uploads when inside an array (array is required for multiple files).

All my patch does is exclude (@type='file' and @multiple) from the first xpath check on the rack_test_driver which solves all the issues for me. All tests pass as before.

Thanks!
