### PR TITLE
Save And Open Page fix

### DIFF
--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -4,7 +4,9 @@ require 'capybara/dsl'
 Capybara.app = Rack::Builder.new do
   map "/" do
     if Rails.version.to_f >= 3.0
-      run Rails.application  
+      app = Rails.application
+      app.config.action_dispatch.show_exceptions = true
+      run app
     else # Rails 2
       use Rails::Rack::Static
       run ActionController::Dispatcher.new

--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -23,7 +23,7 @@ module Capybara
 
     def open_in_browser(path) # :nodoc
       require "launchy"
-      Launchy.open(path)
+      Launchy.open("file://" + path)
     rescue LoadError
       warn "Sorry, you need to install launchy (`gem install launchy`) and " <<
         "make sure it's available to open pages with `save_and_open_page`."
@@ -33,7 +33,7 @@ module Capybara
       root = Capybara.asset_root
       return response_html unless root
       directories = Dir.new(root).entries.select { |name|
-        (root+name).directory? and not name.to_s =~ /^\./
+        File::directory?(File::join(root, name)) and not name.to_s =~ /^\./
       }
       if not directories.empty?
         response_html.gsub!(/("|')\/(#{directories.join('|')})/, '\1' + root.to_s + '/\2')


### PR DESCRIPTION
I was finding that save_and_open_page was giving me headaches when used under Rails - when asset_root is set, it was doing string manipulations and then trying to treat them as directories.  That and adding a file protocol to the path passed to Launchy.
