### PR TITLE
Rename Driver#body to Driver#html

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -9,6 +9,8 @@
   they are disabled. [Jonas Nicklas]
 * Can no longer find elements by id via `find(:foo)`, use `find("#foo")` or
   `find_by_id("foo")` instead. [Jonas Nicklas]
+* Rename `Driver#body` to `Driver#html` (relevant only for driver authors) [Jo
+  Liss]
 
 ### Fixed
 

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -15,7 +15,7 @@ class Capybara::Driver::Base
     raise NotImplementedError
   end
 
-  def body
+  def html
     raise NotImplementedError
   end
 

--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -76,7 +76,7 @@ class Capybara::RackTest::Browser
     @dom = nil
   end
 
-  def body
+  def html
     dom.to_xml
   end
 

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -66,8 +66,8 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     browser.find(selector)
   end
 
-  def body
-    browser.body
+  def html
+    browser.html
   end
 
   def source

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -38,7 +38,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     browser.page_source
   end
 
-  def body
+  def html
     browser.page_source
   end
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -100,10 +100,10 @@ module Capybara
 
     ##
     #
-    # @return [String] A snapshot of the HTML of the current document, as it looks right now (potentially modified by JavaScript).
+    # @return [String] A snapshot of the DOM of the current document, as it looks right now (potentially modified by JavaScript).
     #
     def html
-      driver.body
+      driver.html
     end
 
     ##

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -30,21 +30,21 @@ describe Capybara::Session do
         @session.driver.options[:respect_data_method] = true
         @session.visit "/with_html"
         @session.click_link "A link with data-method"
-        @session.body.should include('The requested object was deleted')
+        @session.html.should include('The requested object was deleted')
       end
 
       it "should not use data-method if option is false" do
         @session.driver.options[:respect_data_method] = false
         @session.visit "/with_html"
         @session.click_link "A link with data-method"
-        @session.body.should include('Not deleted')
+        @session.html.should include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         @session.driver.options[:respect_data_method] = true
         @session.visit "/with_html"
         @session.click_link "A link with capitalized data-method"
-        @session.body.should include('The requested object was deleted')
+        @session.html.should include('The requested object was deleted')
       end
 
       after do
@@ -57,7 +57,7 @@ describe Capybara::Session do
         it "should submit an empty form-data section if no file is submitted" do
           @session.visit("/form")
           @session.click_button("Upload Empty")
-          @session.body.should include('Successfully ignored empty file field.')
+          @session.html.should include('Successfully ignored empty file field.')
         end
       end
     end
@@ -73,27 +73,27 @@ describe Capybara::RackTest::Driver do
     it 'should always set headers' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header')
-      @driver.body.should include('foobar')
+      @driver.html.should include('foobar')
     end
 
     it 'should keep headers on link clicks' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find('.//a').first.click
-      @driver.body.should include('foobar')
+      @driver.html.should include('foobar')
     end
 
     it 'should keep headers on form submit' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find('.//input').first.click
-      @driver.body.should include('foobar')
+      @driver.html.should include('foobar')
     end
 
     it 'should keep headers on redirects' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header_via_redirect')
-      @driver.body.should include('foobar')
+      @driver.html.should include('foobar')
     end
   end
 
@@ -123,7 +123,7 @@ describe Capybara::RackTest::Driver do
 
       it "should follow 5 redirects" do
         @driver.visit("/redirect/5/times")
-        @driver.body.should include('redirection complete')
+        @driver.html.should include('redirection complete')
       end
 
       it "should not follow more than 6 redirects" do
@@ -140,7 +140,7 @@ describe Capybara::RackTest::Driver do
 
       it "should follow 21 redirects" do
         @driver.visit("/redirect/21/times")
-        @driver.body.should include('redirection complete')
+        @driver.html.should include('redirection complete')
       end
 
       it "should not follow more than 21 redirects" do


### PR DESCRIPTION
For historical reasons, Session#html used to delegate to Driver#body,
(but Session#body & Session#source delegate to Driver#source). This
commit puts an end to this confusing state of affairs.

This change requires driver authors to update their drivers.
