### PR TITLE
Uses Capybara.app_host when making requests via the Rack-Test driver

### DIFF
--- a/lib/capybara/driver/rack_test_driver.rb
+++ b/lib/capybara/driver/rack_test_driver.rb
@@ -224,6 +224,7 @@ class Capybara::Driver::RackTest < Capybara::Driver::Base
 
   def submit(method, path, attributes)
     path = request_path if not path or path.empty?
+    path = Capybara.app_host + path if Capybara.app_host and path.start_with?('/')
     send(method, to_binary(path), to_binary(attributes), env)
     follow_redirects!
   end

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -48,14 +48,44 @@ describe Capybara::Driver::RackTest do
     end
   end
 
-  it "should prefix urls with Capybara.app_host if app_host is set" do
-    Capybara.app_host = nil
-    @driver.visit('/')
-    @driver.last_request.url.should == 'http://www.example.com/'
+  describe "Capybara.app_host" do
+    after(:all) { Capybara.app_host = nil } # reset app_host back to nil
 
-    Capybara.app_host = 'http://foo.example.com'
-    @driver.visit('/')
-    @driver.last_request.url.should == 'http://foo.example.com/'
+    describe "set to custom host" do
+      before { Capybara.app_host = 'http://foo.example.com' }
+
+      it "should prefix urls with Capybara.app_host if app_host is set" do
+        @driver.visit('/')
+        @driver.last_request.url.should == 'http://foo.example.com/'
+      end
+
+      it "forms should POST to Capybara.app_host" do
+        @driver.visit('/form')
+        @driver.last_request.url.should == 'http://foo.example.com/form'
+
+        # click button that does a POST to "/form"
+        @driver.find('//input[@id="awe123"]').first.click
+        @driver.last_request.url.should == 'http://foo.example.com/form'
+      end
+    end
+
+    describe "set to nil" do
+      before { Capybara.app_host = nil }
+
+      it "should not prefix urls with Capybara.app_host" do
+        @driver.visit('/')
+        @driver.last_request.url.should == 'http://www.example.com/'
+      end
+
+      it "forms should POST normally" do
+        @driver.visit('/form')
+        @driver.last_request.url.should == 'http://www.example.com/form'
+
+        # click button that does a POST to "/form"
+        @driver.find('//input[@id="awe123"]').first.click
+        @driver.last_request.url.should == 'http://www.example.com/form'
+      end
+    end
   end
 
   it_should_behave_like "driver"


### PR DESCRIPTION
Issue: https://github.com/jnicklas/capybara/issues/232

Thread discussing this: http://groups.google.com/group/ruby-capybara/msg/5f9a726bc4de0b7d

I'm not sure if this change will fix what everyone else wants, but it probably will?  This was enough for me to write specs against my own app which uses different subdomains.
