### PR TITLE
Accept non-string parameters to has_text, notably nil and numbers

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -472,7 +472,7 @@ module Capybara
       # @return [String]         Normalized text
       #
       def normalize_whitespace(text)
-        text.is_a?(Regexp) ? text : text.gsub(/\s+/, ' ').strip
+        text.is_a?(Regexp) ? text : text.to_s.gsub(/\s+/, ' ').strip
       end
 
       ##

--- a/lib/capybara/spec/session/has_text_spec.rb
+++ b/lib/capybara/spec/session/has_text_spec.rb
@@ -83,6 +83,17 @@ shared_examples_for 'has_text' do
       @session.visit('/with_html')
       @session.should_not have_text('.orem')
     end
+
+    it "should accept non-string parameters" do
+      @session.visit('/with_html')
+      @session.should have_text(42)
+    end
+
+    it "should be true when passed nil" do
+      # Historical behavior; no particular reason other than compatibility.
+      @session.visit('/with_html')
+      @session.should have_text(nil)
+    end
   end
 
   describe '#has_no_text?' do

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -72,6 +72,10 @@ banana</textarea>
   <a id="visible" class="visibility">visible link</a>
 </div>
 
+<div>
+  Number 42
+</div>
+
 <ul>
   <li id="john_monkey">Monkey John</li>
   <li id="paul_monkey">Monkey Paul</li>


### PR DESCRIPTION
This is mostly for compatibility with Capybara 1.1.2.
