### PR TITLE
has_link? support for href values

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -207,7 +207,6 @@ module Capybara
       # @return [Boolean]                 Whether it exists
       #
       def has_link?(locator, options={})
-        options = set_link_options options
         has_xpath?(XPath::HTML.link(locator, options))
       end
 
@@ -220,7 +219,6 @@ module Capybara
       # @return [Boolean]            Whether it doesn't exist
       #
       def has_no_link?(locator, options={})
-        options = set_link_options options
         has_no_xpath?(XPath::HTML.link(locator, options))
       end
 
@@ -376,11 +374,6 @@ module Capybara
       #
       def has_no_table?(locator, options={})
         has_no_xpath?(XPath::HTML.table(locator, options))
-      end
-
-      private
-      def set_link_options(options)
-        String===options ? {:href => options} : options
       end
     end
   end

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -8,13 +8,11 @@ shared_examples_for "has_link" do
     it "should be true if the given link is on the page" do
       @session.should have_link('foo')
       @session.should have_link('awesome title')
-      @session.should have_link('A link', '/with_simple_html')
       @session.should have_link('A link', :href => '/with_simple_html')
     end
 
     it "should be false if the given link is not on the page" do
       @session.should_not have_link('monkey')
-      @session.should_not have_link('A link', '/non-existant-href')
       @session.should_not have_link('A link', :href => '/non-existant-href')
     end
   end
@@ -27,13 +25,11 @@ shared_examples_for "has_link" do
     it "should be false if the given link is on the page" do
       @session.should_not have_no_link('foo')
       @session.should_not have_no_link('awesome title')
-      @session.should_not have_no_link('A link', '/with_simple_html')
       @session.should_not have_no_link('A link', :href => '/with_simple_html')
     end
 
     it "should be true if the given link is not on the page" do
       @session.should have_no_link('monkey')
-      @session.should have_no_link('A link', '/non-existant-href')
       @session.should have_no_link('A link', :href => '/non-existant-href')
     end
   end


### PR DESCRIPTION
Added support for has_link? to check href values as discussed in this thread http://groups.google.com/group/ruby-capybara/browse_thread/thread/5ad7f46a2b14469a This commit also requires the HTML#link changes in the pull request I sent for the xpath project: https://github.com/jnicklas/xpath/pull/14

Steve
