### PR TITLE
Server boot timeout

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -14,7 +14,7 @@ module Capybara
 
   class << self
     attr_accessor :asset_root, :app_host, :run_server, :default_host
-    attr_accessor :server_port
+    attr_accessor :server_port, :server_boot_timeout
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
     attr_accessor :save_and_open_page_path
 
@@ -166,6 +166,7 @@ end
 Capybara.configure do |config|
   config.run_server = true
   config.server {|app, port| Capybara.run_default_server(app, port)}
+  config.server_boot_timeout = 10
   config.default_selector = :css
   config.default_wait_time = 2
   config.ignore_hidden_elements = false

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -65,7 +65,9 @@ module Capybara
             Capybara.server.call(Identify.new(@app), @port)
           end
 
-          Capybara.timeout(10) { if responsive? then true else sleep(0.5) and false end }
+          Capybara.timeout(Capybara.server_boot_timeout) do
+            if responsive? then true else sleep(0.5) and false end
+          end
         end
       end
     rescue TimeoutError


### PR DESCRIPTION
Hello,

This patch makes the server boot timeout configurable (`Capybara.server_boot_timeout`). Previously it was hardcoded to 10 (seconds I guess). I needed it, because our app is quite fat and needs time to boot. Without this, I'd have to monkey-patch Capybara.
