### PR TITLE
Maintain URL scheme of current uri when browsing to a relative path.

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -55,6 +55,9 @@ class Capybara::RackTest::Browser
         path = (folders[0, folders.size - 1] << path).join('/')
       end
       path = current_host + path
+      path_uri = URI.parse(path)
+      path_uri.scheme = current_uri.scheme
+      path = path_uri.to_s
     end
 
     reset_cache!


### PR DESCRIPTION
This fixes the case when you are redirected to an SSL page and then click on a form submit button with the form action being a relative URL. Closes #370.
