### PR TITLE
Added mandatory language key to .travis.yml, ensured to build both master and 1.1_stable branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 rvm:
   - 1.9.2
   - 1.9.3
@@ -26,3 +27,7 @@ matrix:
 before_script:
   - sh -e /etc/init.d/xvfb start
   - export DISPLAY=:99.0
+branches:
+  only:
+    - master
+    - 1.1_stable


### PR DESCRIPTION
Apparently this change must be done on master, see http://about.travis-ci.org/docs/user/build-configuration/
