### PR TITLE
Capybara.app_host support for all drivers (specs for local driving)

### DIFF
--- a/lib/capybara/driver/rack_test_driver.rb
+++ b/lib/capybara/driver/rack_test_driver.rb
@@ -203,6 +203,7 @@ class Capybara::Driver::RackTest < Capybara::Driver::Base
   def process(method, path, attributes = {})
     return if path.gsub(/^#{request_path}/, '') =~ /^#/
     path = request_path + path if path =~ /^\?/
+    path = Capybara.app_host + path if Capybara.app_host and path.start_with?('/')
     send(method, to_binary(path), to_binary( attributes ), env)
     follow_redirects!
   end
@@ -235,6 +236,7 @@ class Capybara::Driver::RackTest < Capybara::Driver::Base
 
   def submit(method, path, attributes)
     path = request_path if not path or path.empty?
+    path = Capybara.app_host + path if Capybara.app_host and path.start_with?('/')
     send(method, to_binary(path), to_binary(attributes), env)
     follow_redirects!
   end

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -39,7 +39,8 @@ module Capybara
       if path =~ /^http/
         path
       else
-        (Capybara.app_host || "http://#{host}:#{port}") + path.to_s
+        port_str = Capybara.run_server ? ":#{port}" : ""
+        (Capybara.app_host || "http://#{host}") + port_str + path.to_s
       end
     end
 

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -14,6 +14,9 @@ class TestApp < Sinatra::Base
     'Another World'
   end
 
+  get '/request_info' do
+    "Your Request: #{request.inspect}"
+  end
   get '/redirect' do
     redirect '/redirect_again'
   end

--- a/spec/driver/celerity_driver_spec.rb
+++ b/spec/driver/celerity_driver_spec.rb
@@ -6,6 +6,7 @@ describe Capybara::Driver::Celerity, :jruby => :platform do
   end
 
   it_should_behave_like "driver"
+  it_should_behave_like "driver with local server"
   it_should_behave_like "driver with javascript support"
   it_should_behave_like "driver with header support"
   it_should_behave_like "driver with status code support"

--- a/spec/driver/culerity_driver_spec.rb
+++ b/spec/driver/culerity_driver_spec.rb
@@ -7,6 +7,7 @@ describe Capybara::Driver::Culerity, :jruby => :installed do
   end
 
   it_should_behave_like "driver"
+  it_should_behave_like "driver with local server"
   it_should_behave_like "driver with javascript support"
   it_should_behave_like "driver with header support"
   it_should_behave_like "driver with status code support"

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -49,6 +49,7 @@ describe Capybara::Driver::RackTest do
   end
 
   it_should_behave_like "driver"
+  it_should_behave_like "driver with local server"
   it_should_behave_like "driver with header support"
   it_should_behave_like "driver with status code support"
   it_should_behave_like "driver with cookies support"

--- a/spec/driver/remote_culerity_driver_spec.rb
+++ b/spec/driver/remote_culerity_driver_spec.rb
@@ -4,9 +4,11 @@ describe Capybara::Driver::Culerity, :jruby => :installed do
   before(:all) do
     Capybara.app_host = "http://capybara-testapp.heroku.com"
     @driver = TestSessions::Culerity.driver
+    Capybara.run_server = false
   end
 
   after(:all) do
+    Capybara.run_server = true
     Capybara.app_host = nil
   end
 

--- a/spec/driver/selenium_driver_spec.rb
+++ b/spec/driver/selenium_driver_spec.rb
@@ -6,6 +6,7 @@ describe Capybara::Driver::Selenium do
   end
 
   it_should_behave_like "driver"
+  it_should_behave_like "driver with local server"
   it_should_behave_like "driver with javascript support"
   it_should_behave_like "driver with frame support"
   it_should_behave_like "driver with support for window switching"


### PR DESCRIPTION
Issue: https://github.com/jnicklas/capybara/issues/232
I took the solution for RackTest from https://github.com/jnicklas/capybara/pull/234 (and most of the tests)
and added compatibility for the other drivers.
I added tests only for "local drivers" because I couldn't find a simple way to decouple the state which says if the driver should use the port from the server or not.

Any sugestions to improve it or any comments about this solution?
