### PR TITLE
Fix erroneous execute_script mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ end
 In drivers which support it, you can easily execute JavaScript:
 
 ```ruby
-page.execute_script("$('body').empty()")
+page.evaluate_script("$('body').empty()")
 ```
 
 For simple expressions, you can return the result of the script. Note


### PR DESCRIPTION
README scripting section misnamed evaluate_script as execute_script.
