### PR TITLE
Fixed to make it work with Launchy again. Needed "file:" prefix in order to work.

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -23,7 +23,7 @@ module Capybara
 
     def open_in_browser(path) # :nodoc
       require "launchy"
-      Launchy.open(path)
+      Launchy.open("file:#{path}")
     rescue LoadError
       warn "Sorry, you need to install launchy (`gem install launchy`) and " <<
         "make sure it's available to open pages with `save_and_open_page`."


### PR DESCRIPTION
Added "file: " as a prefix to the path in "open_in_browser" to make it work with Launchy/Cucumber again.
