### PR TITLE
Support giving file name to `save_page` and `save_and_open_page`

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -271,14 +271,14 @@ module Capybara
     #
     # Save a snapshot of the page and open it in a browser for inspection
     #
-    def save_page
+    def save_page(file_name=nil)
       require 'capybara/util/save_and_open_page'
-      Capybara.save_page(body)
+      Capybara.save_page(body, file_name)
     end
 
-    def save_and_open_page
+    def save_and_open_page(file_name=nil)
       require 'capybara/util/save_and_open_page'
-      Capybara.save_and_open_page(body)
+      Capybara.save_and_open_page(body, file_name)
     end
 
     def document


### PR DESCRIPTION
I want to use `Capybara::Session#save_page` with **file name**.

Such as:

``` ruby
save_page 'snapshot.html'
```

Instead of:

``` ruby
require 'capybara/util/save_and_open_page'
Capybara.save_page(body, 'snapshot.html')
```
