### PR TITLE
Actually memoize the attributes of a Selenium node

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -5,7 +5,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def [](name)
-    @attrs = {}
+    @attrs ||= {}
     @attrs[name] ||= native.attribute(name.to_s)
   rescue Selenium::WebDriver::Error::WebDriverError
     nil


### PR DESCRIPTION
Commit 8a9c975 wasn't 100% correct - it would always reset the memo cache, effectively preventing any selenium call from being cached.
