### PR TITLE
XML Support in Rack Test

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -81,7 +81,11 @@ class Capybara::RackTest::Browser
   end
 
   def dom
-    @dom ||= Nokogiri::HTML(source)
+    if headers['Content-Type'] && headers['Content-Type'] =~ /xml/
+      @dom ||= Nokogiri::XML(source)
+    else
+      @dom ||= Nokogiri::HTML(source)
+    end
   end
 
   def find(selector)
@@ -92,6 +96,10 @@ class Capybara::RackTest::Browser
     last_response.body
   rescue Rack::Test::Error
     nil
+  end
+
+  def headers
+    last_response.headers || {}
   end
 
 protected

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -14,6 +14,12 @@ class TestApp < Sinatra::Base
     'Another World'
   end
 
+  get '/foo.xml' do
+    headers "Content-Type" => 'text/xml'
+    '<world>Another</world>'
+  end
+
+
   get '/redirect' do
     redirect '/redirect_again'
   end

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -86,4 +86,16 @@ describe Capybara::RackTest::Driver do
       @driver.body.should include('foobar')
     end
   end
+
+  describe 'content' do
+    it 'should parse HTML as HTML' do
+      @driver.visit('/foo')
+      @driver.body.should match %r{^<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n<html><body>}
+    end
+
+    it 'should parse XML as XML' do
+      @driver.visit('/foo.xml')
+      @driver.body.should match %r{^<\?xml version="1.0"\?>\n<world>}
+    end
+  end
 end


### PR DESCRIPTION
Detect if Content-Type is XML and then use Nokogiri::XML instead of
Nokogiri::HTML to parse the content. This fixes two issues.

Firstly it stops XML being wrapped with an HTML doctype and body tags.

Secondly it stops tags being normalised to lower case and allows tags
with colons like media:author.
