### PR TITLE
I believe the version number is wrong ....

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
   s.add_runtime_dependency("mime-types", [">= 1.16"])
-  s.add_runtime_dependency("selenium-webdriver", ["~> 2.0"])
+  s.add_runtime_dependency("selenium-webdriver", ["~> 2.0.0"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])
   s.add_runtime_dependency("rack-test", [">= 0.5.4"])
   s.add_runtime_dependency("xpath", ["~> 0.1.4"])


### PR DESCRIPTION
Hi jnicklas,

Wonder if  you do a quick pull for the capybara.gemspec. I think you intended the version to be 2.0.0, however, during bundle install - it installs 0.2.0. I did the small changes and updated it.

It hasn't been updated since July though.
