### PR TITLE
Add workaround for "docElement is null" flickering test problem

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,21 @@ RSpec.configure do |config|
       config.default_selector = :xpath
     end
   end
+
+  # Workaround for http://code.google.com/p/selenium/issues/detail?id=3147:
+  # Rerun the example if we hit a transient "docElement is null" error
+  config.around(:each) do |example|
+    attempts = 0
+    begin
+      example.run
+      e = @example.instance_variable_get('@exception') # usually nil
+      if (e.is_a?(Selenium::WebDriver::Error::UnknownError) &&
+          e.message == 'docElement is null' && (attempts += 1) < 5)
+        @example.instance_variable_set('@exception', nil)
+        redo
+      end
+    end until true
+  end
 end
 
 # Required here instead of in rspec_spec to avoid RSpec deprecation warning


### PR DESCRIPTION
---

This works around the "docElement is null" problem first mentioned in #591, which Jari reproduced at http://code.google.com/p/selenium/issues/detail?id=3147. Now we get reliable green builds: See http://travis-ci.org/#!/joliss/capybara/builds #76-#90.

The code is not very pretty, but I'm OK with having temporary hackery in the test code (until Selenium gets fixed).
