### PR TITLE
Adding support for getting an element's parent

### DIFF
--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -118,6 +118,16 @@ module Capybara
         native[:selected]
       end
 
+      ##
+      #
+      # The parent of the node
+      #
+      # @return [Capybara::Node::Simple]   The parent element
+      #
+      def parent
+        Capybara::Node::Simple.new(native.parent)
+      end
+
     protected
 
       def find_in_base(selector, xpath)

--- a/spec/basic_node_spec.rb
+++ b/spec/basic_node_spec.rb
@@ -73,5 +73,10 @@ describe Capybara do
       string.find('//h1').should be_visible
       string.find('//input').should_not be_visible
     end
+
+    it "allows getting the parent of an element" do
+      string.find('//h1').parent[:id].should == 'content'
+    end
+
   end
 end


### PR DESCRIPTION
It seemed Capybara lacked a simple way to get an element's parent ( http://stackoverflow.com/questions/4861863/how-to-get-parent-node-in-capybara ) so I've added support for this.
