### PR TITLE
RSpec DSL should not pollute Object namespace

### DIFF
--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -9,7 +9,7 @@ module Capybara
   end
 end
 
-def feature(*args, &block)
+def self.feature(*args, &block)
   options = if args.last.is_a?(Hash) then args.pop else {} end
   options[:capybara_feature] = true
   options[:type] = :request

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -24,6 +24,10 @@ feature "Capybara's feature DSL" do
   scenario "runs background" do
     @in_background.should be_true
   end
+  
+  scenario "doesn't pollute the Object namespace" do
+    Object.new.respond_to?(:feature, true).should be_false
+  end
 end
 
 feature "Capybara's feature DSL with driver", :driver => :culerity do


### PR DESCRIPTION
Besides it's more polite, this turned out to be a real issue in Steak, causing Cucumber to break: https://github.com/cavalle/steak/issues/closed/#issue/19
