### PR TITLE
Attach file on windows

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -153,6 +153,7 @@ module Capybara
       #
       def attach_file(locator, path)
         msg = "cannot attach file, no file field with id, name, or label '#{locator}' found"
+        path.gsub!(/\//, "\\") if path.match(/^C:\//)
         find(:xpath, XPath::HTML.file_field(locator), :message => msg).set(path)
       end
     end


### PR DESCRIPTION
Hi,
I posted on the [mailing list](https://groups.google.com/group/ruby-capybara/browse_thread/thread/e2f4df9c29deb727/90b8a9a94f5f0eaa) about this a while ago, but didn't get any feedback, so I thought I'd just submit this for discussion.

Jonas, I've also seen your amazement on the mailing list that capybara works on windows at all, so I understand if you aren't concentrating on Windows support and thus aren't interested in this patch.

However, capybara _does_ work on windows, just not attach_file. I'm not sure why, but when capybara attaches the file, the path has forward slashes and file attachment fails. If I attach the file manually through firefox, the path has back slashes and the file attachment succeeds.

This patch just replaces / with \ if the path contains C:/. If there is a better way to fix this issue, I would be happy to modify the patch.

I ran the it_should_behave_like "attach_file" specs and they fail before my change ([output](https://gist.github.com/848212)) and pass after.

Please let me know if there is anything else I can test or do in regards to this issue. Thanks!
