### PR TITLE
Dedicated driver directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ RackTest can be configured with a set of headers like this:
 
 ```ruby
 Capybara.register_driver :rack_test do |app|
-  Capybara::RackTest::Driver.new(app, :browser => :chrome)
+  Capybara::Driver::RackTest.new(app, :browser => :chrome)
 end
 ```
 
@@ -773,7 +773,7 @@ drivers. This is how to switch the selenium driver to use chrome:
 
 ```ruby
 Capybara.register_driver :selenium do |app|
-  Capybara::Selenium::Driver.new(app, :browser => :chrome)
+  Capybara::Driver::Selenium.new(app, :browser => :chrome)
 end
 ```
 
@@ -782,7 +782,7 @@ between using different browsers effortlessly:
 
 ```ruby
 Capybara.register_driver :selenium_chrome do |app|
-  Capybara::Selenium::Driver.new(app, :browser => :chrome)
+  Capybara::Driver::Selenium.new(app, :browser => :chrome)
 end
 ```
 

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -324,31 +324,10 @@ module Capybara
   module Driver
     autoload :Base,     'capybara/driver/base'
     autoload :Node,     'capybara/driver/node'
-
-    class Selenium
-      def initialize(*args)
-        raise "Capybara::Driver::Selenium has been renamed to Capybara::Selenium::Driver"
-      end
-    end
-
-    class RackTest
-      def initialize(*args)
-        raise "Capybara::Driver::RackTest has been renamed to Capybara::RackTest::Driver"
-      end
-    end
+    autoload :RackTest, 'capybara/driver/rack_test'
+    autoload :Selenium, 'capybara/driver/selenium'
   end
 
-  module RackTest
-    autoload :Driver,  'capybara/rack_test/driver'
-    autoload :Node,    'capybara/rack_test/node'
-    autoload :Form,    'capybara/rack_test/form'
-    autoload :Browser, 'capybara/rack_test/browser'
-  end
-
-  module Selenium
-    autoload :Node,    'capybara/selenium/node'
-    autoload :Driver,  'capybara/selenium/driver'
-  end
 end
 
 Capybara.configure do |config|
@@ -363,9 +342,9 @@ Capybara.configure do |config|
 end
 
 Capybara.register_driver :rack_test do |app|
-  Capybara::RackTest::Driver.new(app)
+  Capybara::Driver::RackTest.new(app)
 end
 
 Capybara.register_driver :selenium do |app|
-  Capybara::Selenium::Driver.new(app)
+  Capybara::Driver::Selenium.new(app)
 end

--- a/lib/capybara/driver/rack_test.rb
+++ b/lib/capybara/driver/rack_test.rb
@@ -4,7 +4,12 @@ require 'mime/types'
 require 'nokogiri'
 require 'cgi'
 
-class Capybara::RackTest::Driver < Capybara::Driver::Base
+
+class Capybara::Driver::RackTest < Capybara::Driver::Base
+  autoload :Node,    'capybara/driver/rack_test/node'
+  autoload :Form,    'capybara/driver/rack_test/form'
+  autoload :Browser, 'capybara/driver/rack_test/browser'
+
   DEFAULT_OPTIONS = {
     :respect_data_method => false,
     :follow_redirects => true,
@@ -19,7 +24,7 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
   end
 
   def browser
-    @browser ||= Capybara::RackTest::Browser.new(self)
+    @browser ||= Capybara::Driver::RackTest::Browser.new(self)
   end
 
   def follow_redirects?

--- a/lib/capybara/driver/rack_test/browser.rb
+++ b/lib/capybara/driver/rack_test/browser.rb
@@ -1,4 +1,4 @@
-class Capybara::RackTest::Browser
+class Capybara::Driver::RackTest::Browser
   include ::Rack::Test::Methods
 
   attr_reader :driver
@@ -86,7 +86,7 @@ class Capybara::RackTest::Browser
   end
 
   def find(selector)
-    dom.xpath(selector).map { |node| Capybara::RackTest::Node.new(self, node) }
+    dom.xpath(selector).map { |node| Capybara::Driver::RackTest::Node.new(self, node) }
   end
 
   def source

--- a/lib/capybara/driver/rack_test/form.rb
+++ b/lib/capybara/driver/rack_test/form.rb
@@ -1,4 +1,4 @@
-class Capybara::RackTest::Form < Capybara::RackTest::Node
+class Capybara::Driver::RackTest::Form < Capybara::Driver::RackTest::Node
   # This only needs to inherit from Rack::Test::UploadedFile because Rack::Test checks for
   # the class specifically when determing whether to consturct the request as multipart.
   # That check should be based solely on the form element's 'enctype' attribute value,

--- a/lib/capybara/driver/rack_test/node.rb
+++ b/lib/capybara/driver/rack_test/node.rb
@@ -1,4 +1,4 @@
-class Capybara::RackTest::Node < Capybara::Driver::Node
+class Capybara::Driver::RackTest::Node < Capybara::Driver::Node
   def text
     Capybara::Helpers.normalize_whitespace(unnormalized_text)
   end
@@ -56,7 +56,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
       driver.follow(method, self[:href].to_s)
     elsif (tag_name == 'input' and %w(submit image).include?(type)) or
         ((tag_name == 'button') and type.nil? or type == "submit")
-      Capybara::RackTest::Form.new(driver, form).submit(self)
+      Capybara::Driver::RackTest::Form.new(driver, form).submit(self)
     end
   end
 
@@ -93,7 +93,7 @@ protected
       native.text
     elsif native.element?
       native.children.map do |child|
-        Capybara::RackTest::Node.new(driver, child).unnormalized_text
+        Capybara::Driver::RackTest::Node.new(driver, child).unnormalized_text
       end.join
     else
       ''

--- a/lib/capybara/driver/selenium.rb
+++ b/lib/capybara/driver/selenium.rb
@@ -1,6 +1,9 @@
 require 'selenium-webdriver'
 
-class Capybara::Selenium::Driver < Capybara::Driver::Base
+class Capybara::Driver::Selenium < Capybara::Driver::Base
+  autoload :Node,    'capybara/driver/selenium/node'
+  autoload :Driver,  'capybara/driver/selenium/driver'
+
   DEFAULT_OPTIONS = {
     :browser => :firefox
   }
@@ -47,7 +50,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   end
 
   def find(selector)
-    browser.find_elements(:xpath, selector).map { |node| Capybara::Selenium::Node.new(self, node) }
+    browser.find_elements(:xpath, selector).map { |node| Capybara::Driver::Selenium::Node.new(self, node) }
   end
 
   def wait?; true; end

--- a/lib/capybara/driver/selenium/node.rb
+++ b/lib/capybara/driver/selenium/node.rb
@@ -1,4 +1,4 @@
-class Capybara::Selenium::Node < Capybara::Driver::Node
+class Capybara::Driver::Selenium::Node < Capybara::Driver::Node
   def text
     # Selenium doesn't normalize Unicode whitespace.
     Capybara::Helpers.normalize_whitespace(native.text)

--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -27,5 +27,5 @@ end
 
 # Override default rack_test driver to respect data-method attributes.
 Capybara.register_driver :rack_test do |app|
-  Capybara::RackTest::Driver.new(app, :respect_data_method => true)
+  Capybara::Driver::RackTest.new(app, :respect_data_method => true)
 end

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -17,7 +17,7 @@ describe Capybara do
   describe '.register_driver' do
     it "should add a new driver" do
       Capybara.register_driver :schmoo do |app|
-        Capybara::RackTest::Driver.new(app)
+        Capybara::Driver::RackTest.new(app)
       end
       session = Capybara::Session.new(:schmoo, TestApp)
       session.visit('/')

--- a/spec/fixtures/selenium_driver_rspec_failure.rb
+++ b/spec/fixtures/selenium_driver_rspec_failure.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Capybara::Selenium::Driver do
+describe Capybara::Driver::Selenium do
   it "should exit with a non-zero exit status" do
-    browser = Capybara::Selenium::Driver.new(TestApp).browser
+    browser = Capybara::Driver::Selenium.new(TestApp).browser
     true.should == false
   end
 end

--- a/spec/fixtures/selenium_driver_rspec_success.rb
+++ b/spec/fixtures/selenium_driver_rspec_success.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Capybara::Selenium::Driver do
+describe Capybara::Driver::Selenium do
   it "should exit with a zero exit status" do
-    browser = Capybara::Selenium::Driver.new(TestApp).browser
+    browser = Capybara::Driver::Selenium.new(TestApp).browser
     true.should == true
   end
 end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -15,7 +15,7 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a rack test driver" do
-        @session.driver.should be_an_instance_of(Capybara::RackTest::Driver)
+        @session.driver.should be_an_instance_of(Capybara::Driver::RackTest)
       end
     end
 
@@ -64,34 +64,34 @@ describe Capybara::Session do
   end
 end
 
-describe Capybara::RackTest::Driver do
+describe Capybara::Driver::RackTest do
   before do
     @driver = TestSessions::RackTest.driver
   end
 
   describe ':headers option' do
     it 'should always set headers' do
-      @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      @driver = Capybara::Driver::RackTest.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header')
       @driver.body.should include('foobar')
     end
 
     it 'should keep headers on link clicks' do
-      @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      @driver = Capybara::Driver::RackTest.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find('.//a').first.click
       @driver.body.should include('foobar')
     end
 
     it 'should keep headers on form submit' do
-      @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      @driver = Capybara::Driver::RackTest.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find('.//input').first.click
       @driver.body.should include('foobar')
     end
 
     it 'should keep headers on redirects' do
-      @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      @driver = Capybara::Driver::RackTest.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header_via_redirect')
       @driver.body.should include('foobar')
     end
@@ -99,7 +99,7 @@ describe Capybara::RackTest::Driver do
 
   describe ':follow_redirects option' do
     it "defaults to following redirects" do
-      @driver = Capybara::RackTest::Driver.new(TestApp)
+      @driver = Capybara::Driver::RackTest.new(TestApp)
 
       @driver.visit('/redirect')
       @driver.response.header['Location'].should be_nil
@@ -107,7 +107,7 @@ describe Capybara::RackTest::Driver do
     end
 
     it "is possible to not follow redirects" do
-      @driver = Capybara::RackTest::Driver.new(TestApp, :follow_redirects => false)
+      @driver = Capybara::Driver::RackTest.new(TestApp, :follow_redirects => false)
 
       @driver.visit('/redirect')
       @driver.response.header['Location'].should eq "#{@driver.browser.current_host}/redirect_again"
@@ -118,7 +118,7 @@ describe Capybara::RackTest::Driver do
   describe ':redirect_limit option' do
     context "with default redirect limit" do
       before do
-        @driver = Capybara::RackTest::Driver.new(TestApp)
+        @driver = Capybara::Driver::RackTest.new(TestApp)
       end
 
       it "should follow 5 redirects" do
@@ -135,7 +135,7 @@ describe Capybara::RackTest::Driver do
 
     context "with 21 redirect limit" do
       before do
-        @driver = Capybara::RackTest::Driver.new(TestApp, :redirect_limit => 21)
+        @driver = Capybara::Driver::RackTest.new(TestApp, :redirect_limit => 21)
       end
 
       it "should follow 21 redirects" do

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -15,7 +15,7 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a selenium driver" do
-        @session.driver.should be_an_instance_of(Capybara::Selenium::Driver)
+        @session.driver.should be_an_instance_of(Capybara::Driver::Selenium)
       end
     end
 


### PR DESCRIPTION
# Proposal for dedicated directory for capybara drivers

This is proposal for reorganising driver files into a driver directory. The purpose is to better emphasize the cut between capybara and the drivers. Each driver has a subdirectory under driver. And the public driver API is defined by Capybara::Driver::Base and Capybara::Driver::Node. This file organisation is also used in many other frameworks like active record, paperclip, etc.
