### PR TITLE
Remove leading whitespace. 

### DIFF
--- a/lib/capybara/spec/session.rb
+++ b/lib/capybara/spec/session.rb
@@ -5,7 +5,7 @@ Dir[File.dirname(__FILE__)+'/session/*'].each { |group| require group }
 
 shared_examples_for "session" do
   def extract_results(session)
-    YAML.load Nokogiri::HTML(session.body).xpath("//pre[@id='results']").first.text
+    YAML.load Nokogiri::HTML(session.body).xpath("//pre[@id='results']").first.text.lstrip
   end
 
   after do


### PR DESCRIPTION
I saw a lot of tests failing in the akephalos' test suit I tracked down the issue to `lib/capybara/spec/session`

``` ruby
shared_examples_for "session" do
  def extract_results(session)
    YAML.load Nokogiri::HTML(session.body).xpath("//pre[@id='results']").first.text
  end
....
```

It was failing to load the string properly:

```
 Failure/Error: YAML.load Nokogiri::HTML(session.body).xpath("//pre[@id='results']").first.text
 Psych::SyntaxError:
   couldn't parse YAML at line 3 column 5
```

It seems that the problem was the leading whitespace, as it was fixed adding `lstrip`.

``` ruby
def extract_results(session)
    YAML.load Nokogiri::HTML(session.body).xpath("//pre[@id='results']").first.text.lstrip
end
```
