### PR TITLE
Docs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -203,7 +203,7 @@ JavaScript outside the browser. The driver is installed by installing the capyba
 More info about the driver and env.js are available through the links above. The envjs gem only supports
 Ruby 1.8.7 at this time.
 
-== The DSL
+== <span id=dsl>The DSL</span>
 
 Capybara's DSL (domain-specific language) is inspired by Webrat. While
 backwards compatibility is retained in a lot of cases, there are certain


### PR DESCRIPTION
- Added #dsl anchor in README

Figured this would be very useful for linking.

(We can't have quotes around `dsl`, they'll get mangled.)
