### PR TITLE
RackTest::Node#text now normalizes whitespace like Selenium

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -1,16 +1,6 @@
 class Capybara::RackTest::Node < Capybara::Driver::Node
   def text
-    if !visible?
-      ''
-    elsif native.text?
-      native.text
-    elsif native.element?
-      native.children.map do |child|
-        Capybara::RackTest::Node.new(driver, child).text
-      end.join
-    else
-      ''
-    end
+    unnormalized_text.strip.gsub(/\s+/, ' ')
   end
 
   def [](name)
@@ -92,6 +82,22 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
 
   def find(locator)
     native.xpath(locator).map { |n| self.class.new(driver, n) }
+  end
+
+protected
+
+  def unnormalized_text
+    if !visible?
+      ''
+    elsif native.text?
+      native.text
+    elsif native.element?
+      native.children.map do |child|
+        Capybara::RackTest::Node.new(driver, child).unnormalized_text
+      end.join
+    else
+      ''
+    end
   end
 
 private

--- a/lib/capybara/spec/session/text_spec.rb
+++ b/lib/capybara/spec/session/text_spec.rb
@@ -1,19 +1,24 @@
 shared_examples_for "text" do
   describe '#text' do
-    before do
-      @session.visit('/with_simple_html')
-    end
-
     it "should print the text of the page" do
+      @session.visit('/with_simple_html')
       @session.text.should == 'Bar'
     end
 
     context "with css as default selector" do
       before { Capybara.default_selector = :css }
       it "should print the text of the page" do
+        @session.visit('/with_simple_html')
         @session.text.should == 'Bar'
       end
       after { Capybara.default_selector = :xpath }
+    end
+
+    it "should strip whitespace" do
+      @session.visit('/with_html')
+      n = @session.find(:css, '#second')
+      @session.find(:css, '#second').text.should =~ \
+        /\ADuis aute .* text with whitespace .* est laborum\.\z/
     end
   end
 end


### PR DESCRIPTION
```
RackTest::Node#text now normalizes whitespace like Selenium

Previously Rack::Test's #text method might have returned
"   some  text ", whereas now it returns "some text", just like
Selenium.
```

---

Rack::Test through Nokogiri gives us all the whitespace in #text, which I think is not very helpful for testing, and more importantly it's incompatible with Selenium. This patch fixes that.

I'm actually not convinced that this should be merged into master, since I think it might break existing test code and make people unhappy. My sense (which quite possibly could be off) is that it's more beneficial to be disciplined and wait with this change until version 2.0.

How do you feel about this?
