### PR TITLE
Change Capybara's features type to :acceptance

### DIFF
--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -12,7 +12,7 @@ end
 def self.feature(*args, &block)
   options = if args.last.is_a?(Hash) then args.pop else {} end
   options[:capybara_feature] = true
-  options[:type] = :request
+  options[:type] = :acceptance
   options[:caller] ||= caller
   args.push(options)
 


### PR DESCRIPTION
People wanting to use Capybara as a replacement of Steak, or wanting to keep using Steak with the new version of Capybara, will have to update its includes from `:type => :acceptance` to `:type => :request` because the rspec example created by Capybara's `feature` method sets the type of the example group to `:request` (relating to the rather unused rspec-rails request specs, I suppose)

I've always found `request` a completely misleading name for this type of specs and I can't see any practical reason to prefer `request` over `acceptance` in Capybara's features. So I'd like you to consider using `acceptance` instead of `request` to make the upgrade for Steak users as smooth as possible.
