### PR TITLE
more robust querying of Selenium Nodes which have been removed from the DOM

### DIFF
--- a/lib/capybara/driver/selenium_driver.rb
+++ b/lib/capybara/driver/selenium_driver.rb
@@ -4,6 +4,8 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
   class Node < Capybara::Driver::Node
     def text
       native.text
+    rescue Selenium::WebDriver::Error::ObsoleteElementError
+      ''
     end
 
     def [](name)
@@ -61,6 +63,8 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
     def visible?
       displayed = native.displayed?
       displayed and displayed != "false"
+    rescue Selenium::WebDriver::Error::ObsoleteElementError
+      false
     end
 
     def selected?

--- a/spec/driver/selenium_driver_spec.rb
+++ b/spec/driver/selenium_driver_spec.rb
@@ -11,4 +11,38 @@ describe Capybara::Driver::Selenium do
   it_should_behave_like "driver with support for window switching"
   it_should_behave_like "driver without status code support"
   it_should_behave_like "driver with cookies support"
+
+  describe "Node" do
+    before do
+      @driver = mock
+      @native = mock
+      @node = Capybara::Driver::Selenium::Node.new(@driver, @native)
+    end
+
+    describe "#text" do
+      it "returns text from the native driver" do
+        @native.should_receive(:text).and_return('happy capybara')
+        @node.text.should == 'happy capybara'
+      end
+
+      it "returns '' if the the element has been removed from the dom" do
+        @native.should_receive(:text).and_raise(Selenium::WebDriver::Error::ObsoleteElementError.new('angry capybara'))
+        @node.text.should == ''
+      end
+    end
+
+    describe "#visible?" do
+      it "returns visibility based on the native driver" do
+        @native.should_receive(:displayed?).and_return('true')
+        @node.should be_visible
+        @native.should_receive(:displayed?).and_return('false')
+        @node.should_not be_visible
+      end
+
+      it "returns text from the native driver" do
+        @native.should_receive(:displayed?).and_raise(Selenium::WebDriver::Error::ObsoleteElementError.new('angry capybara'))
+        @node.should_not be_visible
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Capybara::Driver::Selenium::Node#text` now returns `""` and `Capybara::Driver::Selenium::Node#visible?` returns `false` if the native driver raises `Selenium::WebDriver::Error::ObsoleteElementError`.

This change address [an issue](http://groups.google.com/group/ruby-capybara/browse_thread/thread/76c194b92c58ecef) where tests attempting to use the has_no_selector helper to verify an element has been removed from the DOM would intermittently fail due to a `Selenium::WebDriver::Error::ObsoleteElementError` complaining about an attempt to access a node which is no longer in the DOM. 
