### PR TITLE
Show only invisble elements when ':visible => false' given

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -167,8 +167,8 @@ module Capybara
           options[:text] = Regexp.escape(text) unless text.kind_of?(Regexp)
         end
 
-        if !options.has_key?(:visible)
-          options[:visible] = Capybara.ignore_hidden_elements
+        if !options.has_key?(:visible) && Capybara.ignore_hidden_elements
+          options[:visible] = true
         end
 
         if selected = options[:selected]
@@ -179,12 +179,12 @@ module Capybara
       end
 
       def matches_options(node, options)
-        return false if options[:text]      and not node.text.match(options[:text])
-        return false if options[:visible]   and not node.visible?
-        return false if options[:with]      and not node.value == options[:with]
-        return false if options[:checked]   and not node.checked?
-        return false if options[:unchecked] and node.checked?
-        return false if options[:selected]  and not has_selected_options?(node, options[:selected])
+        return false if options[:text]              and not node.text.match(options[:text])
+        return false if options.has_key?(:visible)  and not node.visible? == options[:visible]
+        return false if options[:with]              and not node.value == options[:with]
+        return false if options[:checked]           and not node.checked?
+        return false if options[:unchecked]         and node.checked?
+        return false if options[:selected]          and not has_selected_options?(node, options[:selected])
         true
       end
 

--- a/lib/capybara/spec/session/all_spec.rb
+++ b/lib/capybara/spec/session/all_spec.rb
@@ -58,8 +58,7 @@ shared_examples_for "all" do
       end
 
       it "should only find invisible nodes" do
-        Capybara.ignore_hidden_elements = true
-        @session.all("//a[@title='awesome title']", :visible => false).should have(2).elements
+        @session.all("//a[@title='awesome title']", :visible => false).should have(1).elements
       end
     end
 

--- a/lib/capybara/spec/session/first_spec.rb
+++ b/lib/capybara/spec/session/first_spec.rb
@@ -51,10 +51,8 @@ shared_examples_for "first" do
         @session.first(:css, "a#invisible").should be_nil
       end
 
-      it "should include invisible nodes if false given" do
-        Capybara.ignore_hidden_elements = true
+      it "should only find invisible nodes if false given" do
         @session.first(:css, "a#invisible", :visible => false).should_not be_nil
-        @session.first(:css, "a#invisible").should be_nil
       end
     end
 


### PR DESCRIPTION
When ":visible => false" is given as an option for "all" finder, is intuitive that it matches only invisible elements.
