### PR TITLE
Add text to DSL

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,7 @@ Release date:
 
 * Added DSL for acceptance tests, inspired by Luismi Cavallé's Steak [Jonas Nicklas]
 * Selenium driver automatically waits for AJAX requests to finish [mgiambalvo, Nicklas Ramhöj and Jonas Nicklas]
+* Added text method to DSL.
 
 ### Changed
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -27,7 +27,7 @@ module Capybara
   #
   class Session
     DSL_METHODS = [
-      :all, :first, :attach_file, :body, :html, :check, :choose, :click_link_or_button, :click_button, :click_link, :current_url, :drag, :evaluate_script,
+      :all, :first, :attach_file, :body, :html, :text, :check, :choose, :click_link_or_button, :click_button, :click_link, :current_url, :drag, :evaluate_script,
       :field_labeled, :fill_in, :find, :find_button, :find_by_id, :find_field, :find_link, :has_content?, :has_css?,
       :has_no_content?, :has_no_css?, :has_no_xpath?, :has_xpath?, :locate, :save_page, :save_and_open_page, :select, :source, :uncheck,
       :visit, :wait_until, :within, :within_fieldset, :within_table, :within_frame, :within_window, :has_link?, :has_no_link?, :has_button?,


### PR DESCRIPTION
- Added text method to DSL.

As I suggested on the list: https://groups.google.com/d/topic/ruby-capybara/5Xr4ulBoRX8/discussion

I have no clue if this is the best way to fix it, but since I had it in my repo I figured I'd send you a pull request.  Feel free to just close if you're at all unsure whether this is sensible.
