### PR TITLE
Make :respect_data_method default to true with capybara/rails

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,10 @@
 # master
 
+### Changed
+
+* `require 'capybara/rails'` will automatically enable `:respect_data_method`
+  on the RackTest driver, so the behavior matches Capybara 1.1.2 [Jo Liss]
+
 ### Fixed
 
 * `has_text` (`has_content`) now accepts non-string arguments, like numbers.

--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -24,3 +24,8 @@ RSpec.configure do |config|
     end
   end
 end
+
+# Override default rack_test driver to respect data-method attributes.
+Capybara.register_driver :rack_test do |app|
+  Capybara::RackTest::Driver.new(app, :respect_data_method => true)
+end


### PR DESCRIPTION
I'm writing an upgrade guide, and I find myself telling people "Capybara 2.0 will break your test suite. To stop it from breaking your test suite, enable `:respect_data_method`." This is something that we'll basically have to tell all users, or they'll get tripped up.

Instead, I'd suggest that we enable the right behavior by default, whenever `capybara/rails` is required.

Ignoring data-method in the RackTest driver is very reasonable when we're not testing Rails apps, for what it's worth. But in Rails apps, people will generally want to honor data-method.
