### PR TITLE
Return the real class on Capybara::Driver::Node#inspect.

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -65,9 +65,9 @@ module Capybara
       end
 
       def inspect
-        %(#<Capybara::Driver::Node tag="#{tag_name}" path="#{path}">)
+        %(#<#{self.class} tag="#{tag_name}" path="#{path}">)
       rescue NotSupportedByDriverError
-        %(#<Capybara::Driver::Node tag="#{tag_name}">)
+        %(#<#{self.class} tag="#{tag_name}">)
       end
     end
   end


### PR DESCRIPTION
Hi Jonas,

we just had a hard time debugging Capybara (trying to find out how to get a node's text unnormalized) because Capybara::Driver::Node#inspect returns its own class name instead of the subclasses'.
I've also seen this pattern is used in other locations as well.
Is there a specific reason for this?

Best regards
  Martin
