### PR TITLE
Fix for Document#text method 

### DIFF
--- a/lib/capybara/node/document.rb
+++ b/lib/capybara/node/document.rb
@@ -18,7 +18,7 @@ module Capybara
       # @return [String]    The text of the document
       #
       def text
-        find('.').text
+        find(:xpath, '/html').text
       end
     end
   end

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -99,6 +99,11 @@ shared_examples_for 'driver' do
         @driver.find('//option[@value="sv"]')[0].should_not be_selected
         @driver.find('//h1')[0].should_not be_selected
       end
+
+      it "should return document text on /html selector" do
+        @driver.visit('/with_simple_html')
+        @driver.find('/html')[0].text.should == 'Bar'
+      end
     end
   end
 end

--- a/lib/capybara/spec/session.rb
+++ b/lib/capybara/spec/session.rb
@@ -66,6 +66,7 @@ shared_examples_for "session" do
   it_should_behave_like "has_select"
   it_should_behave_like "has_table"
   it_should_behave_like "select"
+  it_should_behave_like "text"
   it_should_behave_like "uncheck"
   it_should_behave_like "unselect"
   it_should_behave_like "within"

--- a/lib/capybara/spec/session/text_spec.rb
+++ b/lib/capybara/spec/session/text_spec.rb
@@ -1,0 +1,19 @@
+shared_examples_for "text" do
+  describe '#text' do
+    before do
+      @session.visit('/with_simple_html')
+    end
+
+    it "should print the text of the page" do
+      @session.text.should == 'Bar'
+    end
+
+    context "with css as default selector" do
+      before { Capybara.default_selector = :css }
+      it "should print the text of the page" do
+        @session.text.should == 'Bar'
+      end
+      after { Capybara.default_selector = :xpath }
+    end
+  end
+end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -250,6 +250,16 @@ describe Capybara::RSpecMatchers do
             page.should have_content('No such Text')
           end.to raise_error(/expected there to be content "No such Text" in "(.*)This is a test(.*)"/)
         end
+
+        context "with default selector CSS" do
+          before { Capybara.default_selector = :css }
+          it "fails if has_css? returns false" do
+            expect do
+              page.should have_content('No such Text')
+            end.to raise_error(/expected there to be content "No such Text" in "(.*)This is a test(.*)"/)
+          end
+          after { Capybara.default_selector = :xpath }
+        end
       end
 
       context "with should_not" do


### PR DESCRIPTION
The Document#text method was broken.  Here are some tests and a fix for it.  I found this issue while looking at the failure message of the have_content matcher, so there is also a test for that. 
