### PR TITLE
set rspec type to :feature instead

### DIFF
--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -5,10 +5,8 @@ require 'capybara/rspec/matchers'
 require 'capybara/rspec/features'
 
 RSpec.configure do |config|
-  config.include Capybara::DSL, :type => :request
-  config.include Capybara::DSL, :type => :acceptance
-  config.include Capybara::RSpecMatchers, :type => :request
-  config.include Capybara::RSpecMatchers, :type => :acceptance
+  config.include Capybara::DSL, :type => :feature
+  config.include Capybara::RSpecMatchers, :type => :feature
   # The before and after blocks must run instantaneously, because Capybara
   # might not actually be used in all examples where it's included.
   config.after do

--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -12,7 +12,7 @@ end
 def self.feature(*args, &block)
   options = if args.last.is_a?(Hash) then args.pop else {} end
   options[:capybara_feature] = true
-  options[:type] = :request
+  options[:type] = :feature
   options[:caller] ||= caller
   args.push(options)
 

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'capybara/rspec', :type => :request do
+describe 'capybara/rspec', :type => :feature do
   it "should include Capybara in rspec" do
     visit('/foo')
     page.body.should include('Another World')


### PR DESCRIPTION
Hey @josevalim, @dchelimsky, @sobrinho and anyone else who has had an opinion on this. When applied, this commit changes Capybara to use `:feature` as the type for its own `feature` helper, as well as only including Capybara in those steps with type `:feature`. This follows [José's suggestion](http://blog.plataformatec.com.br/2012/06/improving-the-integration-between-capybara-and-rspec/). I feel that this is a very sensible approach.

Though there is obviously a big issue: It breaks compatibility with rspec, especially with rspec-rails.

I'd like to get this into Capybara 2.0 so that we don't have to break the API post release. Can you guys let me know what you think? Should I just release this and hope for the other tools to catch up as soon as possible?
