### PR TITLE
Adding :hidden option to Node::Finders#matches_options

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -175,8 +175,8 @@ module Capybara
           options[:text] = Regexp.escape(text) unless text.kind_of?(Regexp)
         end
 
-        if !options.has_key?(:visible)
-          options[:visible] = Capybara.ignore_hidden_elements
+        if !options.has_key?(:visible) && Capybara.ignore_hidden_elements
+          options[:visible] = true
         end
 
         if selected = options[:selected]


### PR DESCRIPTION
`:visible => false` doesn't work at all how someone might think it does. But that aside, here is a more logical `:hidden => true` option for only selecting elements that are hidden.
