### PR TITLE
Adding wait_for_ajax

### DIFF
--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -47,6 +47,10 @@ class Capybara::Driver::Base
     false
   end
 
+  def wait_for_ajax(handle)
+    raise Capybara::NotSupportedByDriverError
+  end
+
   def wait_until(*args)
   end
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -30,7 +30,7 @@ module Capybara
       :all, :first, :attach_file, :body, :check, :choose, :click_link_or_button, :click_button, :click_link, :current_url, :drag, :evaluate_script,
       :field_labeled, :fill_in, :find, :find_button, :find_by_id, :find_field, :find_link, :has_content?, :has_css?,
       :has_no_content?, :has_no_css?, :has_no_xpath?, :has_xpath?, :locate, :save_and_open_page, :select, :source, :uncheck,
-      :visit, :wait_until, :within, :within_fieldset, :within_table, :within_frame, :within_window, :has_link?, :has_no_link?, :has_button?,
+      :visit, :wait_until, :wait_for_ajax, :within, :within_fieldset, :within_table, :within_frame, :within_window, :has_link?, :has_no_link?, :has_button?,
       :has_no_button?, :has_field?, :has_no_field?, :has_checked_field?, :has_unchecked_field?, :has_no_table?, :has_table?,
       :unselect, :has_select?, :has_no_select?, :current_path, :click, :has_selector?, :has_no_selector?, :click_on
     ]
@@ -218,8 +218,20 @@ module Capybara
     #
     # @param [Integer] timeout   The amount of seconds to retry executing the given block
     #
+    #yield
     def wait_until(timeout = Capybara.default_wait_time)
       Capybara.timeout(timeout,driver) { yield }
+    end
+
+    ##
+    #
+    # Execute the contents of the block and wait until no ajax requests are in flight, or the timeout is exceeded
+    #
+    # @param [Integer] timeout   The amount of seconds to wait for ajax requests to return
+    #
+    #yield
+    def wait_for_ajax(timeout = Capybara.default_wait_time)
+      driver.wait_for_ajax( timeout ) { yield }
     end
 
     ##

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -113,6 +113,20 @@ shared_examples_for "driver with javascript support" do
       @driver.evaluate_script('1+1').should == 2
     end
   end
+
+end
+
+shared_examples_for "driver with wait_for_ajax support" do
+  before { @driver.visit('/with_js') }
+  describe "#wait_for_ajax" do
+    it "should wait for all ajax requests to finish" do
+      @driver.wait_for_ajax(5) do 
+        puts "Firing request"
+        @driver.find('//input[@id="fire_ajax_request"]').first.click
+      end
+      @driver.find('//p[@id="ajax_request_done"]').should_not be_empty
+    end
+  end
 end
 
 shared_examples_for "driver with header support" do

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -30,4 +30,9 @@ $(function() {
   $('#checkbox_with_event').click(function() {
     $('body').append('<p id="checkbox_event_triggered">Checkbox event triggered</p>')
   });
+  $('#fire_ajax_request').click(function() {
+    $.ajax({url: "/slow_response", context: document.body, success: function() { 
+      $('body').append('<p id="ajax_request_done">Ajax request done</p>')
+    }});
+  });
 });

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -59,6 +59,11 @@ class TestApp < Sinatra::Base
     redirect back
   end
 
+  get '/slow_response' do
+    sleep 2
+    'Finally!'
+  end
+
   get '/set_cookie' do
     cookie_value = 'test_cookie'
     response.set_cookie('capybara', cookie_value)

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -34,6 +34,10 @@
     <p>
       <input type="checkbox" id="checkbox_with_event"/>
     </p>
+
+    <p>
+      <input type="submit" id="fire_ajax_request" value="Fire Ajax Request"/>
+    </p>
   </body>
 </html>
 

--- a/spec/driver/selenium_driver_spec.rb
+++ b/spec/driver/selenium_driver_spec.rb
@@ -7,6 +7,7 @@ describe Capybara::Driver::Selenium do
 
   it_should_behave_like "driver"
   it_should_behave_like "driver with javascript support"
+  it_should_behave_like "driver with wait_for_ajax support"
   it_should_behave_like "driver with frame support"
   it_should_behave_like "driver with support for window switching"
   it_should_behave_like "driver without status code support"


### PR DESCRIPTION
These commits add a new command called 'wait_for_ajax', which executes a block expected to fire off some Ajax requests, and will then block until these requests finish.  I've found that I need something like this since the response time of my asynchronous calls can vary wildly in my test environment. 

Also, there's some stuff I added to 'within_window' to let you switch to a window by title or url.
