### PR TITLE
description methods for Capybara::RSpecMatchers

### DIFF
--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -27,6 +27,10 @@ module Capybara
         "expected #{selector_name} not to return anything"
       end
 
+      def description
+        "has #{selector_name}"
+      end
+
       def selector_name
         name = "#{normalized.name} #{normalized.locator.inspect}"
         name << " with text #{normalized.options[:text].inspect}" if normalized.options[:text]
@@ -80,6 +84,10 @@ module Capybara
 
       def failure_message_for_should_not
         "expected #{selector_name} not to return anything"
+      end
+
+      def description
+        "has #{selector_name}"
       end
 
       def selector_name

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -9,6 +9,10 @@ describe Capybara::RSpecMatchers do
   include Capybara::RSpecMatchers
 
   describe "have_css matcher" do
+    it "gives proper description" do
+      have_css('h1').description.should == "has css \"h1\""
+    end
+
     context "on a string" do
       context "with should" do
         it "passes if has_css? returns true" do
@@ -87,6 +91,10 @@ describe Capybara::RSpecMatchers do
   end
 
   describe "have_xpath matcher" do
+    it "gives proper description" do
+      have_xpath('//h1').description.should == "has xpath \"\/\/h1\""
+    end
+
     context "on a string" do
       context "with should" do
         it "passes if has_css? returns true" do
@@ -145,6 +153,10 @@ describe Capybara::RSpecMatchers do
   end
 
   describe "have_selector matcher" do
+    it "gives proper description" do
+      have_selector('//h1').description.should == "has xpath \"//h1\""
+    end
+
     context "on a string" do
       context "with should" do
         it "passes if has_css? returns true" do
@@ -229,6 +241,10 @@ describe Capybara::RSpecMatchers do
   end
 
   describe "have_content matcher" do
+    it "gives proper description" do
+      have_content('Text').description.should == "has content \"Text\""
+    end
+
     context "on a string" do
       context "with should" do
         it "passes if has_css? returns true" do
@@ -299,6 +315,10 @@ describe Capybara::RSpecMatchers do
   describe "have_link matcher" do
     let(:html) { '<a href="#">Just a link</a>' }
 
+    it "gives proper description" do
+      have_link('Just a link').description.should == "has link \"Just a link\""
+    end
+
     it "passes if there is such a button" do
       html.should have_link('Just a link')
     end
@@ -313,6 +333,10 @@ describe Capybara::RSpecMatchers do
   describe "have_button matcher" do
     let(:html) { '<button>A button</button><input type="submit" value="Another button"/>' }
 
+    it "gives proper description" do
+      have_button('A button').description.should == "has button \"A button\""
+    end
+
     it "passes if there is such a button" do
       html.should have_button('A button')
     end
@@ -326,6 +350,10 @@ describe Capybara::RSpecMatchers do
 
   describe "have_field matcher" do
     let(:html) { '<p><label>Text field<input type="text"/></label></p>' }
+
+    it "gives proper description" do
+      have_field('Text field').description.should == "has field \"Text field\""
+    end
 
     it "passes if there is such a field" do
       html.should have_field('Text field')
@@ -342,6 +370,10 @@ describe Capybara::RSpecMatchers do
     let(:html) do
       '<label>it is checked<input type="checkbox" checked="checked"/></label>
       <label>unchecked field<input type="checkbox"/></label>'
+    end
+
+    it "gives proper description" do
+      have_checked_field('it is checked').description.should == "has checked_field \"it is checked\""
     end
 
     context "with should" do
@@ -385,6 +417,10 @@ describe Capybara::RSpecMatchers do
       <label>unchecked field<input type="checkbox"/></label>'
     end
 
+    it "gives proper description" do
+      have_unchecked_field('unchecked field').description.should == "has unchecked_field \"unchecked field\""
+    end
+
     context "with should" do
       it "passes if there is such a field and it is not checked" do
         html.should have_unchecked_field('unchecked field')
@@ -423,6 +459,10 @@ describe Capybara::RSpecMatchers do
   describe "have_select matcher" do
     let(:html) { '<label>Select Box<select></select></label>' }
 
+    it "gives proper description" do
+      have_select('Select Box').description.should == "has select \"Select Box\""
+    end
+
     it "passes if there is such a select" do
       html.should have_select('Select Box')
     end
@@ -436,6 +476,10 @@ describe Capybara::RSpecMatchers do
 
   describe "have_table matcher" do
     let(:html) { '<table><caption>Lovely table</caption></table>' }
+
+    it "gives proper description" do
+      have_table('Lovely table').description.should == "has table \"Lovely table\""
+    end
 
     it "passes if there is such a select" do
       html.should have_table('Lovely table')


### PR DESCRIPTION
When one of capybara rspec matchers is used in an example without a String, you get message like this:

```
should When you call a matcher in an example without a String, like this:

specify { object.should matcher }

or this:

it { should matcher }

RSpec expects the matcher to have a #description method. You should either
add a String to the example this matcher is being used in, or give it a
description method. Then you won't have to suffer this lengthy warning again.
```

So, I added description method for them.
