### PR TITLE
Remove statement about should_not have vs should have_no

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -495,6 +495,22 @@ is (the default is 2 seconds):
 
     Capybara.default_wait_time = 5
 
+Be aware that because of this behaviour, the following two statements are *not*
+equivalent, and you should *always* use the latter!
+
+    !page.has_xpath?('a')
+    page.has_no_xpath?('a')
+
+The former would immediately fail because the content has not yet been removed.
+Only the latter would wait for the asynchronous process to remove the content
+from the page.
+
+Capybara's Rspec matchers, however, are smart enough to handle either form.
+The two following statements are functionally equivalent:
+
+    page.should_not have_xpath('a')
+    page.should have_no_xpath('a')
+
 Capybara's waiting behaviour is quite advanced, and can deal with situations
 such as the following line of code:
 


### PR DESCRIPTION
This section of the README is no longer valid. The following lines should be functionally equivalent, since both will end up calling `has_no_xpath?`.

``` ruby
page.should_not have_xpath('a')
page.should have_no_xpath('a')
```
