### PR TITLE
Adds asset servers for save_and_open

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -17,6 +17,7 @@ module Capybara
 
   class << self
     attr_accessor :asset_root, :app_host, :run_server, :default_host
+    attr_accessor :asset_servers
     attr_accessor :server_host, :server_port
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements, :prefer_visible_elements
     attr_accessor :save_and_open_page_path, :automatic_reload
@@ -35,7 +36,10 @@ module Capybara
     # === Configurable options
     #
     # [asset_root = String]               Where static assets are located, used by save_and_open_page
-    # [app_host = String]                 The default host to use when giving a relative URL to visit
+    # [asset_servers = Hash]              Where dynamic assets are hosted -
+    #                                     hash of URL => path prefix
+    # [app_host = String]                 The default host to use when giving a
+    # relative URL to visit
     # [run_server = Boolean]              Whether to start a Rack server for the given Rack app (Default: true)
     # [default_selector = :css/:xpath]    Methods which take a selector use the given type by default (Default: CSS)
     # [default_wait_time = Integer]       The number of seconds to wait for asynchronous processes to finish (Default: 2)

--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -4,7 +4,7 @@ require 'capybara/dsl'
 Capybara.app = Rack::Builder.new do
   map "/" do
     if Rails.version.to_f >= 3.0
-      run Rails.application  
+      run Rails.application
     else # Rails 2
       use Rails::Rack::Static
       run ActionController::Dispatcher.new
@@ -13,5 +13,7 @@ Capybara.app = Rack::Builder.new do
 end.to_app
 
 Capybara.asset_root = Rails.root.join('public')
+if Rails.version.to_f >= 3.0
+  Capybara.asset_servers = {"http://127.0.0.1:3000" => ['assets']}
+end
 Capybara.save_and_open_page_path = Rails.root.join('tmp/capybara')
-

--- a/lib/capybara/util/save_and_open_page.rb
+++ b/lib/capybara/util/save_and_open_page.rb
@@ -32,7 +32,13 @@ module Capybara
 
     def rewrite_css_and_image_references(response_html) # :nodoc:
       root = Capybara.asset_root
-      return response_html unless root
+      asset_servers = Capybara.asset_servers
+      return response_html unless (root or asset_servers)
+
+      (asset_servers || {}).each_pair do |asset_server, server_assets|
+        response_html.gsub!(/("|')\/(#{server_assets.join('|')})/, '\1' + asset_server.to_s + '/\2')
+      end
+
       directories = Dir.new(root).entries.select { |name|
         (root+name).directory? and not name.to_s =~ /^\./
       }

--- a/spec/save_and_open_page_spec.rb
+++ b/spec/save_and_open_page_spec.rb
@@ -143,6 +143,23 @@ describe Capybara do
         it "should rewrite relative paths to absolute local paths" do
           test_with_directories([ 'javascripts', 'images' ])
         end
+
+        context "asset_server contains a URL and path" do
+          it "should rewrite relative paths to FQ URLs and/or absolute local paths" do
+
+            mock_asset_root_with(['javascripts', 'images'])
+            asset_server = "http://assets.com/"
+            Capybara.should_receive(:asset_servers).and_return(asset_server => ['javascripts'])
+            @temp_file.should_receive(:write) do |html|
+              html.should_not =~ %r{["']/?javascripts}
+              html.should_not =~ %r{["']/?images}
+              html.should_not =~ %r{#{@asset_root_dir}/javascripts}
+                html.should =~ %r{#{asset_server}/javascripts}
+                html.should =~ %r{#{@asset_root_dir}/images}
+            end
+            Capybara.save_page @html, 'page.html'
+          end
+        end
       end
 
       context "asset_root path contains no directories" do


### PR DESCRIPTION
Adds Capybara.asset_servers: is a hash of url => [path prefixes] which will be written analogously to directories in asset_root.  capybara/rails is extended with a sensible default.

Upshot is: use save_and_open_page in a run, run 'rails server', and asset pipeline resources will get served by localhost:3000.
