### PR TITLE
Allow window switching by title or url

### DIFF
--- a/lib/capybara/driver/selenium_driver.rb
+++ b/lib/capybara/driver/selenium_driver.rb
@@ -148,7 +148,23 @@ class Capybara::Driver::Selenium < Capybara::Driver::Base
     browser.switch_to.window old_window
   end
 
-  def within_window(handle, &blk)
+  def find_window( selector )
+    original_handle = browser.window_handle
+    browser.window_handles.each do |handle|
+      browser.switch_to.window handle
+      if( selector == browser.execute_script("return window.name") ||
+          browser.title.include?(selector) ||
+          browser.current_url.include?(selector) ||
+          (selector == handle) )
+        browser.switch_to.window original_handle
+        return handle
+      end
+    end
+    raise Capybara::ElementNotFound, "Could not find a window identified by #{selector}"
+  end
+
+  def within_window(selector, &blk)
+    handle = find_window( selector )
     browser.switch_to.window(handle, &blk)
   end
 

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -207,6 +207,18 @@ shared_examples_for "driver with support for window switching" do
       end
       @driver.find("//*[@id='divInMainWindow']")[0].text.should eql 'This is the text for divInMainWindow'
     end
+
+    it "should find firstPopup by title" do
+      @driver.within_window("This is the title of the first popup") do
+        @driver.find("//*[@id='divInPopupOne']")[0].text.should eql 'This is the text of divInPopupOne'
+      end
+    end
+
+    it "should find firstPopup by url" do
+      @driver.within_window("/popup_one") do
+        @driver.find("//*[@id='divInPopupOne']")[0].text.should eql 'This is the text of divInPopupOne'
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This is pulled out from my last pull request.  I needed this because I work on an application that connects accounts from google, twitter, and facebook with oauth.  I don't really have a name on the popups - it's just much more convenient to use the title or url of the window I want.
