### PR TITLE
Verify drivers send back responses with the correct encoding (ruby 1.9)

### DIFF
--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -26,6 +26,20 @@ shared_examples_for 'driver' do
       @driver.visit('/with_simple_html')
       @driver.body.should include('Bar')
     end
+
+    if "".respond_to?(:encoding)
+      context "encoding of response between ascii and utf8" do
+        it "should be valid with html entities" do
+          @driver.visit('/with_html_entities')
+          lambda { @driver.body.encode!("UTF-8") }.should_not raise_error
+        end
+
+        it "should be valid without html entities" do
+          @driver.visit('/with_html')
+          lambda { @driver.body.encode!("UTF-8") }.should_not raise_error
+        end
+      end
+    end
   end
 
   describe '#find' do

--- a/lib/capybara/spec/views/with_html_entities.erb
+++ b/lib/capybara/spec/views/with_html_entities.erb
@@ -1,0 +1,1 @@
+Encoding with &mdash; html entities &raquo;


### PR DESCRIPTION
Using ruby 1.9.2 with rvm, capybara from git and akephalos (javascript driver for capybara) from my git repo.

The problem comes up when you called show me the page in a cucumber step.  When capybara gets the response body from akephalos it is a utf8 string with its encoding set as "ASCII-8BIT".  This causes problems when capybara tries to write the page to a File that is expecting UTF8 because Ruby will try and #encode!("UTF-8") the string which raises a conversion error.

This set of specs verifies that a driver is sending back a string that can be safely #encode!("UTF-8")    The drivers in the capybara repository do not fail these set of specs but akephalos will (before my changes to fix it).

My reasoning for including these specs in capybara is so all drivers (assuming they use the shared specs) will send back response bodies with the correct encoding.  Otherwise capybara will fail when doing save_and_open_page because of the conversion issue.  This makes the drivers themselves do the right thing instead of cleaning up everything in capybara.

If you want you can do:

```
str = "\xe2\x80\x94".force_encoding("UTF-8").encode!("UTF-8")
p str
tmp = str.force_encoding("ASCII-8BIT")
tmp.encode!("UTF-8")
```

in a ruby 1.9 console.  "\xe2\x80\x94" is the "&mdash;" html entity in unicode.  The above code is taking a utf8 string with the converted html entity, forcing it to "ASCII-8BIT" which is what akephalos has its response body set to and then trying to encode it back to UTF8.

This may affect capybara-mechanize due to issue https://github.com/jeroenvandijk/capybara-mechanize/issues#issue/12   but I have not yet verified that.
