### PR TITLE
Support for html5's contenteditable

### DIFF
--- a/lib/capybara/driver/selenium_driver.rb
+++ b/lib/capybara/driver/selenium_driver.rb
@@ -29,7 +29,7 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
         native.click
       elsif tag_name == 'input' and type == 'checkbox'
         native.click if value ^ native.attribute('checked').to_s.eql?("true")
-      elsif tag_name == 'textarea' or tag_name == 'input'
+      elsif tag_name == 'textarea' or tag_name == 'input' or native.attribute('contenteditable').to_s.eql?('true')
         native.clear
         native.send_keys(value.to_s)
       end

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -226,3 +226,16 @@ shared_examples_for "driver with infinite redirect detection" do
     end.should raise_error(Capybara::InfiniteRedirectError)
   end
 end
+
+shared_examples_for "driver with contenteditable support" do
+  before do
+    @driver.visit('/contenteditable')
+  end
+  
+  it "should allow assignment to nodes with contenteditable attribute true" do
+    @driver.find(%Q{//*[@contenteditable='true']}).first.set('Bafoon')
+    @driver.find(%Q{//*[@class='edit-me']}).first.text.should == 'Bafoon'
+  end
+  
+  
+end

--- a/lib/capybara/spec/views/contenteditable.erb
+++ b/lib/capybara/spec/views/contenteditable.erb
@@ -1,0 +1,2 @@
+<p>I'm not editable</p>
+<p contenteditable="true" class="edit-me" style="min-height: 1px"></p>

--- a/spec/driver/selenium_driver_spec.rb
+++ b/spec/driver/selenium_driver_spec.rb
@@ -11,4 +11,5 @@ describe Capybara::Driver::Selenium do
   it_should_behave_like "driver with support for window switching"
   it_should_behave_like "driver without status code support"
   it_should_behave_like "driver with cookies support"
+  it_should_behave_like "driver with contenteditable support"
 end


### PR DESCRIPTION
Please note:
The selenium webdriver doesn't properly support clearing out contenteditable nodes, so basically set() is more like prepend than set.
Also note that I wasn't quite sure how to express in the gemspec a dependency on another git repostory(xpath), so I moved it into the Gemfile. I need the xpath repository because I had to make some changes to xpath to make it recognize contenteditable as a fillable field too. There's a pull request for that too.

Sorry about the mess, but I'm not sure how this could have been done any different. (Except simply providing patches)
