### PR TITLE
Fix Capybara::RackTest::Browser#build_rack_mock_session

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -82,7 +82,8 @@ class Capybara::RackTest::Browser
 protected
 
   def build_rack_mock_session
-    Rack::MockSession.new(app, current_host)
+    reset_host! unless current_host
+    Rack::MockSession.new(app, URI.parse(current_host).host)
   end
 
   def request_path

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -80,4 +80,38 @@ describe Capybara::RackTest::Driver do
       @driver.body.should include('foobar')
     end
   end
+
+  describe "manual cookie setting" do
+    before do
+      # Use different driver instance in order to not interfere with the other tests
+      @driver = Capybara::Session.new(:rack_test, TestApp).driver
+    end
+
+    it "should allow a cookie to be manually set" do
+      @driver.browser.set_cookie 'capybara=test_cookie'
+
+      @driver.visit('/get_cookie')
+      @driver.body.should include('test_cookie')
+    end
+
+    describe "cookies with a custom Capybara.app_host" do
+      before { Capybara.app_host = 'http://foo.com' }
+      after  { Capybara.app_host = nil              }
+
+      it "should allow a cookie to be manually set" do
+        @driver.browser.set_cookie 'capybara=test_cookie'
+
+        @driver.visit('/get_cookie')
+        @driver.body.should include('test_cookie')
+      end
+
+      it "should allow a cookie to be manually set with a different current host" do
+        @driver.browser.current_host = 'http://foobar.com'
+        @driver.browser.set_cookie 'capybara=test_cookie'
+
+        @driver.visit('http://foobar.com/get_cookie')
+        @driver.body.should include('test_cookie')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The second parameter must be a host string with no scheme component, so I have fixed this.

Also added some tests which show up the bug. They use manual cookie setting through the browser instance, which I realise is not part of the public API so feel free to take or leave these as you see fit.
