### PR TITLE
Fixed a save_and_open_page issue with self-closed tags

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -31,7 +31,7 @@ module Capybara
         (root+name).directory? and not name.to_s =~ /^\./
       }
       if not directories.empty?
-        response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root + '/\2')
+        response_html.gsub!(/("|')\/(#{directories.join('|')})(?!>)/, '\1' + root + '/\2')
       end
       return response_html
     end


### PR DESCRIPTION
I noticed that when I looked at the source of files saved with save_and_open_page, any self-closed tags had their closing "/" replaced with the apps' root directory. I see why the replace is happening, but it shouldn't apply to the "/" in tags like <br />. I've solved this by adding a negative lookahead after the "/" that ensures that it's not followed by a ">".

I don't have tests for this change. I'm honestly not sure how to test it. However, in my app it works, leaving the self-closed tags intact while continuing to make the other public content refs (stylesheet, scripts, images, etc) pull from the right place.
