### PR TITLE
Add configursble delay before resynchronization looks for ajax requests

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -4,9 +4,10 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   DEFAULT_OPTIONS = {
     :resynchronize => true,
     :resynchronization_timeout => 10,
+    :resynchronization_delay=>0,
     :browser => :firefox
   }
-  SPECIAL_OPTIONS = [:browser, :resynchronize, :resynchronization_timeout]
+  SPECIAL_OPTIONS = [:browser, :resynchronize, :resynchronization_timeout, :resynchronization_delay]
 
   attr_reader :app, :rack_server, :options
 
@@ -55,6 +56,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     if options[:resynchronize]
       load_wait_for_ajax_support
       yield
+      sleep(options[:resynchronization_delay])
       Capybara.timeout(options[:resynchronization_timeout], self, "failed to resynchronize, ajax request timed out") do
         evaluate_script("!window.capybaraRequestsOutstanding")
       end

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -166,6 +166,22 @@ shared_examples_for "driver with resynchronization support" do
 
       after { @driver.options[:resynchronization_timeout] = 10 }
     end
+    
+    context "with no synchronization delay" do
+      it "should miss the start of the ajax request when do delay" do
+        @driver.options[:resynchronization_delay]=0
+        @driver.find('//input[@id="fire_delayed_ajax_request"]').first.click
+        @driver.find('//p[@id="ajax_request_done"]').should be_empty
+      end
+      
+      it "should wait for ajax requsts to finish when delay is long enough to see the start" do
+        @driver.options[:resynchronization_delay]=0.5
+        @driver.find('//input[@id="fire_delayed_ajax_request"]').first.click
+        @driver.find('//p[@id="ajax_request_done"]').should_not be_empty
+      end
+      
+      after { @driver.options[:resynchronization_delay]=0 }
+    end
   end
 end
 

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -35,4 +35,11 @@ $(function() {
       $('body').append('<p id="ajax_request_done">Ajax request done</p>');
     }});
   });
+  $('#fire_delayed_ajax_request').click(function() {
+    setTimeout(function() {
+      $.ajax({url: "/slow_response", context: document.body, success: function() {
+        $('body').append('<p id="ajax_request_done">Ajax request done</p>');
+      }});
+    }, 400)
+  });
 });

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -38,6 +38,10 @@
     <p>
       <input type="submit" id="fire_ajax_request" value="Fire Ajax Request"/>
     </p>
+
+    <p>
+      <input type="submit" id="fire_delayed_ajax_request" value="Fire Delayed Ajax Request"/>
+    </p>
   </body>
 </html>
 


### PR DESCRIPTION
This is to allow resynchronization to work in the case where ajax requests are delayed slightly from the user interaction that triggers them.  In my case it was a search box that waited 200 ms after the user typed the last key before triggering the search.  
