### PR TITLE
Don't follow external redirects for the rack-test driver.

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -6,7 +6,8 @@ require 'cgi'
 
 class Capybara::RackTest::Driver < Capybara::Driver::Base
   DEFAULT_OPTIONS = {
-    :respect_data_method => true
+    :respect_data_method        => true,
+    :follow_external_redirects  => false
   }
   attr_reader :app, :options
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -135,6 +135,14 @@ module Capybara
     def current_url
       driver.current_url
     end
+    
+    ##
+    #
+    # @return [String] Fully qualified URL of the external location being redirected to
+    #
+    def redirect_url
+      response_headers['Location']
+    end
 
     ##
     #

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -74,6 +74,10 @@ class TestApp < Sinatra::Base
   get '/redirect_secure' do
     redirect "https://#{request.host}/host"
   end
+  
+  get '/external_redirect' do
+    redirect "http://www.google.com/"
+  end
 
   get '/slow_response' do
     sleep 2

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -31,6 +31,13 @@ describe Capybara::RackTest::Driver do
   it_should_behave_like "driver with cookies support"
   it_should_behave_like "driver with infinite redirect detection"
 
+  describe '#visit' do
+    it 'should not follow redirects to an external URL' do
+      @driver.visit('/external_redirect')
+      @driver.response_headers["Location"].should == 'http://www.google.com/'
+    end
+  end
+
   describe '#reset!' do
     it { @driver.visit('/foo'); lambda { @driver.reset! }.should change(@driver, :current_url).to('') }
 
@@ -84,6 +91,14 @@ describe Capybara::RackTest::Driver do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header_via_redirect')
       @driver.body.should include('foobar')
+    end
+  end
+
+  describe ':external_redirects option' do
+    it 'should allow external redirects to be followed' do
+      @driver = Capybara::RackTest::Driver.new(TestApp, :follow_external_redirects => true)
+      @driver.visit('/external_redirect')
+      @driver.current_url.should == 'http://www.google.com/'
     end
   end
 end

--- a/spec/session/rack_test_session_spec.rb
+++ b/spec/session/rack_test_session_spec.rb
@@ -52,6 +52,13 @@ describe Capybara::Session do
         end
       end
     end
+    
+    describe '#redirect_url' do
+      it "should report the external URL redirected to" do
+        @session.visit('/external_redirect')
+        @session.redirect_url.should == "http://www.google.com/"
+      end
+    end
 
     it_should_behave_like "session"
     it_should_behave_like "session without javascript support"


### PR DESCRIPTION
Previously the `Capybara::RackTest::Driver` would follow all redirects even those to external URLs. This would cause exceptions to be raised if the path of the URL didn't match a route in the application being tested. This is because rack-test can't hit external URLs. The expected usage here is that the developer just wants to test that the redirect went to the correct external location not test anything about it. If they actually want to make assertion about the content at the external URL or interact with the external page in some way they should use an alternate driver. So what this now does is just not continue to process requests after we reach a redirect to an external URL.

This new behavior can be changed back to the old behavior by passing `false` to the `:follow_external_redirects` option to the `Capybara::RackTest::Driver`:

``` ruby
Capybara.register_driver :rack_test do |app|
  Capybara::RackTest::Driver.new(app, :follow_external_redirects => true)
end
```

This also adds the `#redirect_url` method to the `Capybara::Session` object. This way the developer can test that the app redirected to the correct location:

``` ruby
visit('/redirect_to_external_location')
redirect_url.should == 'http://www.google.com'
```
