### PR TITLE
Output the number of matches that were expected if called with the count option

### DIFF
--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -77,6 +77,8 @@ module Capybara
       def failure_message_for_should
         if failure_message
           failure_message.call(actual, self)
+        elsif(@options[:count])
+          "expected #{selector_name} to be returned #{@options[:count]} times"
         else
           "expected #{selector_name} to return something"
         end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -32,7 +32,7 @@ describe Capybara::RSpecMatchers do
         it "fails if matched node count does not equal expected count" do
           expect do
             "<h1>Text</h1>".should have_css('h1', :count => 2)
-          end.to raise_error(/expected css "h1" to return something/)
+          end.to raise_error(/expected css "h1" to be returned 2 times/)
         end
       end
 


### PR DESCRIPTION
I thought this might be nice little enhancement. I was confused when I first used capybara because selectors were matching but not the correct number of times. This would make things clearer I think :)
