### PR TITLE
Reset current_host after follow_redirect!

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -52,6 +52,8 @@ class Capybara::RackTest::Browser
     reset_cache!
     send(method, path, attributes, env)
     follow_redirects!
+    current_uri = URI.parse(current_url)
+    @current_host = current_uri.scheme + '://' + current_uri.host
   end
 
   def current_url

--- a/lib/capybara/spec/session/current_host_spec.rb
+++ b/lib/capybara/spec/session/current_host_spec.rb
@@ -45,6 +45,12 @@ shared_examples_for "current_host" do
       @session.current_host.should == 'http://capybara2.elabs.se'
     end
 
+    it "is affected by a redirect to another host" do
+      @session.visit('http://capybara-testapp.heroku.com/redirect_to_other')
+      @session.body.should include('Current host is http://capybara2.elabs.se')
+      @session.current_host.should == 'http://capybara2.elabs.se'
+    end
+
     it "is unaffected by posting through a relative form" do
       @session.visit('http://capybara-testapp.heroku.com/host_links')
       @session.click_button('Relative Host')


### PR DESCRIPTION
When a redirect is followed to a different host, the value of @current_host is not updated. This commit fixes that.

I wasn't sure how to add a spec for this though. I think the best place would be an addition to current_host_spec.rb, where say e.g. page http://capybara-testapp.heroku.com/redirect_to_other would redirect to http://capybara2.elabs.se. The spec would then be something like:

```
 it "is affected by a redirect to another host" do
   @session.visit('http://capybara-testapp.heroku.com/redirect_to_other')
   @session.body.should include('Current host is http://capybara2.elabs.se')
   @session.current_host.should == 'http://capybara2.elabs.se'
 end
```

Just don't know how to get a /redirect_to_other page hosted on that site ;-)
