### PR TITLE
Ability to preload Selenium's browser

### DIFF
--- a/lib/capybara/driver/selenium_driver.rb
+++ b/lib/capybara/driver/selenium_driver.rb
@@ -122,7 +122,7 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
   end
 
   def browser
-    @browser ||= Selenium.preloaded_browser || Selenium.spawn_browser(options)
+    @browser ||= self.class.preloaded_browser || self.class.spawn_browser(options)
   end
 
   def initialize(app, options={})


### PR DESCRIPTION
I made this quick patch to be able to spawn Firefox in the `Spork.prefork` block.

It's quite simple: 

```
Spork.prefork do
  Capybara::Driver::Selenium.preload_browser
end
```

then in tests the Selenium driver reuses the preloaded browser instead of creating a new one.

Upside: shave seconds off test startup time.
Downside: Firefox takes up memory all the time.

This goes well with running [headless](http://github.com/leonid-shevtsov/headless) to background the browser; I initially planned to add it to the preloader as an option, but decided that's out of the driver's responsibility.
