### PR TITLE
Require 'capybara/dsl' in capybara.rb. Thanks to @audionerd in #565

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -1,6 +1,8 @@
 require 'timeout'
 require 'nokogiri'
 require 'xpath'
+require 'capybara/dsl'
+
 module Capybara
   class CapybaraError < StandardError; end
   class DriverNotFoundError < CapybaraError; end


### PR DESCRIPTION
See discussion in #565. I don't think this is easily testable, is it?
