### PR TITLE
I added some info to the section about capybara-webkit that will probably save some time for anyone new to both capybara and capybara-webkit.  I'm not sure if the wording is the best, but please consider adding something like this.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -294,9 +294,23 @@ You can install it with:
 
   gem install capybara-webkit
 
-And you can use it by:
+And if you are using Cucumber, you can use it by:
 
   Capybara.javascript_driver = :webkit
+
+Otherwise (if you are using Test::Unit, for example):
+
+  Capybara.default_driver = :webkit
+
+You will also need to require the database_cleaner gem, and most likely the following monkey patch
+to ensure that your fixtures are accessible to the requests coming from capybara-webkit once they've
+been loaded into the db:
+
+Thread.main[:activerecord_connection] = ActiveRecord::Base.retrieve_connection
+
+def (ActiveRecord::Base).connection
+  Thread.main[:activerecord_connection]
+end
 
 
 == The DSL


### PR DESCRIPTION
Updated docs to include crucial information for those using capybara-webkit.  Without these steps, capybara-webkit will not be able to see any fixtures loaded into the db.
