### PR TITLE
Delegate common Result methods to Array

### DIFF
--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -1,6 +1,9 @@
+require 'forwardable'
+
 module Capybara
   class Result
     include Enumerable
+    extend Forwardable
 
     def initialize(elements, query)
       @elements = elements
@@ -9,13 +12,7 @@ module Capybara
       @query = query
     end
 
-    def each(&block)
-      @result.each(&block)
-    end
-
-    def first
-      @result.first
-    end
+    def_delegators :@result, :each, :[], :at, :size, :count, :length, :first, :last, :empty?
 
     def matches_count?
       @query.matches_count?(@result.size)
@@ -25,10 +22,6 @@ module Capybara
       raise find_error if @result.count != 1
       @result.first
     end
-
-    def size; @result.size; end
-    alias_method :length, :size
-    alias_method :count, :size
 
     def find_error
       if @result.count == 0
@@ -65,11 +58,6 @@ module Capybara
     def negative_failure_message
       "expected not to find #{@query.description}, but there #{declension("was", "were")} #{count} #{declension("match", "matches")}"
     end
-
-    def empty?
-      @result.empty?
-    end
-    def [](key); @result[key]; end
 
   private
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Capybara::Result do
+  let :string do
+    Capybara.string <<-STRING
+      <ul>
+        <li>Alpha</li>
+        <li>Beta</li>
+        <li>Gamma</li>
+        <li>Delta</li>
+      </ul>
+    STRING
+  end
+
+  let :result do
+    string.all '//li'
+  end
+
+  it "has a length" do
+    result.length.should == 4
+  end
+
+  it "has a first element" do
+    result.first.text == 'Alpha'
+  end
+
+  it "has a last element" do
+    result.last.text == 'Delta'
+  end
+
+  it "can return an element by its index" do
+    result.at(1).text.should == 'Beta'
+    result[2].text.should == 'Gamma'
+  end
+
+  it "can be mapped" do
+    result.map(&:text).should == %w(Alpha Beta Gamma Delta)
+  end
+
+  it "can be selected" do
+    result.select do |element|
+      element.text.include? 't'
+    end.length.should == 2
+  end
+
+  it "can be reduced" do
+    result.reduce('') do |memo, element|
+      memo += element.text[0]
+    end.should == 'ABGD'
+  end
+end


### PR DESCRIPTION
Closes #784. I used the Forwardable module to avoid method_missing at runtime.
