### PR TITLE
error message for blank page.body

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -33,6 +33,7 @@ module Capybara
           normalized = Capybara::Selector.normalize(*args)
           message = options[:message] || "Unable to find #{normalized.name} #{normalized.locator.inspect}"
           message = normalized.failure_message.call(self, normalized) if normalized.failure_message
+          message += " -- your page.body may be blank" if 'Unable to find xpath "/html"' == message
           raise Capybara::ElementNotFound, message
         end
         return node


### PR DESCRIPTION
I'm getting this happening, for some insane reason. I was using 0.4.1.2 earlier, upgraded to 1.0 today, and the error message became a lot less clear.

my error message went from something along the lines of `expected has_content?('foobar') to return true, got false` to `Unable to find xpath "/html"`. I personally am reasonably fluent with xpath, and had spent enough time tearing my hair out over this to become aware of Capybara's XPath internals, but I think people without that perspective might find the error cryptic.
