### PR TITLE
handle cucumber 1.1.5 api change

### DIFF
--- a/lib/capybara/cucumber.rb
+++ b/lib/capybara/cucumber.rb
@@ -16,7 +16,13 @@ Before '@javascript' do
 end
 
 Before do |scenario|
-  scenario.source_tag_names.each do |tag|
+  tags = begin
+    scenario.source_tags.map(&:name) # Cucumber >= 1.1.5
+  rescue NoMethodError
+    scenario.source_tag_names
+  end
+
+  tags.each do |tag|
     driver_name = tag.sub(/^@/, '').to_sym
     if Capybara.drivers.has_key?(driver_name)
       Capybara.current_driver = driver_name


### PR DESCRIPTION
Ok, slightly more digestible version I hope.

Tested Capybara cuke tests on Cucumber 1.1.4 and 1.1.5.

(previous pull request: https://github.com/jnicklas/capybara/pull/644)
