### PR TITLE
Changes made by AJAX not reflected in page object

### DIFF
--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -44,7 +44,7 @@ class Capybara::Driver::Base
   end
 
   def wait?
-    false
+    true
   end
 
   def wait_until(*args)


### PR DESCRIPTION
With driver wait set to false the changes in the HTML made by an AJAX call will never be seen by the Capybara object page, even though Capybara.default_wait_time is set. Make sure the driver waits that amount of time to see those changes.
