### PR TITLE
Document gotcha about visiting absolute URLs in tests

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -473,6 +473,12 @@ Gems can use this API to add their own drivers to Capybara.
   use plugins which allow you to travel in time, rather than freeze time.
   One such plugin is {Timecop}[http://github.com/jtrupiano/timecop].
 
+* When using Rack::Test, beware if attempting to visit absolute URLs. For
+  example, a session might not be shared between visits to <tt>posts_path</tt>
+  and <tt>posts_url</tt>. If testing an absolute URL in an Action Mailer email,
+  set <tt>default_url_options</tt> to match the Rails default of
+  <tt>www.example.com</tt>.
+
 == License:
 
 (The MIT License)


### PR DESCRIPTION
This is a really tricky one, and I'm not sure I did the best possible job, but I wanted to add a note about a gotcha that I ran into. As discussed in this thread:

http://groups.google.com/group/ruby-capybara/browse_thread/thread/b13370f52e9f4194

...you really need to be careful when attempting to visit absolute URLs in tests. In this case, it was unavoidable because I need to use URLs in outgoing emails (as opposed to paths) and I found a relatively easy way to make it work. Put simply, the hosts all had to match up. 

Anyway, this doc note might help point someone in the right direction if they hit the same problem. 

Thanks!
