### PR TITLE
Selenium::WebDriver::Element#select and #toggle are deprecated - replace with click

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
   s.add_runtime_dependency("mime-types", [">= 1.16"])
-  s.add_runtime_dependency("selenium-webdriver", ["~> 0.2.0"])
+  s.add_runtime_dependency("selenium-webdriver", ["~> 0.2.2"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])
   s.add_runtime_dependency("rack-test", [">= 0.5.4"])
   s.add_runtime_dependency("xpath", ["~> 0.1.4"])

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -31,14 +31,14 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def select_option
-    resynchronize { native.select }
+    resynchronize { native.click } unless selected?
   end
 
   def unselect_option
     if select_node['multiple'] != 'multiple' and select_node['multiple'] != 'true'
       raise Capybara::UnselectNotAllowed, "Cannot unselect option from single select box."
     end
-    resynchronize { native.toggle } if selected?
+    resynchronize { native.click } if selected?
   end
 
   def click

--- a/lib/capybara/spec/session/select_spec.rb
+++ b/lib/capybara/spec/session/select_spec.rb
@@ -97,6 +97,14 @@ shared_examples_for "select" do
         extract_results(@session)['languages'].should include('Ruby', 'Javascript')
       end
       
+      it "should remain selected if already selected" do
+        @session.select("Ruby",       :from => 'Language')
+        @session.select("Javascript", :from => 'Language')
+        @session.select("Ruby",       :from => 'Language')
+        @session.click_button('awesome')
+        extract_results(@session)['languages'].should include('Ruby', 'Javascript')
+      end
+      
       it "should return value attribute rather than content if present" do
         @session.find_field('Underwear').value.should include('thermal')
       end


### PR DESCRIPTION
Selenium::WebDriver::Element#select and #toggle are deprecated - replace with click
This requires updating the minimum version of selenium-webdriver to 0.2.2 since it adds special handling for click on multiple select listboxes that appears to negate the need for modifier keys when clicking on options to make multiple selections.  Also added a test to make sure options remain selected if select is called on them twice
