### PR TITLE
RSpec 3 deprecation warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,15 @@ require "bundler/setup"
 
 require 'rspec'
 require 'capybara'
+
+RSpec.configure do |config|
+  config.before do
+    Capybara.configure do |config|
+      config.default_selector = :xpath
+    end
+  end
+end
+
 require 'capybara/spec/driver'
 require 'capybara/spec/session'
 
@@ -15,12 +24,4 @@ Capybara.default_wait_time = 0 # less timeout so tests run faster
 module TestSessions
   RackTest = Capybara::Session.new(:rack_test, TestApp)
   Selenium = Capybara::Session.new(:selenium, TestApp)
-end
-
-RSpec.configure do |config|
-  config.before do
-    Capybara.configure do |config|
-      config.default_selector = :xpath
-    end
-  end
 end


### PR DESCRIPTION
There is a deprecation warning about rspec 3 that says that no configuration option should be set after defining a group of specs. This commit fix the issue by moving the setting of options to a position before the specs are required loaded.
