### PR TITLE
Gherkin change inducing change in cucumber.rb

### DIFF
--- a/lib/capybara/cucumber.rb
+++ b/lib/capybara/cucumber.rb
@@ -16,7 +16,7 @@ Before '@javascript' do
 end
 
 Before do |scenario|
-  scenario.source_tag_names.each do |tag|
+  scenario.source_tags.each do |tag|
     driver_name = tag.sub(/^@/, '').to_sym
     if Capybara.drivers.has_key?(driver_name)
       Capybara.current_driver = driver_name


### PR DESCRIPTION
Latest Gherkin update changed the method name from `source_tag_names` to `source_tags`.
