### PR TITLE
Make within_frame return the value of calling the given block

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -79,6 +79,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     old_window = browser.window_handle
     browser.switch_to.frame(frame_id)
     yield
+  ensure
     browser.switch_to.window old_window
   end
 

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -189,6 +189,9 @@ shared_examples_for "driver with frame support" do
       end
       @driver.find("//*[@id='divInMainWindow']")[0].text.should eql 'This is the text for divInMainWindow'
     end
+    it "should return the result of executing the block" do
+      @driver.within_frame("frameOne") { "return value" }.should eql "return value"
+    end
   end
 end
 


### PR DESCRIPTION
Currently when using within_frame the return value of the given block gets swallowed up, so you can't do stuff like

``` ruby
foo = within_frame('bar') { #do stuff }
```

This fixes it so that the return value bubbles up.
