### PR TITLE
Switching subdomains with visit()

### DIFF
--- a/lib/capybara/driver/rack_test_driver.rb
+++ b/lib/capybara/driver/rack_test_driver.rb
@@ -206,6 +206,7 @@ class Capybara::Driver::RackTest < Capybara::Driver::Base
   def process(method, path, attributes = {})
     return if path.gsub(/^#{request_path}/, '') =~ /^#/
     path = request_path + path if path =~ /^\?/
+    path = current_url.gsub(/#{request_path}$/, '') + path if path.start_with?('/') && current_url != ''
     send(method, to_binary(path), to_binary( attributes ), env)
     follow_redirects!
   end

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -295,3 +295,16 @@ shared_examples_for "driver with infinite redirect detection" do
     end.should raise_error(Capybara::InfiniteRedirectError)
   end
 end
+
+shared_examples_for "driver with subdomain support" do
+  it "should stay on a subdomain" do
+    @driver.visit('/')
+    @driver.current_url.should == "http://www.example.com/"
+    @driver.visit("http://subdomain.example.com/")
+    @driver.current_url.should == "http://subdomain.example.com/"
+    @driver.visit('/')
+    @driver.current_url.should == "http://subdomain.example.com/"
+    @driver.visit('/foo')
+    @driver.current_url.should == "http://subdomain.example.com/foo"
+  end
+end

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -53,6 +53,7 @@ describe Capybara::Driver::RackTest do
   it_should_behave_like "driver with status code support"
   it_should_behave_like "driver with cookies support"
   it_should_behave_like "driver with infinite redirect detection"
+  it_should_behave_like "driver with subdomain support"
 
   describe '#reset!' do
     it { @driver.visit('/foo'); lambda { @driver.reset! }.should change(@driver, :current_url).to('') }


### PR DESCRIPTION
I've been struggling with subdomains for a few days, not so much with the default rack test driver, but more so with the envjs driver. With rack-test I was using the Capybara.default_host hack, which I've read isn't supposed to be the correct way to do it, but rather you should just be able to do visit('http://subdomain.example.com'). I totally agree that visit() should be the way to do it, but it wasn't working correctly.

This pull request adds a shared example group for "driver subdomain support" that has been applied to the rack-test driver. It tests that when you visit() a subdomain, and then you visit() a path, that the current_url is of the subdomain and not the default_host.

This is just a start to fully resolve this issue, as it will need to be applied to the other drivers and such. Anything else that needs to happen, just let me know, and I'll get it done.

Thanks for all the work you've done ... Capybara is awesome.
