### PR TITLE
Save the HTML-Document when a Cucumber Scenario fails

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -13,6 +13,7 @@ Release date:
 * Built in support for RSpec [Jonas Nicklas]
 * Capybara.using_driver to switch to a different driver temporarily [Jeff Kreeftmeijer]
 * Added Session#first which is somewhat speedier than Session#all, use it internally for speed boost [John Firebaugh]
+* Capybara.save_failed_scenarios to keep a copy of the html when a scenario fails [Yves Senn]
 
 ### Changed
 

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -15,7 +15,7 @@ module Capybara
     attr_accessor :asset_root, :app_host, :run_server, :default_host
     attr_accessor :server_port, :server_boot_timeout
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
-    attr_accessor :save_and_open_page_path
+    attr_accessor :save_and_open_page_path, :save_failed_scenarios
 
     ##
     #
@@ -212,6 +212,7 @@ Capybara.configure do |config|
   config.default_selector = :css
   config.default_wait_time = 2
   config.ignore_hidden_elements = false
+  config.save_failed_scenarios = true
 end
 
 Capybara.register_driver :rack_test do |app|

--- a/lib/capybara/cucumber.rb
+++ b/lib/capybara/cucumber.rb
@@ -30,3 +30,20 @@ end
 After do
   Capybara.use_default_driver
 end
+
+Before do
+  if Capybara.save_failed_scenarios && !$capybara_failed_scenarios_have_been_deleted
+    require 'capybara/util/save_and_open_page'
+    Capybara.delete_saved_pages
+    $capybara_failed_scenarios_have_been_deleted = true
+  end
+end
+
+After do |scenario|
+  if Capybara.save_failed_scenarios && scenario.failed?
+    name = scenario.name
+    name = "#{scenario.scenario_outline.name}_00_#{name}" if scenario.respond_to? :scenario_outline
+    name = name.gsub /\s/, '_'
+    Capybara.save_page(body, "#{name}.html")
+  end
+end

--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -1,7 +1,13 @@
 module Capybara
   class << self
     def save_and_open_page(html)
-      name = File.join(*[Capybara.save_and_open_page_path, "capybara-#{Time.new.strftime("%Y%m%d%H%M%S")}.html"].compact)
+      saved_page = save_page(html)
+      open_in_browser(saved_page)
+    end
+
+    def save_page(html, filename = nil)
+      filename = "capybara-#{Time.new.strftime("%Y%m%d%H%M%S")}.html" unless filename
+      name = File.join(*[Capybara.save_and_open_page_path, filename].compact)
 
       unless Capybara.save_and_open_page_path.nil? || File.directory?(Capybara.save_and_open_page_path )
         FileUtils.mkdir_p(Capybara.save_and_open_page_path)
@@ -11,8 +17,13 @@ module Capybara
       tempfile = File.new(name,'w')
       tempfile.write(rewrite_css_and_image_references(html))
       tempfile.close
+      tempfile.path
+    end
 
-      open_in_browser(tempfile.path)
+    def delete_saved_pages
+      Dir.glob File.join(Capybara.save_and_open_page_path, '*.html') do |filename|
+        File.delete(filename)
+      end
     end
 
   protected

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -14,6 +14,21 @@ describe Capybara do
     end
   end
 
+  describe "save_failed_scenarios" do
+    after do
+      Capybara.save_failed_scenarios = true
+    end
+
+    it "should be true by default" do
+      Capybara.save_failed_scenarios.should == true
+    end
+
+    it "should be changeable" do
+      Capybara.save_failed_scenarios = false
+      Capybara.save_failed_scenarios.should == false
+    end
+  end
+
   describe '.register_driver' do
     it "should add a new driver" do
       Capybara.register_driver :schmoo do |app|


### PR DESCRIPTION
This patch adds an option to Capybara to save the HTML-Documents automatically when a Cucumber Scenario fails. This is very handy when developing new features because you always have a reference to the state where your scenario failed.
Another use-case is a CI-Server. It is great to keep the failed HTML-Documents form your CI builds and archive them as artifacts. This way you can always pull up the state where the CI-Server failed.

I changed the involved specs and added a Capybara.save_failed_scenarios option.

Cheers
-- Yves
