### PR TITLE
Static 5 redirects limit

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -16,7 +16,7 @@ module Capybara
   class InfiniteRedirectError < TimeoutError; end
 
   class << self
-    attr_accessor :asset_root, :app_host, :run_server, :default_host
+    attr_accessor :asset_root, :app_host, :run_server, :default_host, :redirect_limit
     attr_accessor :server_host, :server_port
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
     attr_accessor :save_and_open_page_path, :automatic_reload
@@ -355,6 +355,7 @@ Capybara.configure do |config|
   config.ignore_hidden_elements = false
   config.default_host = "http://www.example.com"
   config.automatic_reload = true
+  config.redirect_limit = 5
 end
 
 Capybara.register_driver :rack_test do |app|

--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -33,10 +33,10 @@ class Capybara::RackTest::Browser
 
   def process_and_follow_redirects(method, path, attributes = {}, env = {})
     process(method, path, attributes, env)
-    5.times do
+    Capybara.redirect_limit.times do
       process(:get, last_response["Location"], {}, env) if last_response.redirect?
     end
-    raise Capybara::InfiniteRedirectError, "redirected more than 5 times, check for infinite redirects." if last_response.redirect?
+    raise Capybara::InfiniteRedirectError, "redirected more than #{Capybara.redirect_limit} times, check for infinite redirects." if last_response.redirect?
   end
 
   def process(method, path, attributes = {}, env = {})


### PR DESCRIPTION
Hi!

I'm using Capybara + Cucumber to test [this project](https://github.com/meurio/seurio).

I got the Capybara::InfiniteRedirectError in one of my scenarios, but it's not a redirect loop actually.

I have a specific scenario in my app that fires 6 redirects in sequence.

Then I made this change in Capybara, and I was wondering if you want to pull it ;)

Cheers!
