### PR TITLE
Added errors to a invalid_element_errors to support IE9

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -122,7 +122,9 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   end
 
   def invalid_element_errors
-    [Selenium::WebDriver::Error::ObsoleteElementError]
+    [ Selenium::WebDriver::Error::ObsoleteElementError,
+      Selenium::WebDriver::Error::InvalidSelectorError,
+      Selenium::WebDriver::Error::UnknownError ]
   end
 
 private


### PR DESCRIPTION
Added two errors that IE9 likes to throw when under the selenium remote driver:
- Selenium::WebDriver::Error::InvalidSelectorError  -- Thrown by IEServerDriver.exe v0.25.1 when a selector is invalid or does not return any results.
- Selenium::WebDriver::Error::UnknownError -- Thrown by selenium-standalone v0.25.1 when bad things happen.  I'm getting an intermittent NPE from the bowels of selenium during a find when running IE9.  Adding this error to invalid_element_errors seems to mitigate whatever race condition is causing this to happen.

As there are currently no IE tests I didn't introduce any.  Other than that, all specs that were passing still pass (the exception being spec/rspec/features_spec.rb:32 that was failing before I made changes).

Thanks!
