### PR TITLE
configurable redirect limit

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -20,7 +20,7 @@ module Capybara
     attr_accessor :server_host, :server_port
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
     attr_accessor :save_and_open_page_path, :automatic_reload
-    attr_writer :default_driver, :current_driver, :javascript_driver, :session_name
+    attr_writer :default_driver, :current_driver, :javascript_driver, :session_name, :redirect_limit
     attr_accessor :app
 
     ##
@@ -185,6 +185,14 @@ module Capybara
 
     ##
     #
+    # @return [Integer]   Current redirect limit
+    #
+    def redirect_limit
+      @redirect_limit
+    end
+
+    ##
+    #
     # @return [Symbol]    The name of the driver to use by default
     #
     def default_driver
@@ -299,6 +307,7 @@ module Capybara
 
   self.default_driver = nil
   self.current_driver = nil
+  self.redirect_limit = 5
 
   autoload :DSL,        'capybara/dsl'
   autoload :Server,     'capybara/server'

--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -33,10 +33,10 @@ class Capybara::RackTest::Browser
 
   def process_and_follow_redirects(method, path, attributes = {}, env = {})
     process(method, path, attributes, env)
-    5.times do
+    Capybara.redirect_limit.times do
       process(:get, last_response["Location"], {}, env) if last_response.redirect?
     end
-    raise Capybara::InfiniteRedirectError, "redirected more than 5 times, check for infinite redirects." if last_response.redirect?
+    raise Capybara::InfiniteRedirectError, "redirected more than #{Capybara.redirect_limit} times, check for infinite redirects." if last_response.redirect?
   end
 
   def process(method, path, attributes = {}, env = {})

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -253,15 +253,37 @@ shared_examples_for "driver with cookies support" do
 end
 
 shared_examples_for "driver with infinite redirect detection" do
-  it "should follow 5 redirects" do
-    @driver.visit('/redirect/5/times')
-    @driver.body.should include('redirection complete')
-  end
+  context "with default redirect limit" do
+    let(:default_limit) { Capybara.redirect_limit }
+    it "should follow #{Capybara.redirect_limit} redirects" do
+      @driver.visit("/redirect/#{default_limit}/times")
+      @driver.body.should include('redirection complete')
+    end
 
-  it "should not follow more than 5 redirects" do
-    running do
-      @driver.visit('/redirect/6/times')
-    end.should raise_error(Capybara::InfiniteRedirectError)
+    it "should not follow more than #{Capybara.redirect_limit} redirects" do
+      running do
+        @driver.visit("/redirect/#{default_limit + 1}/times")
+      end.should raise_error(Capybara::InfiniteRedirectError)
+    end
+  end
+  context "with 21 redirect limit" do
+    let(:custom_limit) { 21 }
+    around(:each) do |example|
+      default_limit = Capybara.redirect_limit
+      Capybara.redirect_limit= custom_limit
+      example.run
+      Capybara.redirect_limit= default_limit
+    end
+    it "should follow 21 redirects" do
+      @driver.visit("/redirect/#{custom_limit}/times")
+      @driver.body.should include('redirection complete')
+    end
+
+    it "should not follow more than 21 redirects" do
+      running do
+        @driver.visit("/redirect/#{custom_limit + 1}/times")
+      end.should raise_error(Capybara::InfiniteRedirectError)
+    end
   end
 end
 


### PR DESCRIPTION
Adds configuration variable `Capybara#redirect_limit`. Defaults to 5 (current hard default)
