### PR TITLE
Selenium::Webdriver#drag_and_drop_on is deprecated

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
   s.add_runtime_dependency("mime-types", [">= 1.16"])
-  s.add_runtime_dependency("selenium-webdriver", ["~> 0.2.2"])
+  s.add_runtime_dependency("selenium-webdriver", ["~> 2.0.0"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])
   s.add_runtime_dependency("rack-test", [">= 0.5.4"])
   s.add_runtime_dependency("xpath", ["~> 0.1.4"])

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -46,7 +46,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def drag_to(element)
-    resynchronize { native.drag_and_drop_on(element.native) }
+    resynchronize { driver.browser.action.drag_and_drop(native, element.native).perform }
   end
 
   def tag_name


### PR DESCRIPTION
drag_and_drop_on was deprecated and has now been removed from selenium-webdriver 2.0.0 .  selenium-webdriver 2.0.0 has also added synthetic mouse support so that mouse actions can be used on platforms without native event support
