### PR TITLE
Add rake as a development dependency

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("yard", [">= 0.5.8"])
   s.add_development_dependency("fuubar", [">= 0.0.1"])
   s.add_development_dependency("cucumber", [">= 0.10"])
+  s.add_development_dependency("rake")
 end


### PR DESCRIPTION
Otherwise, running `bundle exec rake ...` will lead to an error:

``` bash
/Users/markdodwell/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.0.21/lib/bundler/rubygems_integration.rb:156:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /Users/markdodwell/.rvm/gems/ruby-1.9.2-p290/bin/rake:18:in `<main>'
```
