### PR TITLE
allow scenarios to be pending

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,17 +148,11 @@ feature "Signing up" do
     end
     click_link 'Sign in'
   end
-
-  xscenario "Signing out" do
-    # this test is pending
-  end
-
 end
 ```
 
 `feature` is in fact just an alias for `describe ..., :type => :request`,
 `background` is an alias for `before`, `scenario` for `it`, and `given`/`given!` aliases for `let`/`let!`, respectively.
-`xscenario` is an alias for `pending`, allowing you to temporarily disable a test.
 
 ## Using Capybara with Test::Unit
 

--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -4,7 +4,7 @@ module Capybara
       base.instance_eval do
         alias :background :before
         alias :scenario :it
-        alias :xscenario :pending
+        alias_example_to :xscenario, :pending => "temporarily disabled with xscenario"
         alias :given :let
         alias :given! :let!
       end

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -51,7 +51,7 @@ feature "given and given! aliases to let and let!" do
 end
 
 feature "if xscenario aliases to pending then" do
-  xscenario "this test should be pending" do
+  xscenario "this test should be 'temporarily disabled with xscenario'" do
   end
 end
 


### PR DESCRIPTION
What I did: Tried to set a scenario to pending by using xscenario.

What I expected to happen: the scenario would be set to pending when I ran my specs.

What happened instead: undefined method 'xscenario.'

Since scenario is an alias for it, I figure xscenario should be an alias for xit (except xit adds some extra text, so I aliased xscenario to pending, the text-free version). Alas, I couldn't think of a better way to test this. Thoughts?
