### PR TITLE
Added Rails 3.1 asset pipeline support

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -54,14 +54,15 @@ module Capybara
     def rewrite_assets_from_asset_pipeline(response_html)
       asset_prefix = ::Rails.application.config.assets.prefix
       public_asset_path = File.join(::Rails.public_path, asset_prefix)
-      manifest = File.join(public_asset_path, "manifest.yml")
+      manifest = File.join(::Rails.application.config.assets.manifest, "manifest.yml")
       unless Dir.exists?(public_asset_path) && File.exists?(manifest)
         raise "You must first run `rake assets:precompile`"
       end
-      assets    = YAML::load(File.open(manifest))
+      assets = YAML::load(File.open(manifest))
       assets.each do |name, asset_name|
         response_html.gsub!(name, asset_name)
       end
+
       return response_html
     end
   end


### PR DESCRIPTION
I added support for the Rails 3.1 asset pipeline to `save_and_open_page`.

It's pretty straight forward. Currently, the method rewrites local asset paths to absolute filesystem paths in the rendered HTML. So, I basically just added a check to see if `::Rails` is defined, if the version is 3.1 or greater, and if the asset pipeline is enabled. If so, it loads the asset manifest file to grab the asset fingerprints for each file, and then rewrites the fingerprints into the rendered HTML.

I have not yet extensively tested this, or had a chance to think about what a test case would look like, but it works very well with my app.
