### PR TITLE
Makes it possible to not follow redirects with the RackTest driver.

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -3,9 +3,11 @@ class Capybara::RackTest::Browser
 
   attr_reader :driver
   attr_accessor :current_host
+  attr_accessor :follow_redirects
 
   def initialize(driver)
     @driver = driver
+    @follow_redirects = true
   end
 
   def app
@@ -33,6 +35,7 @@ class Capybara::RackTest::Browser
 
   def process_and_follow_redirects(method, path, attributes = {}, env = {})
     process(method, path, attributes, env)
+    return unless follow_redirects
     5.times do
       process(:get, last_response["Location"], {}, env) if last_response.redirect?
     end

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -72,6 +72,12 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     @browser = nil
   end
 
+  def without_redirects
+    browser.follow_redirects = false
+    yield
+    browser.follow_redirects = true
+  end
+
   def get(*args, &block); browser.get(*args, &block); end
   def post(*args, &block); browser.post(*args, &block); end
   def put(*args, &block); browser.put(*args, &block); end

--- a/spec/driver/rack_test_driver_spec.rb
+++ b/spec/driver/rack_test_driver_spec.rb
@@ -87,4 +87,17 @@ describe Capybara::RackTest::Driver do
       @driver.body.should include('foobar')
     end
   end
+
+  it "is possible to not follow redirects" do
+    @driver = Capybara::RackTest::Driver.new(TestApp)
+
+    @driver.without_redirects do
+      @driver.visit('/redirect')
+      @driver.response.header['Location'].should eq "#{@driver.browser.current_host}/redirect_again"
+      @driver.browser.current_url.should eq "#{@driver.browser.current_host}/redirect"
+    end
+    @driver.visit('/redirect')
+    @driver.response.header['Location'].should be_nil
+    @driver.browser.current_url.should eq "#{@driver.browser.current_host}/landed"
+  end
 end


### PR DESCRIPTION
This patch makes it possible to test scenarios where your app is redirecting to external URLs without a lot of hustle. I have a lot of trouble testing those things in our SSO server which redirects to different apps, depending on which one you choose when logging on.
