### PR TITLE
This adds a server_host option to Capybara.

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -16,7 +16,7 @@ module Capybara
 
   class << self
     attr_accessor :asset_root, :app_host, :run_server, :default_host
-    attr_accessor :server_port, :server_boot_timeout
+    attr_accessor :server_host, :server_port, :server_boot_timeout
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements, :prefer_visible_elements
     attr_accessor :save_and_open_page_path, :automatic_reload
 

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -32,7 +32,7 @@ module Capybara
     end
 
     def host
-      "127.0.0.1"
+      Capybara.server_host || "127.0.0.1"
     end
 
     def url(path)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -17,6 +17,16 @@ describe Capybara::Server do
     end.should_not raise_error
   end
 
+  it "should bind to the specified host" do
+    Capybara.server_host = '0.0.0.0'
+
+    app = proc { |env| [200, {}, "Hello Server!"]}
+    server = Capybara::Server.new(app).boot
+    server.host.should == '0.0.0.0'
+
+    Capybara.server_host = nil
+  end
+
   it "should use specified port" do
     Capybara.server_port = 22789
 


### PR DESCRIPTION
Hey @jnicklas!

In order to run Selenium via Capybara on my virtual machine running IE (kill me), you need to be able to bind the server IP to a net interface on the same subnet as the VM.

This patch exposes an configuration variable to allow you to bind the test server to any net interface on your local machine.

It falls back to 127.0.0.1 if the config var is not set.

Thanks!
