### PR TITLE
Issue 188 commit fix

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -31,7 +31,7 @@ module Capybara
         (root+name).directory? and not name.to_s =~ /^\./
       }
       if not directories.empty?
-        response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root + '/\2')
+        response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root.to_s + '/\2')
       end
       return response_html
     end


### PR DESCRIPTION
There was an error introduced with the most recent commit involving the fix for paths added to self-closing tags (#188).

I was getting a `can't convert Pathname into String (TypeError)` error any time I tried to `save and open page`.

Small fix and I tried to run through the test to see why it was passing and the implementation was failing but I couldn't find anything.  The test in question has a lot of mocking and stubbing going on and just looking at it, it smelled bad.

It seems that at this point, it might be nice to have a `PathResolver` or something of the kind to abstract that away.  Just a thought.  Hope this helps.
