### PR TITLE
Making #using_driver specs clearer in light of the fix for issue #452

### DIFF
--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -68,12 +68,20 @@ describe Capybara::DSL do
       driver.should == :selenium
     end
 
-    it 'should reset the driver using Capybara.use_default_driver, even if an exception occurs' do
+    it 'should return the driver to default if it has not been changed' do
+      Capybara.using_driver(:selenium) do
+        Capybara.current_driver.should == :selenium
+      end
+      Capybara.current_driver.should == Capybara.default_driver
+    end
+
+    it 'should reset the driver even if an exception occurs' do
+      driver_before_block = Capybara.current_driver
       begin
         Capybara.using_driver(:selenium) { raise "ohnoes!" }
       rescue Exception
       end
-      Capybara.current_driver.should == Capybara.default_driver
+      Capybara.current_driver.should == driver_before_block
     end
 
     it 'should return the driver to what it was previously' do


### PR DESCRIPTION
This is in response to the suggestion from @betelgeuse [1] -- I see what you mean. 

I was going to change that test's description, but then it got long, and then I was going to add a comment, but I'm not a big fan of comments when code could speak for itself, so I split the previous test whose description was "should reset the driver using Capybara.use_default_driver, even if an exception occurs" into two tests.

One test shows that the driver will be reset to default if it wasn't set to anything before #using_driver, the other test makes sure that it's reset even if there's an exception, and I assigned the driver before the block to a variable to remove the confusion with default_driver altogether, hopefully.

Again, please let me know if there are any improvements I can make to this patch; I will be more than happy to do so. Thanks!

[1] - https://github.com/clnclarinet/capybara/commit/9b0447f203978bf5ad8259574f60801d442aad53#commitcomment-541398
