### PR TITLE
Fixed so that i can check the browser state after a test.

### DIFF
--- a/lib/capybara/cucumber.rb
+++ b/lib/capybara/cucumber.rb
@@ -3,8 +3,9 @@ require 'capybara/dsl'
 
 World(Capybara)
 
-After do
+Before do
   Capybara.reset_sessions!
+  Capybara.use_default_driver
 end
 
 Before('@javascript') do
@@ -25,8 +26,4 @@ end
 
 Before('@rack_test') do
   Capybara.current_driver = :rack_test
-end
-
-After do
-  Capybara.use_default_driver
 end


### PR DESCRIPTION
Moved session cleanup to before the test so that i still have browser state when debuging a faild test, (I reuse the Selenuium/Firefox instance by starting it in the prefork part of spork)

As i can't think of anything negative of doing the cleanup before the test i thought maybe you could accept this small change.
