### PR TITLE
Unset @browser so it starts a new session if used again

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -116,7 +116,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   end
 
   def quit
-    @browser.quit
+    @browser.quit if @browser
     @browser = nil
   rescue Errno::ECONNREFUSED
     # Browser must have already gone


### PR DESCRIPTION
I've spent the last ~3 weeks integrating cucumber with selenium & ie8

One of the issues I've encountered is memory leakage, a search turned up this result:

> Regardless of whether it is a Capybara or WebDriver issue, having tests run
> consecutive with Internet Explorer tends to be problematic. IE is infamous
> for memory leaks. Most people don't see it as much anymore because Windows
> Updates forces you to reboot your computer all the time. However, if you
> used one IE session as much as a test automation suite does before closing
> IE, you'll see it crash.
> 
> I'm not saying this is your issue or that you don't have multiple issues
> here. I'm just saying it is usually unwise to run a hundred consecutive
> tests without quitting and starting IE. For other reasons, I write my tests
> so they open the browser, set up the environment, run one test, clean up
> the environment, close the browser. So if I had 100 tests, I would open and
> close the browser 100 times.
> 
> I have noticed however that slowing down consecutive tests helps. It is
> almost as if IE does some sort of garbage collection but if you are using
> the browser too heavily, it does not have time for garbage collection and
> runs out of memory. If you slow down your automation to close to human
> speeds, it gives IE a chance to clean up a little.

http://grokbase.com/t/gg/webdriver/128hka6qg1/ie9-runs-out-of-memory-on-32bit-windows7/oldest
