### PR TITLE
Added section to readme to be more clear about how to configure non-rack apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,16 @@ expectations for Capybara. For example:
 page.must_have_content('Important!')
 ```
 
-## Using Capybara to test non-Rack web applications
+## Using Capybara with non-Rack web applications
 
 Capybara comes bundled with `selenium-webdriver`. By setting the `Capybara.default_driver` to 
 `:selenium` we can use Capybara for testing our non-Ruby web applications.
 
 ```ruby
+# Assuming you are using Cucumber, this file lives in features/support/env.rb
 require 'capybara/cucumber'
 Capybara.default_driver = :selenium
-Capybara.app_host = 'http://example.com' # base url of the application you are testing
+Capybara.app_host = 'http://example.com' # The base url of the application you are testing
 ```
 
 Read on for more information on configuring the Selenium driver and changing the default browser.


### PR DESCRIPTION
I had a little trouble understanding how to set up capybara for a non-rack application, so I decided to add this to the readme since it turned out to be way easier than I thought. Hopefully this is a helpful addition. I know that it's mentioned a little bit in the drivers section, but it felt like it needed its own section.
