### PR TITLE
Fix test to call correct method under test

### DIFF
--- a/lib/capybara/spec/session.rb
+++ b/lib/capybara/spec/session.rb
@@ -34,7 +34,7 @@ shared_examples_for "session" do
       # method(:html) == method(:body) because these shared examples get run
       # against the DSL, which uses forwarding methods.  So we test behavior.
       @session.visit('/')
-      @session.body.should include('Hello world!')
+      @session.html.should include('Hello world!')
     end
   end
 


### PR DESCRIPTION
Test for #html in session shared example group was actually calling #body. This fix corrects it to call #html, to match the name of the test. (The call to #body is in the previous spec, so it looks like a cut and paste error.)
