### PR TITLE
Refactor #has_select? matcher option filters

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -348,10 +348,15 @@ module Capybara
       # It's also possible to check if the exact set of options exists for
       # this select box:
       #
-      #     page.has_select?('Language', :options => ['English', 'German'])
+      #     page.has_select?('Language', :options => ['English', 'German', 'Spanish'])
+      #
+      # You can also check for a partial set of options:
+      #
+      #     page.has_select?('Language', :with_options => ['English', 'German'])
       #
       # @param [String] locator                      The label, name or id of a select box
       # @option options [Array] :options             Options which should be contained in this select box
+      # @option options [Array] :with_options        Partial set of options which should be contained in this select box
       # @option options [String, Array] :selected    Options which should be selected
       # @return [Boolean]                            Whether it exists
       #

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -131,6 +131,7 @@ Capybara.add_selector(:select) do
     actual = node.all(:xpath, './/option').map { |option| option.text }
     options.sort == actual.sort
   end
+  filter(:with_options) { |node, options| options.all? { |option| node.first(:option, option) } }
   filter(:selected) do |node, selected|
     actual = node.all(:xpath, './/option').select { |option| option.selected? }.map { |option| option.text }
     ([selected].flatten - actual).empty?

--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -48,7 +48,7 @@ shared_examples_for "has_select" do
       end
     end
 
-    context 'with options' do
+    context 'with exact options' do
       it "should be true if a field with the given options is on the page" do
         @session.should have_select('Region', :options => ['Norway', 'Sweden', 'Finland'])
         @session.should have_select('Tendency', :options => [])
@@ -60,6 +60,19 @@ shared_examples_for "has_select" do
         @session.should_not have_select('City', :options => ['London', 'Made up city'])
         @session.should_not have_select('Region', :options => ['Norway', 'Sweden'])
         @session.should_not have_select('Region', :options => ['Norway', 'Norway', 'Norway'])
+      end
+    end
+
+    context 'with partial options' do
+      it "should be true if a field with the given partial options is on the page" do
+        @session.should have_select('Region', :with_options => ['Norway', 'Sweden'])
+        @session.should have_select('City', :with_options => ['London'])
+      end
+
+      it "should be false if a field with the given partial options is not on the page" do
+        @session.should_not have_select('Locale', :with_options => ['Uruguayan'])
+        @session.should_not have_select('Does not exist', :with_options => ['John'])
+        @session.should_not have_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
       end
     end
   end
@@ -113,7 +126,7 @@ shared_examples_for "has_select" do
       end
     end
 
-    context 'with options' do
+    context 'with exact options' do
       it "should be false if a field with the given options is on the page" do
         @session.should_not have_no_select('Region', :options => ['Norway', 'Sweden', 'Finland'])
       end
@@ -124,6 +137,19 @@ shared_examples_for "has_select" do
         @session.should have_no_select('City', :options => ['London', 'Made up city'])
         @session.should have_no_select('Region', :options => ['Norway', 'Sweden'])
         @session.should have_no_select('Region', :options => ['Norway', 'Norway', 'Norway'])
+      end
+    end
+
+    context 'with partial options' do
+      it "should be false if a field with the given partial options is on the page" do
+        @session.should_not have_no_select('Region', :with_options => ['Norway', 'Sweden'])
+        @session.should_not have_no_select('City', :with_options => ['London'])
+      end
+
+      it "should be true if a field with the given partial options is not on the page" do
+        @session.should have_no_select('Locale', :with_options => ['Uruguayan'])
+        @session.should have_no_select('Does not exist', :with_options => ['John'])
+        @session.should have_no_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
       end
     end
   end


### PR DESCRIPTION
This one addresses #654
- The partial matching behaviour that had the `:options` filter was moved to a `:included_options` filter
- Change `:options` filter to match only the exact set of options
