### PR TITLE
Pass `feature` caller to `describe`

### DIFF
--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -13,6 +13,7 @@ def feature(*args, &block)
   options = if args.last.is_a?(Hash) then args.pop else {} end
   options[:capybara_feature] = true
   options[:type] = :request
+  options[:caller] ||= caller
   args.push(options)
 
   describe(*args, &block)

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -3,6 +3,10 @@ require 'capybara/rspec'
 
 Capybara.app = TestApp
 
+RSpec.configuration.before(:each, :example_group => {:file_path => __FILE__}) do
+  @in_filtered_hook = true
+end
+
 feature "Capybara's feature DSL" do
   background do
     @in_background = true
@@ -23,6 +27,10 @@ feature "Capybara's feature DSL" do
 
   scenario "runs background" do
     @in_background.should be_true
+  end
+  
+  scenario "runs hooks filtered by file path" do
+    @in_filtered_hook.should be_true
   end
 end
 


### PR DESCRIPTION
Another backport from Steak. 

It's necessary to pass the caller of the `feature` to the `describe` method in order to avoid filtering by file_path to not work (see the test case in the commit)
