### PR TITLE
Allow #within to take a node in addition to a selector

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -173,11 +173,20 @@ module Capybara
     #       fill_in('Street', :with => '12 Main Street')
     #     end
     #
-    # @param (see Capybara::Node::Finders#all)
+    # @overload within(*find_args)
+    #   @param (see Capybara::Node::Finders#all)
+    #
+    # @overload within(a_node)
+    #   @param [Capybara::Node::Base] a_node   The node in whose scope the block should be evaluated
+    #
     # @raise  [Capybara::ElementNotFound]   If the scope can't be found before time expires
     #
     def within(*args)
-      new_scope = find(*args)
+      new_scope = if args.size == 1 && Capybara::Node::Base === args.first
+                    args.first
+                  else
+                    find(*args)
+                  end
       begin
         scopes.push(new_scope)
         yield

--- a/lib/capybara/spec/session/within_spec.rb
+++ b/lib/capybara/spec/session/within_spec.rb
@@ -38,6 +38,17 @@ shared_examples_for "within" do
       end
     end
 
+    context "with Node rather than selector" do
+      it "should click links in the given scope" do
+        node_of_interest = @session.find(:css, "ul li[contains('With Simple HTML')]")
+
+        @session.within(node_of_interest) do 
+          @session.click_link('Go')
+        end
+        @session.body.should include('Bar')
+      end
+    end
+
     context "with the default selector set to CSS" do
       before { Capybara.default_selector = :css }
       it "should use CSS" do


### PR DESCRIPTION
Sometimes you have already found a node, or finding the right node is no doable in a selector.  In either case this allows one to add a bit more clarity to the tests.
