### PR TITLE
Remove Capybara.server_boot_timeout, hard-code 60 seconds. Closes #589

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -19,6 +19,11 @@
 * Element#text on RackTest now only returns visible text and normalizes
   (strips) whitespace, as with Selenium [Mark Dodwell, Jo Liss]
 
+### Removed
+
+* #589: Capybara.server_boot_timeout has been removed in favor of a higher
+  (60-second) hard-coded timeout [Jo Liss]
+
 # Version 1.1.2
 
 Release date: 2011-11-15

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -17,7 +17,7 @@ module Capybara
 
   class << self
     attr_accessor :asset_root, :app_host, :run_server, :default_host
-    attr_accessor :server_host, :server_port, :server_boot_timeout
+    attr_accessor :server_host, :server_port
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements, :prefer_visible_elements
     attr_accessor :save_and_open_page_path, :automatic_reload
     attr_writer :default_driver, :current_driver, :javascript_driver, :session_name
@@ -351,7 +351,6 @@ end
 Capybara.configure do |config|
   config.run_server = true
   config.server {|app, port| Capybara.run_default_server(app, port)}
-  config.server_boot_timeout = 10
   config.default_selector = :css
   config.default_wait_time = 2
   config.ignore_hidden_elements = false

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -65,9 +65,7 @@ module Capybara
             Capybara.server.call(Identify.new(@app), @port)
           end
 
-          Capybara.timeout(Capybara.server_boot_timeout) do
-            responsive?
-          end
+          Capybara.timeout(60) { responsive? }
         end
       end
     rescue TimeoutError


### PR DESCRIPTION
Thanks to Adam Cigánek for his helpful input and the original patch!

---

Jonas, what do you think?
