### PR TITLE
Seeing failures when a get redirects to a form on a different site, the f

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -26,7 +26,13 @@ class Capybara::RackTest::Browser
 
   def follow_redirects!
     5.times do
-      follow_redirect! if last_response.redirect?
+      if last_response.redirect?
+        redirect_location = URI.parse(last_response.location)
+        if redirect_location.host
+          @current_host = redirect_location.scheme + '://' + redirect_location.host
+        end
+        follow_redirect!
+      end
     end
     raise Capybara::InfiniteRedirectError, "redirected more than 5 times, check for infinite redirects." if last_response.redirect?
   end


### PR DESCRIPTION
Seeing failures when a get redirects to a form on a different site, the form incorrectly posts to the original url not based on the base url of the new site.

I should probably write a test... but playing with this new Github "pull request without even cloning the repo" thing.
