### PR TITLE
Support :type option for #has_field? matcher

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -253,8 +253,13 @@ module Capybara
       #
       #     page.has_field?('Name', :with => 'Jonas')
       #
+      # It is also possible to filter by the field type attribute:
+      #
+      #     page.has_field?('Email', :type => 'email')
+      #
       # @param [String] locator           The label, name or id of a field to check for
       # @option options [String] :with    The text content of the field
+      # @option options [String] :type    The type attribute of the field
       # @return [Boolean]                 Whether it exists
       #
       def has_field?(locator, options={})
@@ -268,6 +273,7 @@ module Capybara
       #
       # @param [String] locator           The label, name or id of a field to check for
       # @option options [String] :with    The text content of the field
+      # @option options [String] :type    The type attribute of the field
       # @return [Boolean]                 Whether it doesn't exist
       #
       def has_no_field?(locator, options={})

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -80,6 +80,7 @@ Capybara.add_selector(:field) do
   filter(:checked) { |node, value| not(value ^ node.checked?) }
   filter(:unchecked) { |node, value| (value ^ node.checked?) }
   filter(:with) { |node, with| node.value == with }
+  filter(:type) { |node, type| node[:type] == type }
 end
 
 Capybara.add_selector(:fieldset) do

--- a/lib/capybara/spec/session/has_field_spec.rb
+++ b/lib/capybara/spec/session/has_field_spec.rb
@@ -36,6 +36,20 @@ shared_examples_for "has_field" do
         @session.should_not have_field('First Name', :with => 'John')
       end
     end
+
+    context 'with type' do
+      it "should be true if a field with the given type is on the page" do
+        @session.should have_field('First Name', :type => 'text')
+        @session.should have_field('Html5 Email', :type => 'email')
+        @session.should have_field('Html5 Tel', :type => 'tel')
+      end
+
+      it "should be false if the given field is not on the page" do
+        @session.should_not have_field('First Name', :type => 'email')
+        @session.should_not have_field('Html5 Email', :type => 'tel')
+        @session.should_not have_field('Description', :type => '')
+      end
+    end
   end
 
   describe '#has_no_field' do
@@ -73,6 +87,20 @@ shared_examples_for "has_field" do
       it "should be true after the field has been filled in with a different value" do
         @session.fill_in('First Name', :with => 'Jonas')
         @session.should have_no_field('First Name', :with => 'John')
+      end
+    end
+
+    context 'with type' do
+      it "should be false if a field with the given type is on the page" do
+        @session.should_not have_no_field('First Name', :type => 'text')
+        @session.should_not have_no_field('Html5 Email', :type => 'email')
+        @session.should_not have_no_field('Html5 Tel', :type => 'tel')
+      end
+
+      it "should be true if the given field is not on the page" do
+        @session.should have_no_field('First Name', :type => 'email')
+        @session.should have_no_field('Html5 Email', :type => 'tel')
+        @session.should have_no_field('Description', :type => '')
       end
     end
   end


### PR DESCRIPTION
Add support for `:type` option for both `has_field?` and `has_no_field?` matchers.
Closes #650
