### PR TITLE
Fix for issue 188

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -26,10 +26,9 @@ module Capybara
 
     def rewrite_css_and_image_references(response_html) # :nodoc:
       return response_html unless Capybara.asset_root
-      directories = Dir.new(Capybara.asset_root).entries.inject([]) do |list, name|
-        list << name if File.directory?(name) and not name.to_s =~ /^\./
-        list
-      end
+      directories = Dir.new(Capybara.asset_root).entries.select { |name|
+        File.directory?(name) and not name.to_s =~ /^\./
+      }
       response_html.gsub(/=("|')\/(#{directories.join('|')})/, '=\1' + Capybara.asset_root.to_s + '/\2')
     end
   end


### PR DESCRIPTION
This is a suggested fix for [issue 188](https://github.com/jnicklas/capybara/issues#issue/188) and one other minor self-explanatory tweak.  Adding '=' to the beginning of the gsub pattern does the trick when the paths are attributes within HTML elements, although it might miss some other cases which haven't occurred to me - I'll leave that decision to you :)

Thanks!
