### PR TITLE
Capybara was using an old selenium-webdriver

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
   s.add_runtime_dependency("mime-types", [">= 1.16"])
-  s.add_runtime_dependency("selenium-webdriver", ["~> 2.0"])
+  s.add_runtime_dependency("selenium-webdriver", ["~> 2.4.0"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])
   s.add_runtime_dependency("rack-test", [">= 0.5.4"])
   s.add_runtime_dependency("xpath", ["~> 0.1.4"])


### PR DESCRIPTION
I found that capybara had installed selenium-webdriver version 0.2.2 as a dependency. This caused problems when trying to use firefox 6. The commit changes the dependency to 2.4.0 of selenium-webdriver.
