### PR TITLE
Use method="post".

### DIFF
--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -40,6 +40,10 @@ class TestApp < Sinatra::Base
     "Current host is #{request.scheme}://#{request.host}:#{request.port}"
   end
 
+  post '/host' do
+    "Current host is #{request.scheme}://#{request.host}:#{request.port}"
+  end
+
   get '/redirect/:times/times' do
     times = params[:times].to_i
     if times.zero?

--- a/lib/capybara/spec/views/host_links.erb
+++ b/lib/capybara/spec/views/host_links.erb
@@ -3,10 +3,10 @@
   <a href="<%= params[:absolute_host] %>/host">Absolute Host</a>
 </p>
 
-<form action="/host">
+<form action="/host" method="post">
   <p><input type="submit" value="Relative Host"/></p>
 </form>
 
-<form action="<%= params[:absolute_host] %>/host">
+<form action="<%= params[:absolute_host] %>/host" method="post">
   <p><input type="submit" value="Absolute Host"/></p>
 </form>


### PR DESCRIPTION
WebKit will append a '?' to the URL when submitting a form via GET, even
if there is no actual form data. (Firefox does not.) This causes a couple
of tests to fail for the Poltergeist driver, because the tests do not
expect there to be a '?'. Presumably it would also affect
capybara-webkit.

I am not sure which behaviour is 'correct' but it would seem a bad idea
to mess with the URL that the browser is actually providing, so changing
to test like this just allows the results to be consistent.
