### PR TITLE
Do not pass on :browser to Webdriver

### DIFF
--- a/lib/capybara/driver/selenium_driver.rb
+++ b/lib/capybara/driver/selenium_driver.rb
@@ -91,7 +91,7 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
 
   def browser
     unless @browser
-      @browser = Selenium::WebDriver.for(options[:browser] || :firefox, options)
+      @browser = Selenium::WebDriver.for(options.delete(:browser) || :firefox, options)
       at_exit do
         @browser.quit
       end


### PR DESCRIPTION
This broke Capybara::Driver::Selenium.new(app, :browser => :firefox).

There's no obvious way to test this right now, since Capybara::Driver::Selenium.new (which is where we could set options) doesn't get called from the test suite.  So I figured I'd rather just submit the fix without a test for now -- hope that's OK?
