### PR TITLE
Backporting pull request #687 from khustochka/textarea-newline to 1.1_stable

### DIFF
--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -74,7 +74,7 @@ module Capybara
       #
       def value
         if tag_name == 'textarea'
-          native.content
+          native.content.sub(/\A\n/, '')
         elsif tag_name == 'select'
           if native['multiple'] == 'multiple'
             native.xpath(".//option[@selected='selected']").map { |option| option[:value] || option.content  }

--- a/lib/capybara/spec/driver.rb
+++ b/lib/capybara/spec/driver.rb
@@ -64,7 +64,11 @@ shared_examples_for 'driver' do
       end
 
       it "should allow retrieval of the value" do
-        @driver.find('//textarea').first.value.should == 'banana'
+        @driver.find('//textarea[@id="normal"]').first.value.should == 'banana'
+      end
+
+      it "should not swallow extra newlines in textarea" do
+        @driver.find('//textarea[@id="additional_newline"]').first.value.should == "\nbanana"
       end
 
       it "should allow assignment of field value" do

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -28,7 +28,11 @@
 
 <p>
   <input type="text" id="test_field" value="monkey"/>
-  <textarea>banana</textarea>
+  <textarea id="normal">
+banana</textarea>
+  <textarea id="additional_newline">
+
+banana</textarea>
   <a href="/redirect_back">BackToMyself</a>
   <a title="twas a fine link" href="/redirect">A link came first</a>
   <a title="a fine link" href="/with_simple_html">A link</a>


### PR DESCRIPTION
Rack-test driver should ignore the first leading newline in textarea (fixes #677)

I am requesting to get this back ported because it only exists in a major update, 2.0.0.beta1/2, and I need this fix in a current version.
