### PR TITLE
Capybara#evaluate_script method (at least for WebDriver) should accept an *args parameter

### DIFF
--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -19,11 +19,11 @@ class Capybara::Driver::Base
     raise NotImplementedError
   end
 
-  def execute_script(script)
+  def execute_script(script, *args)
     raise Capybara::NotSupportedByDriverError
   end
 
-  def evaluate_script(script)
+  def evaluate_script(script, *args)
     raise Capybara::NotSupportedByDriverError
   end
 

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -66,12 +66,12 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     end
   end
 
-  def execute_script(script)
-    browser.execute_script script
+  def execute_script(script, *args)
+    browser.execute_script(script, *args)
   end
 
-  def evaluate_script(script)
-    browser.execute_script "return #{script}"
+  def evaluate_script(script, *args)
+    browser.execute_script("return #{script}", *args)
   end
 
   def reset!

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -261,9 +261,10 @@ module Capybara
     # +evaluate_script+ whenever possible.
     #
     # @param [String] script   A string of JavaScript to execute
+    # @param [Array]  *args    An optional array of parameters for the JavaScript string
     #
-    def execute_script(script)
-      driver.execute_script(script)
+    def execute_script(script, *args)
+      driver.execute_script(script, *args)
     end
 
     ##
@@ -273,10 +274,11 @@ module Capybara
     # be a better alternative.
     #
     # @param  [String] script   A string of JavaScript to evaluate
+    # @param  [Array]  *args    An optional array of parameters for the JavaScript string
     # @return [Object]          The result of the evaluated JavaScript (may be driver specific)
     #
-    def evaluate_script(script)
-      driver.evaluate_script(script)
+    def evaluate_script(script, *args)
+      driver.evaluate_script(script, *args)
     end
 
     ##


### PR DESCRIPTION
The Capybara bindings to WebDriver have fallen slightly behind the current functionality of WebDriver.

In particular, the WebDriver#execute_script function has the capability of acting on a WebDriver::Element object as follows: 

  button = driver.find_element(:id, "plainButton")
  driver.execute_script("return arguments[0].innerText;", button)

This is because the WebDriver#execute_script method is defined as:

  def execute_script(script, *args) 
      ... #stuff
  end

I added the following functionality (note, wherever something was applied to evaluate_script, it was applied to execute_script as well): 
In capybara/session.rb -> 
    ##
    #
    # Evaluate the given JavaScript and return the result. Be careful when using this with
    # scripts that return complex objects, such as jQuery statements. +execute_script+ might
    # be a better alternative.
    #
    # @param  [String] script   A string of JavaScript to evaluate
    # @param  [Array]  *args    An optional array of arguments to feed the script
    # @return [Object]          The result of the evaluated JavaScript (may be driver specific)
    #
    def evaluate_script(script, *args)
      driver.evaluate_script(script, *args)
    end

In capybara/selenium/driver.rb:

  def execute_script(script, *args)
    browser.execute_script(script, *args)
  end

  def evaluate_script(script, *args)
    browser.execute_script("return #{script}", *args)
  end

In capybara/driver/base.rb:

  def execute_script(script, *args)
    raise Capybara::NotSupportedByDriverError
  end

  def evaluate_script(script, *args)
    raise Capybara::NotSupportedByDriverError
  end

I am in the process of running the test suite on Capybara to see if my changes messed with any functionality, but I suspect not. If it does, we can simply back it out to just change the Selenium bindings to evaluate_script/execute_script?

Thanks,
Em
