### PR TITLE
Corrected webkit config instructions in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -292,7 +292,7 @@ You can install it with:
 
 And you can use it by:
 
-  Capybara.javascript_driver = :webkit
+  Capybara.default_driver = :webkit
 
 
 == The DSL


### PR DESCRIPTION
Configuration for webkit driver in README said:

Capybara.javascript_driver = :webkit

...which had no effect when I added it to spec_helper.rb. When I adjusted it to match the config instructions for selenium:

Capybara.default_driver = :webkit

Everything worked as expected. I updated the README to reflect the change.

Thanks for the great tool!

-- Bill
