### PR TITLE
Move the RackTest driver override to capybara/rails

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,11 @@
+# master
+
+### Changed
+
+* Move the RackTest driver override with the `:respect_data_method` option
+  enabled from capybara/rspec to capybara/rails, so that it is enabled in
+  Rails projects that don't use RSpec. [Carlos Antonio da Silva]
+
 # Version 2.0.0
 
 Release date: 2012-11-05

--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -4,7 +4,7 @@ require 'capybara/dsl'
 Capybara.app = Rack::Builder.new do
   map "/" do
     if Rails.version.to_f >= 3.0
-      run Rails.application  
+      run Rails.application
     else # Rails 2
       use Rails::Rack::Static
       run ActionController::Dispatcher.new
@@ -15,3 +15,7 @@ end.to_app
 Capybara.asset_root = Rails.root.join('public')
 Capybara.save_and_open_page_path = Rails.root.join('tmp/capybara')
 
+# Override default rack_test driver to respect data-method attributes.
+Capybara.register_driver :rack_test do |app|
+  Capybara::RackTest::Driver.new(app, :respect_data_method => true)
+end

--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -22,8 +22,3 @@ RSpec.configure do |config|
     end
   end
 end
-
-# Override default rack_test driver to respect data-method attributes.
-Capybara.register_driver :rack_test do |app|
-  Capybara::RackTest::Driver.new(app, :respect_data_method => true)
-end


### PR DESCRIPTION
Pull request #793 merged in 14411d438fc5f0f4c96166ed73abc782f53b34cd enables `:respect_data_method` when requiring `capybara/rspec`, making it work seamlessly with Rails projects that do use RSpec.

However, projects that do not use RSpec will end up only requiring `capybara/rails`, and won't get this functionality.

This change enables the `:respect_data_method` option from the RackTest driver for Rails projects that don't use RSpec, by moving the code that overrides the `:rack_test` driver with the `:respect_data_method` option enabled to `capybara/rails`.

I'm not sure it's required to have this code in both files, since most users will be using this option with Rails projects and probably not with projects that require RSpec only (non-Rails projects). But if you guys think it's necessary to maintain any sort of compatibility I may not be aware of, I can leave it in `capybara/rspec` as well.

Let me know if anything needs improvement, thanks!
