### PR TITLE
fix wrong spec descriptions for rspec matcher specs

### DIFF
--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -95,11 +95,11 @@ describe Capybara::RSpecMatchers do
 
     context "on a string" do
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_xpath? returns true" do
           "<h1>Text</h1>".should have_xpath('//h1')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_xpath? returns false" do
           expect do
             "<h1>Text</h1>".should have_xpath('//h2')
           end.to raise_error(%r(expected xpath "//h2" to return something))
@@ -107,11 +107,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_xpath? returns true" do
           "<h1>Text</h1>".should_not have_xpath('//h2')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_xpath? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_xpath('//h1')
           end.to raise_error(%r(expected xpath "//h1" not to return anything))
@@ -125,11 +125,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_xpath? returns true" do
           page.should have_xpath('//h1')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_xpath? returns false" do
           expect do
             page.should have_xpath("//h1[@id='doesnotexist']")
           end.to raise_error(%r(expected xpath "//h1\[@id='doesnotexist'\]" to return something))
@@ -137,11 +137,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_xpath? returns true" do
           page.should_not have_xpath('//h1[@id="doesnotexist"]')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_xpath? returns false" do
           expect do
             page.should_not have_xpath('//h1')
           end.to raise_error(%r(expected xpath "//h1" not to return anything))
@@ -159,11 +159,11 @@ describe Capybara::RSpecMatchers do
 
     context "on a string" do
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_selector? returns true" do
           "<h1>Text</h1>".should have_selector('//h1')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_selector? returns false" do
           expect do
             "<h1>Text</h1>".should have_selector('//h2')
           end.to raise_error(%r(expected xpath "//h2" to return something))
@@ -181,11 +181,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_selector? returns true" do
           "<h1>Text</h1>".should_not have_selector(:css, 'h2')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_selector? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_selector(:css, 'h1')
           end.to raise_error(%r(expected css "h1" not to return anything))
@@ -199,11 +199,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_selector? returns true" do
           page.should have_selector('//h1', :text => 'test')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_selector? returns false" do
           expect do
             page.should have_selector("//h1[@id='doesnotexist']")
           end.to raise_error(%r(expected xpath "//h1\[@id='doesnotexist'\]" to return something))
@@ -231,7 +231,7 @@ describe Capybara::RSpecMatchers do
           page.should_not have_selector(:css, 'h1#doesnotexist')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_selector? returns false" do
           expect do
             page.should_not have_selector(:css, 'h1', :text => 'test')
           end.to raise_error(%r(expected css "h1" with text "test" not to return anything))
@@ -247,11 +247,11 @@ describe Capybara::RSpecMatchers do
 
     context "on a string" do
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_content? returns true" do
           "<h1>Text</h1>".should have_content('Text')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_content? returns false" do
           expect do
             "<h1>Text</h1>".should have_content('No such Text')
           end.to raise_error(/expected there to be content "No such Text" in "Text"/)
@@ -259,11 +259,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_content? returns true" do
           "<h1>Text</h1>".should_not have_content('No such Text')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_content? returns false" do
           expect do
             "<h1>Text</h1>".should_not have_content('Text')
           end.to raise_error(/expected content "Text" not to return anything/)
@@ -277,11 +277,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should" do
-        it "passes if has_css? returns true" do
+        it "passes if has_content? returns true" do
           page.should have_content('This is a test')
         end
 
-        it "fails if has_css? returns false" do
+        it "fails if has_content? returns false" do
           expect do
             page.should have_content('No such Text')
           end.to raise_error(/expected there to be content "No such Text" in "(.*)This is a test(.*)"/)
@@ -289,7 +289,7 @@ describe Capybara::RSpecMatchers do
 
         context "with default selector CSS" do
           before { Capybara.default_selector = :css }
-          it "fails if has_css? returns false" do
+          it "fails if has_content? returns false" do
             expect do
               page.should have_content('No such Text')
             end.to raise_error(/expected there to be content "No such Text" in "(.*)This is a test(.*)"/)
@@ -299,11 +299,11 @@ describe Capybara::RSpecMatchers do
       end
 
       context "with should_not" do
-        it "passes if has_no_css? returns true" do
+        it "passes if has_no_content? returns true" do
           page.should_not have_content('No such Text')
         end
 
-        it "fails if has_no_css? returns false" do
+        it "fails if has_no_content? returns false" do
           expect do
             page.should_not have_content('This is a test')
           end.to raise_error(/expected content "This is a test" not to return anything/)


### PR DESCRIPTION
looks like it was copypasted
