### PR TITLE
Fix for issue introduced in fix for 200

### DIFF
--- a/lib/capybara/driver/selenium_driver.rb
+++ b/lib/capybara/driver/selenium_driver.rb
@@ -91,7 +91,7 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
 
   def browser
     unless @browser
-      @browser = Selenium::WebDriver.for(options[:browser] || :firefox, options)
+      @browser = Selenium::WebDriver.for(options[:browser] || :firefox, options.reject{|key,val| key == :browser})
       at_exit do
         @browser.quit
       end


### PR DESCRIPTION
Fixing an issue introduced in commit e514f2e99cceb3db5be2a6fef8fdfd9a2cb74e2d for issue 200

After upgrading capybara to 0.4.1.1 and attempting to run our tests, the fix for issue 200 no longer deletes :browser from the options.  This does fix that issue, but options is now passed to Selenium::WebDriver.for with the :browser key still in the options which then throws an argument error.  The code is in Selenium::WebDriver::Firefox::Bridge:18
