### PR TITLE
Closes issue #452. #using_driver now restores the driver to what it was b

### DIFF
--- a/lib/capybara/dsl.rb
+++ b/lib/capybara/dsl.rb
@@ -49,10 +49,11 @@ module Capybara
     # Yield a block using a specific driver
     #
     def using_driver(driver)
+      previous_driver = Capybara.current_driver
       Capybara.current_driver = driver
       yield
     ensure
-      Capybara.use_default_driver
+      @current_driver = previous_driver
     end
 
     ##

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -76,6 +76,17 @@ describe Capybara::DSL do
       Capybara.current_driver.should == Capybara.default_driver
     end
 
+    it 'should return the driver to what it was previously' do
+      Capybara.current_driver = :selenium
+      Capybara.using_driver(:culerity) do
+        Capybara.using_driver(:rack_test) do
+          Capybara.current_driver.should == :rack_test
+        end
+        Capybara.current_driver.should == :culerity
+      end
+      Capybara.current_driver.should == :selenium
+    end
+
     it 'should yield the passed block' do
       called = false
       Capybara.using_driver(:selenium) { called = true }


### PR DESCRIPTION
Closes issue #452. #using_driver now restores the driver to what it was before the block rather than default_driver.

Please let me know if there are any improvements I can make to this patch.

I use capybara in my work and personal projects every single day, and I'm really thankful for all the work that @jnicklas and other maintainers have done. Please consider this a very tiny token of my appreciation!
