### PR TITLE
Remove rbx-18mode from Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 1.9.3
   - ree
   - jruby
-  - rbx-18mode
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.base-versions


### PR DESCRIPTION
Something seems to go wrong, perhaps with the RSpec exit handler:
http://travis-ci.org/#!/jnicklas/capybara/jobs/887918

---

I'm not in the mood for tracking this down, especially since it affects the tests only, and I've never seen anybody complain about Rubinius support. So unless someone else is volunteering, I say we go the easy route and remove it from the build.
