### PR TITLE
proper fix for issue 188

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -25,11 +25,15 @@ module Capybara
     end
 
     def rewrite_css_and_image_references(response_html) # :nodoc:
-      return response_html unless Capybara.asset_root
-      directories = Dir.new(Capybara.asset_root).entries.select { |name|
-        File.directory?(name) and not name.to_s =~ /^\./
+      root = Capybara.asset_root
+      return response_html unless root
+      directories = Dir.new(root).entries.select { |name|
+        (root+name).directory? and not name.to_s =~ /^\./
       }
-      response_html.gsub(/=("|')\/(#{directories.join('|')})/, '=\1' + Capybara.asset_root.to_s + '/\2')
+      if not directories.empty?
+        response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root + '/\2')
+      end
+      return response_html
     end
   end
 end

--- a/spec/save_and_open_page_spec.rb
+++ b/spec/save_and_open_page_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'capybara/util/save_and_open_page'
 require 'launchy'
 describe Capybara do
-  describe ".save_save_and_open_page" do
+  describe ".save_and_open_page" do
     before do
       @time = Time.new.strftime("%Y%m%d%H%M%S")
 
@@ -14,9 +14,25 @@ describe Capybara do
       @html = <<-HTML
         <html>
           <head>
+            <script type="text/javascript" src="/javascripts/prototype.js?123"/>
           </head>
           <body>
             <h1>test</h1>
+            <p>
+              Some images (note differing whitespace closing tag):
+              <img src="/images/image1.jpeg" />
+              <img src="/images/image2.jpeg"/>
+            </p>
+            <p>
+              Some more in a non-existent directory:
+              <img src="/img/image3.jpeg" />
+              <img src="/img/image4.jpeg"/>
+            </p>
+            <p>
+              <a href="/not-here/foo.html">
+                A link to a file in a non-existent directory.
+              </a>
+            </p>
           </body>
         <html>
       HTML
@@ -24,14 +40,18 @@ describe Capybara do
       Launchy::Browser.stub(:run)
     end
 
+    def default_file_expectations
+      @name = "capybara-#{@time}.html"
+
+      @temp_file.stub!(:path).and_return(@name)
+
+      File.should_receive(:exist?).and_return true
+      File.should_receive(:new).and_return @temp_file
+    end
+
     describe "defaults" do
       before do
-        @name = "capybara-#{@time}.html"
-
-        @temp_file.stub!(:path).and_return(@name)
-
-        File.should_receive(:exist?).and_return true
-        File.should_receive(:new).and_return @temp_file
+        default_file_expectations
       end
 
       it "should create a new temporary file" do
@@ -77,6 +97,62 @@ describe Capybara do
             Capybara.save_and_open_page_path.should == File.join('tmp', 'capybara')
           }.should_not raise_error
         Capybara.save_and_open_page_path = default_setting
+      end
+    end
+
+    describe "rewrite_css_and_image_references" do
+      before do
+        default_file_expectations
+        @asset_root_dir = "/path/to/rails/public"
+      end
+
+      def mock_asset_root_with(directories)
+        @asset_root = Pathname.new(@asset_root_dir)
+        Capybara.should_receive(:asset_root).and_return @asset_root
+
+        dir = mock('asset_root mock dir')
+        Dir.should_receive(:new).with(@asset_root).and_return dir
+
+        dirents = [ '.', '..', 'file.html' ] + directories
+        dir.should_receive(:entries).and_return dirents
+
+        directories_regexp = directories.join('|')
+        FileTest.should_receive(:directory?) \
+                .at_least(dirents.size - 2).times \
+                .and_return { |dir|
+          dir =~ %r!#{@asset_root_dir}/(#{directories_regexp})$!
+        }
+      end
+
+      def expected_html_for_asset_root_with(directories)
+        mock_asset_root_with(directories)
+
+        expected_html = @html.clone
+        if not directories.empty?
+          directories_regexp = directories.join('|')
+          expected_html.gsub!(/"(\/(#{directories_regexp})\/)/,
+                              '"%s\1' % @asset_root_dir)
+        end
+
+        return expected_html
+      end
+
+      def test_with_directories(directories)
+        @temp_file.should_receive(:write) \
+          .with expected_html_for_asset_root_with(directories)
+        Capybara.save_and_open_page @html
+      end
+
+      context "asset_root contains some directories" do
+        it "should rewrite relative paths to absolute local paths" do
+          test_with_directories([ 'javascripts', 'images' ])
+        end
+      end
+
+      context "asset_root path contains no directories" do
+        it "should not rewrite any relative paths" do
+          test_with_directories([ ])
+        end
       end
     end
   end


### PR DESCRIPTION
OK, take 2 :-)  This is a much better approach, and should be fairly self-explanatory now that I have provided specs.  If you run the new spec against the existing save_and_open_page.rb (the version prior to this commit), you will see it fail both of the new examples, and it should be clear by comparing the "expected" HTML against the "got" HTML why the existing version is buggy.
