### PR TITLE
Raise on Rack application timeout

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -71,8 +71,7 @@ module Capybara
         end
       end
     rescue TimeoutError
-      puts "Rack application timed out during boot"
-      exit
+      raise "Rack application timed out during boot"
     else
       self
     end


### PR DESCRIPTION
We're using Evergreen for JS testing on our Rails app, and it uses Capybara internally.  We have one of the largest Rails apps out there, and 10 seconds was barely enough to boot it (sometimes not).

When Capybara hit the timeout during our test:javascripts task, it would output this message and exit the entire Rake process (successfully), which (in our automated testing environment) made the entire test run "succeed" — when in fact it had failed to run the JS tests or anything after them.

The simple fix is just to re-raise with a more useful message rather than merely puts'ing the message and exiting with a successful code (0).  (Obviously we also increased the timeout on our end.)
