### PR TITLE
Rack-test driver should ignore the first leading newline in textarea (fixes #677)

### DIFF
--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -74,7 +74,7 @@ module Capybara
       #
       def value
         if tag_name == 'textarea'
-          native.content
+          native.content.sub(/\A\n/, '')
         elsif tag_name == 'select'
           if native['multiple'] == 'multiple'
             native.xpath(".//option[@selected='selected']").map { |option| option[:value] || option.content  }

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -64,7 +64,11 @@ shared_examples_for 'driver' do
       end
 
       it "should allow retrieval of the value" do
-        @driver.find('//textarea').first.value.should == 'banana'
+        @driver.find('//textarea[@id="normal"]').first.value.should == 'banana'
+      end
+
+      it "should not swallow extra newlines in textarea" do
+        @driver.find('//textarea[@id="additional_newline"]').first.value.should == "\nbanana"
       end
 
       it "should allow assignment of field value" do

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -28,7 +28,11 @@
 
 <p>
   <input type="text" id="test_field" value="monkey"/>
-  <textarea>banana</textarea>
+  <textarea id="normal">
+banana</textarea>
+  <textarea id="additional_newline">
+
+banana</textarea>
   <a href="/redirect_back">BackToMyself</a>
   <a title="twas a fine link" href="/redirect">A link came first</a>
   <a title="a fine link" href="/with_simple_html">A link</a>


### PR DESCRIPTION
Rails recently (since v3.2.3.rc1) introduced a newline after opening <textarea> tag (https://github.com/rails/rails/pull/4000). They say the XHTML spec says to ignore this newline and all modern browsers do.

This change makes capybara rack-test driver to do the same (fixes #677)

However I have two considerations/questions:

1) `with_html.erb` file looks a bit uglier now. The reason is `textarea` tag is pretty much like `pre` where every whitespace is significant, so if you add additional newlines and indentation they are all included in the text.

2) Probably I should have patched not `Capybara::Node::Simple#value` but `Capybara::RackTest::Node#value`?
