### PR TITLE
Exclude spec files from gem distribution

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.email = ["jonas.nicklas@gmail.com"]
   s.description = "Capybara is an integration testing tool for rack based web applications. It simulates how a user would interact with a website"
 
-  s.files = Dir.glob("{lib,spec}/**/*") + %w(README.md History.txt License.txt)
+  s.files = Dir.glob("lib/**/*") + %w(README.md History.txt License.txt) \
+    - Dir.glob("lib/capybara/spec/**/*")
 
   s.homepage = "http://github.com/jnicklas/capybara"
   s.require_paths = ["lib"]


### PR DESCRIPTION
The resulting capybara-1.1.2.gem file contents look OK. I'm just not sure if there was some reason why we'd want to include the spec files.

Excluding spec files would slim the distribution by almost 1MB.
