### PR TITLE
Raise ArgumentError when passing invalid keys to has_selector?

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -1,6 +1,7 @@
 module Capybara
   module Node
     module Matchers
+      ValidKeys = [:between, :count, :maximum, :minimum]
 
       ##
       #
@@ -34,6 +35,7 @@ module Capybara
       #
       def has_selector?(*args)
         options = if args.last.is_a?(Hash) then args.last else {} end
+        assert_valid_options(options)
         wait_until do
           results = all(*args)
 
@@ -66,6 +68,7 @@ module Capybara
       #
       def has_no_selector?(*args)
         options = if args.last.is_a?(Hash) then args.last else {} end
+        assert_valid_options(options)
         wait_until do
           results = all(*args)
 
@@ -437,6 +440,19 @@ module Capybara
       def normalize_whitespace(text)
         text.gsub(/\s+/, ' ').strip
       end
+
+      ##
+      #
+      # Raise ArgumentError unless all keys are supported by
+      # has_selector?, Capybara::Selector, or Capybara::Query
+      #
+      def assert_valid_options(options)
+        valid_keys = ValidKeys + Capybara::Query::ValidKeys + Capybara::Selector::ValidKeys
+        options.keys.each do |key|
+          raise(ArgumentError, "Unknown key: #{key}") unless valid_keys.include?(key)
+        end
+      end
+
     end
   end
 end

--- a/lib/capybara/query.rb
+++ b/lib/capybara/query.rb
@@ -1,5 +1,6 @@
 module Capybara
   class Query
+    ValidKeys = [:message, :text, :visible]
     attr_accessor :selector, :locator, :options, :xpaths
 
     def initialize(*args)

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -1,5 +1,6 @@
 module Capybara
   class Selector
+    ValidKeys = []
     attr_reader :name, :custom_filters
 
 
@@ -57,6 +58,7 @@ module Capybara
     end
 
     def filter(name, &block)
+      ValidKeys.push(name) unless ValidKeys.include?(name)
       @custom_filters[name] = block
     end
   end

--- a/lib/capybara/spec/session/has_selector_spec.rb
+++ b/lib/capybara/spec/session/has_selector_spec.rb
@@ -61,6 +61,14 @@ shared_examples_for "has_selector" do
         @session.should_not have_selector("//p//a", :text => /Red$/)
       end
     end
+
+    context "with invalid input" do
+      it "should raise ArgumentError when using invalid options" do
+        lambda{
+          @session.should have_selector("//p//a", :contents=>"Redirect")
+        }.should raise_error(ArgumentError, "Unknown key: contents")
+      end
+    end
   end
 
   describe '#has_no_selector?' do
@@ -123,6 +131,14 @@ shared_examples_for "has_selector" do
       it "should discard all matches where the given regexp is matched" do
         @session.should_not have_no_selector("//p//a", :text => /re[dab]i/i, :count => 1)
         @session.should have_no_selector("//p//a", :text => /Red$/)
+      end
+    end
+
+    context "with invalid input" do
+      it "should raise ArgumentError when using invalid options" do
+        lambda{
+          @session.should have_no_selector("//p//a", :contents=>"Redirect")
+        }.should raise_error(ArgumentError, "Unknown key: contents")
       end
     end
   end


### PR DESCRIPTION
It's a relatively common misconception that you can use :content as a key - e.g.

``` ruby
has_selector?('h1', :content=>'wooo!')
```

which would silently pass, even when 'wooo!' is nowhere to be found.  This change should make that error much more obvious.

Related issues : https://github.com/jnicklas/capybara/issues/525

It would be nice to raise an error on passing a block in - eg 

``` ruby
@session.should have_selector("//p") do |p_tag|
  p_tag.should have_selector("//a")
end
```

which seems to be a common error on people switching to capybara via webrat.  However, that's a bit more tricky and would probably need fixing at the rspec-matcher level, since the block doesn't make it as far as has_selector? and gets silently discarded.
