### PR TITLE
Small change to code example in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -628,14 +628,14 @@ an API to tweak those drivers with whatever settings you want, or to add your ow
 drivers. This is how to switch the selenium driver to use chrome:
 
     Capybara.register_driver :selenium do |app|
-      Capybara::Selenium::Driver.new(app, :browser => :chrome)
+      Capybara::Driver::Selenium.new(app, :browser => :chrome)
     end
 
 However, it's also possible to give this a different name, so tests can switch
 between using different browsers effortlessly:
 
     Capybara.register_driver :selenium_chrome do |app|
-      Capybara::Selenium::Driver.new(app, :browser => :chrome)
+      Capybara::Driver::Selenium.new(app, :browser => :chrome)
     end
 
 Whatever is returned from the block should conform to the API described by


### PR DESCRIPTION
I recently installed your gem. I got stuck for a little bit, trying to use selenium with chrome until I realised Capybara::Driver::Selenium worked where Capybara::Selenium::Driver didn't. I've updated the readme to save others having the same problem.

Apologies if I've gone about this the wrong way - it's the first time I've performed a fork, let alone a pull request.
