### PR TITLE
Fix Capybara::RackTest::Browser#build_rack_mock_session

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -82,7 +82,8 @@ class Capybara::RackTest::Browser
 protected
 
   def build_rack_mock_session
-    Rack::MockSession.new(app, current_host)
+    reset_host! unless current_host
+    Rack::MockSession.new(app, URI.parse(current_host).host)
   end
 
   def request_path


### PR DESCRIPTION
This replaces #362 - I have removed the tests as discussed. Cheers.
