### PR TITLE
Fix for issue #331 - providing more information in RSpec matcher failure message

### DIFF
--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -31,7 +31,14 @@ module Capybara
       end
 
       def failure_message_for_should_not
-        "expected #{selector_name} not to return anything"
+        message = "expected #{selector_name} "
+        if normalized.options.has_key?(:text)
+          @args.last.delete(:text)
+          message << %(not to be present with text "#{@actual.first(*@args).text}")
+        else
+          message << "not to return anything"
+        end
+        message
       end
 
       def description

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -234,7 +234,7 @@ describe Capybara::RSpecMatchers do
         it "fails if has_no_css? returns false" do
           expect do
             page.should_not have_selector(:css, 'h1', :text => 'test')
-          end.to raise_error(%r(expected css "h1" with text "test" not to return anything))
+          end.to raise_error(%r(expected css "h1" with text "test" not to be present with text "This is a test"))
         end
       end
     end


### PR DESCRIPTION
Here's a fix for the [issue](https://github.com/jnicklas/capybara/issues/331) dchelimsky filed in April. When a element with particular text isn't found using RSpec's have_selector, the actual text is now included in the failure message. This has been added to `failure_message_for_should` and `failure_message_for_should_not`. Specs are have been modified to include the actual text.

``` ruby
"<h1>tester</h1>".should have_selector(:css, 'h1', :text => 'testable')
     # => 'expected css "h1" with text "testable" but instead got "tester"'
```
