### PR TITLE
Correct the specs for Session#body, #html, #source.

### DIFF
--- a/lib/capybara/spec/session/javascript.rb
+++ b/lib/capybara/spec/session/javascript.rb
@@ -88,22 +88,24 @@ shared_examples_for "session with javascript support" do
       end
     end
 
-    describe '#body' do
+    describe '#html' do
       it "should return the current state of the page" do
         @session.visit('/with_js')
-        @session.body.should include('I changed it')
-        @session.body.should_not include('This is text')
+        @session.html.should include('I changed it')
+        @session.html.should_not include('This is text')
       end
     end
 
-    describe '#source' do
-      it "should return the original, unmodified source of the page" do
-        # Not supported by Selenium. See for example
-        # http://stackoverflow.com/questions/6050805
-        unless @session.mode == :selenium
-          @session.visit('/with_js')
-          @session.source.should include('This is text')
-          @session.source.should_not include('I changed it')
+    [:body, :source].each do |method|
+      describe "##{method}" do
+        it "should return the original, unmodified source of the page" do
+          # Not supported by Selenium. See for example
+          # http://stackoverflow.com/questions/6050805
+          unless @session.mode == :selenium
+            @session.visit('/with_js')
+            @session.send(method).should include('This is text')
+            @session.send(method).should_not include('I changed it')
+          end
         end
       end
     end


### PR DESCRIPTION
Per f4360f60998ea4805dfba89a1613939d054975c4, #body should return the
unmodified source, just like #source. However, in Selenium it doesn't,
which is why this test was passing, even though it is incorrect.

I have corrected the spec for #body to match #source (as it is just an
alias), and changed the original spec for #body to be the spec for #html.

(The #body spec fails against Poltergeist before this fix.)
