### PR TITLE
fix the rspec 3 deprecation warning when running tests

### DIFF
--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'capybara/rspec'
 
 Capybara.app = TestApp
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
   end
 end
 
+require 'capybara/rspec'
 require 'capybara/spec/driver'
 require 'capybara/spec/session'
 


### PR DESCRIPTION
Fix the warning that appears when running the capybara tests

DEPRECATION WARNING: you are using deprecated behaviour that will
be removed from RSpec 3.

You have set some configuration options after an example group has
already been defined.  In RSpec 3, this will not be allowed.  All
configuration should happen before the first example group is
defined.  
