### PR TITLE
Remove forking test. Closes #763

### DIFF
--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -26,23 +26,6 @@ describe Capybara::Session do
     it_should_behave_like "session without headers support"
     it_should_behave_like "session without status code support"
 
-    unless RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
-      it "should not interfere with forking child processes" do
-        # Launch a browser, which registers the at_exit hook
-        browser = Capybara::Selenium::Driver.new(TestApp).browser
-
-        # Fork an unrelated child process. This should not run the code in the at_exit hook.
-        begin
-          pid = fork { "child" }
-          Process.wait2(pid)[1].exitstatus.should == 0
-        rescue NotImplementedError
-          # Fork unsupported (e.g. on JRuby)
-        end
-
-        browser.quit
-      end
-    end
-
     describe "exit codes" do
       before do
         @current_dir = Dir.getwd


### PR DESCRIPTION
This causes "file not added for reaping" errors with Selenium, as the
exit handler is called twice.

Thanks @jarib for tracking this one down!
