### PR TITLE
Fixed failure messages when using :count on have_selector

### DIFF
--- a/lib/capybara/query.rb
+++ b/lib/capybara/query.rb
@@ -26,6 +26,8 @@ module Capybara
       message ||= options[:message]
       if find
         message ||= "Unable to find #{description}"
+      elsif options[:count]
+        message ||= "expected #{description} to be returned #{options[:count]} times"
       else
         message ||= "expected #{description} to return something"
       end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -95,11 +95,11 @@ describe Capybara::RSpecMatchers do
 
     context "on a string" do
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_xpath? returns true" do
           "<h1>Text</h1>".should have_xpath('//h1')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_xpath? returns false" do
           expect do
             "<h1>Text</h1>".should have_xpath('//h2')
           end.to raise_error(%r(expected xpath "//h2" to return something))
@@ -107,11 +107,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_xpath? returns true" do
           "<h1>Text</h1>".should_not have_xpath('//h2')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_xpath? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_xpath('//h1')
           end.to raise_error(%r(expected xpath "//h1" not to return anything))
@@ -125,11 +125,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_xpath? returns true" do
           page.should have_xpath('//h1')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_xpath? returns false" do
           expect do
             page.should have_xpath("//h1[@id='doesnotexist']")
           end.to raise_error(%r(expected xpath "//h1\[@id='doesnotexist'\]" to return something))
@@ -137,11 +137,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_xpath? returns true" do
           page.should_not have_xpath('//h1[@id="doesnotexist"]')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_xpath? returns false" do
           expect do
             page.should_not have_xpath('//h1')
           end.to raise_error(%r(expected xpath "//h1" not to return anything))
@@ -159,14 +159,24 @@ describe Capybara::RSpecMatchers do
 
     context "on a string" do
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_selector? returns true" do
           "<h1>Text</h1>".should have_selector('//h1')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_selector? returns false" do
           expect do
             "<h1>Text</h1>".should have_selector('//h2')
           end.to raise_error(%r(expected xpath "//h2" to return something))
+        end
+
+        it "passes if matched node count equals expected count" do
+          "<h1>Text</h1>".should have_selector('//h1', :count => 1)
+        end
+
+        it "fails if matched node count does not equal expected count" do
+          expect do
+            "<h1>Text</h1>".should have_selector('//h1', :count => 2)
+          end.to raise_error(%r(expected xpath "//h1" to be returned 2 times))
         end
 
         it "fails with the selector's failure_message if set" do
@@ -181,11 +191,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_selector? returns true" do
           "<h1>Text</h1>".should_not have_selector(:css, 'h2')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_selector? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_selector(:css, 'h1')
           end.to raise_error(%r(expected css "h1" not to return anything))
@@ -199,11 +209,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_selector? returns true" do
           page.should have_selector('//h1', :text => 'test')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_selector? returns false" do
           expect do
             page.should have_selector("//h1[@id='doesnotexist']")
           end.to raise_error(%r(expected xpath "//h1\[@id='doesnotexist'\]" to return something))
@@ -227,11 +237,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_selector? returns true" do
           page.should_not have_selector(:css, 'h1#doesnotexist')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_selector? returns false" do
           expect do
             page.should_not have_selector(:css, 'h1', :text => 'test')
           end.to raise_error(%r(expected css "h1" with text "test" not to return anything))
@@ -247,11 +257,11 @@ describe Capybara::RSpecMatchers do
 
     context "on a string" do
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_content? returns true" do
           "<h1>Text</h1>".should have_content('Text')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_content? returns false" do
           expect do
             "<h1>Text</h1>".should have_content('No such Text')
           end.to raise_error(/expected there to be content "No such Text" in "Text"/)
@@ -259,11 +269,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_content? returns true" do
           "<h1>Text</h1>".should_not have_content('No such Text')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_content? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_content('Text')
           end.to raise_error(/expected content "Text" not to return anything/)
@@ -277,11 +287,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_content? returns true" do
           page.should have_content('This is a test')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_content? returns false" do
           expect do
             page.should have_content('No such Text')
           end.to raise_error(/expected there to be content "No such Text" in "(.*)This is a test(.*)"/)
@@ -299,11 +309,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_content? returns true" do
           page.should_not have_content('No such Text')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_content returns false" do
           expect do
             page.should_not have_content('This is a test')
           end.to raise_error(/expected content "This is a test" not to return anything/)


### PR DESCRIPTION
## Problem

The `have_selector` method generates the following error when it cannot find a matching element for a given (in this case css) selector:

``` text
expected css ".foo" to return something
```

When using a `:count` option to the `have_selector` call (using a selector that matches elements) it generates the same error when the given count is bigger than number of found elements.
## Cause

The `error`-method on the `Query` class does not check for the presence of the `@options[:count]` (e.g. as the `HaveMatcher` class' failure message method does).
## Solution

I've added the condition to the `error`-method and I've added some tests for it (also made some changed some descriptions of specs that were not correct - couldn't help it ;)). 

FYI: I'm working on a refactoring to remove the duplication in the failure message generation - hope to be able to squeeze in some hours this weekend. 
