### PR TITLE
Gracefully handle intermittent getBBox failures

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -1,6 +1,9 @@
 class Capybara::Selenium::Node < Capybara::Driver::Node
   def text
     native.text
+  rescue Selenium::WebDriver::Error::UnhandledError => ex
+    return '' if ex.to_s =~ /nsIDOMSVGLocatable.getBBox/i
+    raise
   end
 
   def [](name)


### PR DESCRIPTION
This works around the issue described in #501. The repo case in that issue is also reproducible for me, see comments for version info:
https://gist.github.com/11681383c6779ad15ce9

Been using this fix on a fairly large acceptance suite for a few weeks and it's been working well. In practice, it seems to only happen when using `Element#text`. I suspect, it may be related to the complexity of that method in Selenium:
http://code.google.com/p/selenium/source/browse/trunk/javascript/selenium-atoms/text.js#43
