### PR TITLE
#select no longer has to be given an absolute option text

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -111,7 +111,7 @@ module Capybara
           no_select_msg = "cannot select option, no select box with id, name, or label '#{options[:from]}' found"
           no_option_msg = "cannot select option, no option with text '#{value}' in select box '#{options[:from]}'"
           select = find(:xpath, XPath::HTML.select(options[:from]), :message => no_select_msg)
-          select.find(:xpath, XPath::HTML.option(value), :message => no_option_msg).select_option
+          select.find(:xpath, option_xpath_for(value), :message => no_option_msg).select_option
         else
           no_option_msg = "cannot select option, no option with text '#{value}'"
           find(:xpath, XPath::HTML.option(value), :message => no_option_msg).select_option
@@ -153,6 +153,17 @@ module Capybara
       def attach_file(locator, path)
         msg = "cannot attach file, no file field with id, name, or label '#{locator}' found"
         find(:xpath, XPath::HTML.file_field(locator), :message => msg).set(path)
+      end
+
+      private
+      def option_xpath_for(value)
+        if [:any, :anything, :whatever].include? value
+          ".//option[@value != '']"
+        elsif value == :first_item
+          ".//option[1]"
+        else
+          XPath::HTML.option(value)
+        end
       end
     end
   end


### PR DESCRIPTION
I'm sure someone else can give me some pointers on a better implementation but this is my basic idea.

There are often times when you're creating tests when you don't care what item you're selecting from a `select` element.  Here's an extremely simple and somewhat illogical example to help illustrate:

```
Given a color exists
When I go to the t-shirt entry page
And I select anything from "Color"
etc, etc
```

I don't care if the `And a color exists` step creates "Green", "Blue" or whatever, I just need a color to select.

So after these modifications, you can do:
    select :anything, :from => "Color"
    select :first_item, :from => "Color"

The only difference being that if there's an empty value, `:anything` would return the second option and `:first_item` would return the first (empty) option.

So here's my first pass; the web steps will also need to be modified but I'd like to get comments first.
