### PR TITLE
Problems when concatenating

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -31,7 +31,7 @@ module Capybara
         (root+name).directory? and not name.to_s =~ /^\./
       }
       if not directories.empty?
-        response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root + '/\2')
+        response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root.to_s + '/\2')
       end
       return response_html
     end


### PR DESCRIPTION
Hi there, I noticed that after a commit (link below) on 11/21, save_and_open_page stopped working properly, and I noticed that it was due to a simple <em>to_s</em> that was missing in save_and_open_page.rb. There was also a failing spec, so I did the fix and all specs are passing now (I'm using Ruby 1.9.2p0 MRI). 

Hoping to be useful,

Guilherme

Commit:
SHA: 6fa8a5652c6ebf2eea4847928dfe55cd39a1b241
