### PR TITLE
Check Launchy version as suggested by @levity in #415

### DIFF
--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -22,10 +22,11 @@ module Capybara
   protected
 
     def open_in_browser(path) # :nodoc
-      require "launchy"
+      require "launchy" # could raise LoadError
+      raise LoadError unless Launchy::Version::MAJOR >= 2
       Launchy.open(path)
     rescue LoadError
-      warn "Sorry, you need to install launchy (`gem install launchy`) and " <<
+      warn "Sorry, you need to install launchy >=2.0.0 (`gem install launchy`) and " <<
         "make sure it's available to open pages with `save_and_open_page`."
     end
 


### PR DESCRIPTION
Launchy versions older than 2.0.0 (like 0.4.0) are not compatible.
Capybara now complains if it finds such a Launchy version. (I tested all
of this.)
