### PR TITLE
Update section 'Using Capybara with Test::Unit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ end
     `ActionDispatch::IntegrationTest`:
 
     ```ruby
+    require 'database_cleaner'
+
     # Transactional fixtures do not work with Selenium tests, because Capybara
     # uses a separate server thread, which the transactions would be hidden
     # from. We hence use DatabaseCleaner to truncate our test database.


### PR DESCRIPTION
Add `require 'database_cleaner'` to section 'Using Capybara with Test::Unit'
Otherwise `DatabaseCleaner.strategy = :truncation` fails :)
