### PR TITLE
Add a check in Capybara.timeout to make sure Time hasn't been frozen with Timecop.

### DIFF
--- a/lib/capybara/util/timeout.rb
+++ b/lib/capybara/util/timeout.rb
@@ -5,6 +5,12 @@ module Capybara
     # Provides timeout similar to standard library Timeout, but avoids threads
     #
     def timeout(seconds = 1, driver = nil, error_message = nil, &block)
+      if defined?(Timecop)
+        if Timecop.top_stack_item && Timecop.top_stack_item.mock_type == :freeze
+          raise RuntimeError, "Capybara.timeout cannot work with Timecop.freeze. Use Timecop.travel instead."
+        end
+      end
+
       start_time = Time.now
 
       result = nil

--- a/spec/timeout_spec.rb
+++ b/spec/timeout_spec.rb
@@ -7,6 +7,41 @@ module Capybara
 
   describe '.timeout' do
 
+    context "with Timecop loaded" do
+      let(:timecop) { stub('Stubbed Timecop', :top_stack_item => time_stack_item)}
+      before { Kernel.const_set(:Timecop, timecop) }
+
+      context "loaded, but not used" do
+        let(:time_stack_item) { nil }
+
+        it "should not raise a RuntimeError" do
+          expect {
+            Capybara.timeout { :finished }
+          }.to_not raise_error
+        end
+      end
+
+      context "with time frozen" do
+        let(:time_stack_item) { stub('TimeStackItem', :mock_type => :freeze) }
+
+        it "should raise a RuntimeError" do
+          expect {
+            Capybara.timeout { :finished }
+          }.to raise_error(RuntimeError, "Capybara.timeout cannot work with Timecop.freeze. Use Timecop.travel instead.")
+        end
+      end
+
+      context "with time travel" do
+        let(:time_stack_item) { stub('TimeStackItem', :mock_type => :travel) }
+
+        it "should not raise a RuntimeError" do
+          expect {
+            Capybara.timeout { :finished }
+          }.to_not raise_error
+        end
+      end
+    end
+
     it "should return result of yield if it returns true value within timeout" do
       Capybara.timeout { "hello" }.should == "hello"
     end


### PR DESCRIPTION
I was pulling my hair out for 3 hours today trying to figure this out. I realise that Timecop is not really related to Capybara and I would understand your hesitation to pulling this in, but it is an awkward bug to discover.

I was blaming versions & incompatibilities between Cucumber, Capybara, Firefox - and all the time it was Timecop doing what it was meant to be doing.

What do you think?
