### PR TITLE
add ability to turn off wait behaviour on individual has_selector calls

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -485,10 +485,17 @@ equivalent, and you should *always* use the latter!
     page.should_not have_xpath('a')
     page.should have_no_xpath('a')
 
-The former would incorrectly wait for the content to appear, since the
-asynchronous process has not yet removed the element from the page, it would
+Imagine we have an asynchronous process that removes the a from the page.
+The former will wait for the content to appear, and exit immediately since the
+asynchronous process has not yet removed the element from the page. It would
 therefore fail, even though the code might be working correctly. The latter
 correctly waits for the element to disappear from the page.
+
+If you are sure you have no asynchronous processes that can affect your particular element,
+you can turn off this behaviour for has_xpath?, has_css? and has_selector? ( and their negative counterparts)
+
+  page.should have_no_xpath('a', :wait => false)
+  
 
 == Using the DSL in unsupported testing frameworks
 

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -17,6 +17,12 @@ module Capybara
       #
       # This will check if the expression occurs exactly 4 times.
       #
+      # By default, in javascript drivers, it will wait for the selector to appear up until the capybara timeout 
+      # (in case we need to wait for javascript to complete). 
+      # If you do not want this behaviour you can prevent it by using the :wait option
+      #
+      #     page.has_selector?('p#foo', :wait => false)
+      #
       # It also accepts all options that {Capybara::Node::Finders#all} accepts,
       # such as :text and :visible.
       #
@@ -34,24 +40,27 @@ module Capybara
       #
       def has_selector?(*args)
         options = if args.last.is_a?(Hash) then args.last else {} end
-        wait_conditionally_until do
-          results = all(*args)
-
-          case
-          when results.empty?
-            false
-          when options[:between]
-            options[:between] === results.size
-          when options[:count]
-            options[:count].to_i == results.size
-          when options[:maximum]
-            options[:maximum].to_i >= results.size
-          when options[:minimum]
-            options[:minimum].to_i <= results.size
-          else
-            results.size > 0
-          end
+          
+        selector_present = Proc.new do
+           results = all(*args)
+              
+               case
+               when results.empty?
+                 false
+               when options[:between]
+                 options[:between] === results.size
+               when options[:count]
+                 options[:count].to_i == results.size
+               when options[:maximum]
+                 options[:maximum].to_i >= results.size
+               when options[:minimum]
+                 options[:minimum].to_i <= results.size
+               else
+                 results.size > 0
+               end
         end
+        return selector_present.call if options[:wait] == false     
+        wait_conditionally_until(&selector_present)
       rescue Capybara::TimeoutError
         return false
       end
@@ -66,24 +75,27 @@ module Capybara
       #
       def has_no_selector?(*args)
         options = if args.last.is_a?(Hash) then args.last else {} end
-        wait_conditionally_until do
-          results = all(*args)
+          
+        selector_not_present = Proc.new do
+           results = all(*args)
 
-          case
-          when results.empty?
-            true
-          when options[:between]
-            not(options[:between] === results.size)
-          when options[:count]
-            not(options[:count].to_i == results.size)
-          when options[:maximum]
-            not(options[:maximum].to_i >= results.size)
-          when options[:minimum]
-            not(options[:minimum].to_i <= results.size)
-          else
-            results.empty?
-          end
-        end
+            case
+            when results.empty?
+              true
+            when options[:between]
+              not(options[:between] === results.size)
+            when options[:count]
+              not(options[:count].to_i == results.size)
+            when options[:maximum]
+              not(options[:maximum].to_i >= results.size)
+            when options[:minimum]
+              not(options[:minimum].to_i <= results.size)
+            else
+              results.empty?
+            end
+        end  
+        return selector_not_present.call if options[:wait] == false      
+        wait_conditionally_until(&selector_not_present)
       rescue Capybara::TimeoutError
         return false
       end
@@ -100,6 +112,12 @@ module Capybara
       #     page.has_xpath?('.//p[@id="foo"]', :count => 4)
       #
       # This will check if the expression occurs exactly 4 times.
+      #
+      # By default, in javascript drivers, it will wait for the selector to appear up until the capybara timeout 
+      # (in case we need to wait for javascript to complete). 
+      # If you do not want this behaviour you can prevent it by using the :wait option
+      #
+      #     page.has_xpath?('.//li', :wait => false)
       #
       # It also accepts all options that {Capybara::Node::Finders#all} accepts,
       # such as :text and :visible.
@@ -145,6 +163,12 @@ module Capybara
       #     page.has_css?('p#foo', :count => 4)
       #
       # This will check if the selector occurs exactly 4 times.
+      #
+      # By default, in javascript drivers, it will wait for the selector to appear up until the capybara timeout 
+      # (in case we need to wait for javascript to complete). 
+      # If you do not want this behaviour you can prevent it by using the :wait option
+      #
+      #     page.has_xpath?('p#foo', :wait => false)
       #
       # It also accepts all options that {Capybara::Node::Finders#all} accepts,
       # such as :text and :visible.

--- a/lib/capybara/spec/session/javascript.rb
+++ b/lib/capybara/spec/session/javascript.rb
@@ -160,35 +160,87 @@ shared_examples_for "session with javascript support" do
     end
 
     describe '#has_xpath?' do
-      it "should wait for content to appear" do
+      it "should wait for content to appear by default" do
         @session.visit('/with_js')
         @session.click_link('Click me')
         @session.should have_xpath("//input[@type='submit' and @value='New Here']")
       end
+      
+      it "should not wait for content to appear if asked not to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should_not have_xpath("//input[@type='submit' and @value='New Here']", :wait => false)
+      end
+      
+      it "should wait for content to appear if asked to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should have_xpath("//input[@type='submit' and @value='New Here']", :wait => true)
+      end
+      
     end
 
     describe '#has_no_xpath?' do
-      it "should wait for content to disappear" do
+      it "should wait for content to disappear by default" do
         @session.visit('/with_js')
         @session.click_link('Click me')
         @session.should have_no_xpath("//p[@id='change']")
       end
+      
+      it "should not wait for content to disappear if asked not to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should_not have_no_xpath("//p[@id='change']", :wait => false)
+      end
+      
+      it "should wait for content to disappear if asked to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should have_no_xpath("//p[@id='change']", :wait => true)
+      end
+      
     end
 
     describe '#has_css?' do
-      it "should wait for content to appear" do
+      it "should wait for content to appear by default" do
         @session.visit('/with_js')
         @session.click_link('Click me')
         @session.should have_css("input[type='submit'][value='New Here']")
       end
+      
+      it "should not wait for content to appear if asked not to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should_not have_css("input[type='submit'][value='New Here']", :wait => false)
+      end
+      
+      it "should wait for content to appear by default if asked to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should have_css("input[type='submit'][value='New Here']", :wait => true)
+      end
+      
     end
 
-    describe '#has_no_xpath?' do
-      it "should wait for content to disappear" do
+    describe '#has_no_css?' do
+      it "should wait for content to disappear by default" do
         @session.visit('/with_js')
         @session.click_link('Click me')
         @session.should have_no_css("p#change")
       end
+      
+      it "should not wait for content to disappear if asked not to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should_not have_no_css("p#change", :wait => false)
+      end
+      
+      it "should wait for content to disappear if asked to" do
+        @session.visit('/with_js')
+        @session.click_link('Click me')
+        @session.should have_no_css("p#change", :wait => true)
+      end
+      
     end
 
     describe '#has_content?' do


### PR DESCRIPTION
Hi

I am currently working on a large suite of acceptance tests that originally consisted of webrat + some hand rolled stuff. We long ago upgraded to Capybara, but the hand rolled stuff is still there even though Capybara does most of what we need - so we have been ripping it out.

We have found that the one thing we need is more fine grained control over Capybara's wait behaviour than is afforded by switching drivers. ( ie we want to be able to tell Capybara not to wait for some selectors even when we are using the selenium driver ). I can go into more detail on exactly why this is useful to us if you would like.

Anyway, here is a patch that allows the user to specify that Capybara should not wait on individual calls to has_selector? Default behaviour is left unchanged.

cheers
Perryn
