### PR TITLE
Fix for options to have_css not working

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -33,7 +33,14 @@ module Capybara
       # @return [Boolean]                         If the expression exists
       #
       def has_selector?(*args)
-        options = if args.last.is_a?(Hash) then args.last else {} end
+        options = if args.last.is_a?(Hash)
+          args.last
+        elsif args.last.is_a?(Array)
+          Hash[*args.last]
+        else
+          {}
+        end
+
         wait_conditionally_until do
           results = all(*args)
 
@@ -65,7 +72,13 @@ module Capybara
       # @return [Boolean]
       #
       def has_no_selector?(*args)
-        options = if args.last.is_a?(Hash) then args.last else {} end
+        options = if args.last.is_a?(Hash)
+          args.last
+        elsif args.last.is_a?(Array)
+          Hash[*args.last]
+        else
+          {}
+        end
         wait_conditionally_until do
           results = all(*args)
 

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -20,6 +20,16 @@ describe Capybara::RSpecMatchers do
             "<h1>Text</h1>".should have_css('h2')
           end.to raise_error(/expected css "h2" to return something/)
         end
+
+        it "passes if matched node count equals expected count" do
+          "<h1>Text</h1>".should have_css('h1', :count => 1)
+        end
+
+        it "fails if matched node count does not equal expected count" do
+          expect do
+            "<h1>Text</h1>".should have_css('h1', :count => 2)
+          end.to raise_error(/expected css "h1" to return something/)
+        end
       end
 
       context "with should_not" do
@@ -30,6 +40,16 @@ describe Capybara::RSpecMatchers do
         it "fails if has_no_css? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_css('h1')
+          end.to raise_error(/expected css "h1" not to return anything/)
+        end
+
+        it "passes if matched node count does not equal expected count" do
+          "<h1>Text</h1>".should_not have_css('h1', :count => 2)
+        end
+
+        it "fails if matched node count equals expected count" do
+          expect do
+            "<h1>Text</h1>".should_not have_css('h1', :count => 1)
           end.to raise_error(/expected css "h1" not to return anything/)
         end
       end


### PR DESCRIPTION
Hi,

I had specs which passed options to have_css:

```
page.should have_css('ul > li', :count => 2)
```

They were not failing when they should.

Thanks!
Mike
