### PR TITLE
Handle form submissions for relative URLs

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -39,9 +39,13 @@ class Capybara::RackTest::Browser
       @current_host = new_uri.scheme + '://' + new_uri.host
     end
     
-    unless new_uri.absolute?
+    if new_uri.relative?
       path = request_path + path if path.start_with?('?')
-      path = request_path + '/' + path unless path.start_with?('/')
+      
+      unless path.start_with?('/')
+        folders = request_path.split('/')
+        path = (folders[0, folders.size - 1] << path).join('/')
+      end
       path = current_host + path
     end
     

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -15,11 +15,19 @@ shared_examples_for "click_button" do
     context "with a form that has a relative url as an action" do
       it "should post to the correct url" do
         @session.click_button('Relative Action')
-        @session.current_path.should == '/form/relative'
+        @session.current_path.should == '/relative'
         extract_results(@session)['relative'].should == 'Relative Action'
       end
     end
 
+    context "with a form that has no action specified" do
+      it "should post to the correct url" do
+        @session.click_button('No Action')
+        @session.current_path.should == '/form'
+        extract_results(@session)['no_action'].should == 'No Action'
+      end
+    end
+    
     context "with value given on a submit button" do
       context "on a form with HTML5 fields" do
         before do

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -47,7 +47,7 @@ class TestApp < Sinatra::Base
     '<pre id="results">' + params[:form].to_yaml + '</pre>'
   end
 
-  post '/form/relative' do
+  post '/relative' do
     '<pre id="results">' + params[:form].to_yaml + '</pre>'
   end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -357,3 +357,9 @@
     <input type="submit" name="form[relative]" value="Relative Action" />
   </p>
 </form>
+
+<form method="post">
+  <p>
+    <input type="submit" name="form[no_action]" value="No Action" />
+  </p>
+</form>


### PR DESCRIPTION
I was using capybara to add a bunch of regression tests to a legacy app I inherited... and it included quite a few forms posting either to a relative url, or to the page it was on itself.

Capybara::RackTest::Browser#process does a bit of URL manipulation (i'm assuming to pretend to be a browser) before handing off to rack test, but it wasn't properly handling the relative urls, and its error message was a pretty unhelpful "bad component(expected host component): http://www.example.com (URI::InvalidComponentError)"

So I've written code to cover the two failing situations for me, there may be other ways that are still broken but just wanted to patch my current pain.
