### PR TITLE
Add Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/jnicklas/capybara.png)](http://travis-ci.org/jnicklas/capybara)
 [![Dependency Status](https://gemnasium.com/jnicklas/capybara.png)](https://gemnasium.com/jnicklas/capybara)
+[![Code Quality](https://codeclimate.com/badge.png)](https://codeclimate.com/github/jnicklas/capybara)
 
 Capybara helps you test Rails and Rack applications by simulating how a real
 user would interact with your app. It is agnostic about the driver running your


### PR DESCRIPTION
Hey Jonas,

Hope all is well. I just launched the free-for-OSS support for Code Climate, the product I've been working on for awhile now, and I thought Capybara would be a good repo to add. Code Climate is hosted quality metrics for Ruby. Here's what it generated for Capybara:

```
https://codeclimate.com/github/jnicklas/capybara
```

I threw together this quick pull request to add a link to Code Climate from the README, in case you want to make this available to Capybara contributors (like RSpec and Cucumber added recently).

I'll probably also do the same for CarrierWave.

Let me know if you have any questions!

Cheers,

-Bryan
