### PR TITLE
Remove usage of method deprecated in selenium-webdriver

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -4,20 +4,16 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def [](name)
-    if name == :value
-      value
-    else
-      native.attribute(name.to_s)
-    end
+    native.attribute(name.to_s)
   rescue Selenium::WebDriver::Error::WebDriverError
     nil
   end
 
   def value
     if tag_name == "select" and self[:multiple] and not self[:multiple] == "false"
-      native.find_elements(:xpath, ".//option").select { |n| n.selected? }.map { |n| n.value || n.text }
+      native.find_elements(:xpath, ".//option").select { |n| n.selected? }.map { |n| n.attribute(:value) || n.text }
     else
-      native.value
+      self[:value]
     end
   end
 


### PR DESCRIPTION
Hi,

Element#value is deprecated in the latest version of selenium-webdriver. This patch replaces its usage with Element#attribute(:value). Behaviour should be the same.

Jari
