### PR TITLE
to_i matcher opts

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -43,11 +43,11 @@ module Capybara
           when options[:between]
             options[:between] === results.size
           when options[:count]
-            options[:count] == results.size
+            options[:count].to_i == results.size
           when options[:maximum]
-            options[:maximum] >= results.size
+            options[:maximum].to_i >= results.size
           when options[:minimum]
-            options[:minimum] <= results.size
+            options[:minimum].to_i <= results.size
           else
             results.size > 0
           end
@@ -75,11 +75,11 @@ module Capybara
           when options[:between]
             not(options[:between] === results.size)
           when options[:count]
-            not(options[:count] == results.size)
+            not(options[:count].to_i == results.size)
           when options[:maximum]
-            not(options[:maximum] >= results.size)
+            not(options[:maximum].to_i >= results.size)
           when options[:minimum]
-            not(options[:minimum] <= results.size)
+            not(options[:minimum].to_i <= results.size)
           else
             results.empty?
           end

--- a/lib/capybara/spec/session/has_css_spec.rb
+++ b/lib/capybara/spec/session/has_css_spec.rb
@@ -54,6 +54,11 @@ shared_examples_for "has_css" do
         @session.should_not have_css("abbr", :count => 2)
         @session.should_not have_css("p a.doesnotexist", :count => 1)
       end
+
+      it "should coerce count to an integer" do
+        @session.should have_css("p", :count => "3")
+        @session.should have_css("p a#foo", :count => "1")
+      end
     end
 
     context "with maximum" do
@@ -72,6 +77,11 @@ shared_examples_for "has_css" do
         @session.should_not have_css("abbr", :maximum => 2)
         @session.should_not have_css("p a.doesnotexist", :maximum => 1)
       end
+
+      it "should coerce maximum to an integer" do
+        @session.should have_css("h2.head", :maximum => "5") # edge case
+        @session.should have_css("h2", :maximum => "10")
+      end
     end
 
     context "with minimum" do
@@ -89,6 +99,11 @@ shared_examples_for "has_css" do
       it "should be false if the content isn't on the page at all" do
         @session.should_not have_css("abbr", :minimum => 2)
         @session.should_not have_css("p a.doesnotexist", :minimum => 7)
+      end
+
+      it "should coerce minimum to an integer" do
+        @session.should have_css("h2.head", :minimum => "5") # edge case
+        @session.should have_css("h2", :minimum => "3")
       end
     end
 
@@ -160,6 +175,11 @@ shared_examples_for "has_css" do
         @session.should have_no_css("abbr", :count => 2)
         @session.should have_no_css("p a.doesnotexist", :count => 1)
       end
+
+      it "should coerce count to an integer" do
+        @session.should_not have_no_css("p", :count => "3")
+        @session.should_not have_no_css("p a#foo", :count => "1")
+      end
     end
 
     context "with maximum" do
@@ -178,6 +198,11 @@ shared_examples_for "has_css" do
         @session.should have_no_css("abbr", :maximum => 5)
         @session.should have_no_css("p a.doesnotexist", :maximum => 10)
       end
+
+      it "should coerce maximum to an integer" do
+        @session.should_not have_no_css("h2.head", :maximum => "5") # edge case
+        @session.should_not have_no_css("h2", :maximum => "10")
+      end
     end
 
     context "with minimum" do
@@ -195,6 +220,11 @@ shared_examples_for "has_css" do
       it "should be true if the content isn't on the page at all" do
         @session.should have_no_css("abbr", :minimum => 5)
         @session.should have_no_css("p a.doesnotexist", :minimum => 10)
+      end
+
+      it "should coerce minimum to an integer" do
+        @session.should_not have_no_css("h2.head", :minimum => 4) # edge case
+        @session.should_not have_no_css("h2", :minimum => 3)
       end
     end
 


### PR DESCRIPTION
It's pretty common to have cucumber steps that look like this:

Then /^I should see (\d+) post summaries$/ do |n|
  page.should have_css(".post_summary", :count => n)
end

You'll notice my mistake above. I didn't convert n to an integer. The resulting error is:

Then I should see 3 post summaries     # features/step_definitions/posts.rb:6
      expected #has_css?(".post_summary") to return true, got false (RSpec::Expectations::ExpectationNotMetError)
      ./features/step_definitions/posts.rb:7:in `/^I should see (\d+) post summaries$/'
      features/user_views_posts.feature:15:in`Then I should see 3 post summaries'

This led me to look at the page in a browser, confirm that the markup was correct, and forcefully remove some hair. I found my mistake a few minutes later, but if I had been new to ruby/rails/cucumber, I wouldn't have caught my mistake and wouldn't have had a helpful error message to guide me out of it.

Since Integer.to_i is so cheap, I didn't see any harm in sprinkling in to_i for count, minimum, and maximum (along with the relevant tests). I think it's a win for making the path for programmers new to the stack as smooth as possible.

Tests are included. Let me know if you have any feedback.
