### PR TITLE
alias given and given! to let and let!

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,22 @@ feature "Signing up" do
     end
     click_link 'Sign in'
   end
+
+  given(:other_user) { User.make(:email => 'other@example.com', :password => 'rous') }
+  
+  scenario "Signing in as another user" do
+    within("#session") do
+      fill_in 'Login', :with => other_user.email
+      fill_in 'Password', :with => other_user.password
+    end
+    click_link 'Sign in'
+  end
+
 end
 ```
 
 `feature` is in fact just an alias for `describe ..., :type => :request`,
-`background` is an alias for `before`, and `scenario` for `it`.
+`background` is an alias for `before`, `scenario` for `it`, and `given`/`given!` aliases for `let`/`let!`, respectively.
 
 ## Using Capybara with Test::Unit
 

--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -4,6 +4,8 @@ module Capybara
       base.instance_eval do
         alias :background :before
         alias :scenario :it
+        alias :given :let
+        alias :given! :let!
       end
     end
   end

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -36,6 +36,20 @@ feature "Capybara's feature DSL" do
   end
 end
 
+feature "given and given! aliases to let and let!" do
+  given(:value) { :available }
+  given!(:value_in_background) { :available }
+
+  background do
+    value_in_background.should be(:available)
+  end
+
+  scenario "given and given! work as intended" do
+    value.should be(:available)
+    value_in_background.should be(:available)
+  end
+end
+
 feature "Capybara's feature DSL with driver", :driver => :culerity do
   scenario "switches driver" do
     Capybara.current_driver.should == :culerity


### PR DESCRIPTION
I use `let` all over the place in vanilla RSpec, but something just didn't feel right using it with the feature DSL. This pull request adds aliases for `let` and `let!` in the form of `given` and `given!`. It's only syntactic sugar but it helps remind me I'm writing acceptance tests.

Using these aliases, the DSL example in the README could be rewritten as:

``` ruby
feature "Signing up" do
  given(:user) { User.make(:email => 'user@example.com', :password => 'caplin') }

  scenario "Signing in as another user" do
    within("#session") do
      fill_in 'Login', :with => user.email
      fill_in 'Password', :with => user.password
    end
    click_link 'Sign in'
  end

end
```
