### PR TITLE
Properly clear input by moving to the end before backspacing in Selenium driver

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -32,7 +32,8 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
       path_names = value.to_s.empty? ? [] : value
       native.send_keys(*path_names)
     elsif tag_name == 'textarea' or tag_name == 'input'
-      native.send_keys(("\b" * native[:value].size) + value.to_s)
+      chars = native[:value].size
+      native.send_keys(([:right] * chars) + ([:backspace] * chars) + [ value.to_s ])
     end
   end
 

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -65,6 +65,12 @@ Capybara::SpecHelper.spec "node" do
       @session.first('//input').set('gorilla')
       @session.first('//input').value.should == 'gorilla'
     end
+
+    it "should fill the field even if the caret was not at the end", :requires => [:js] do
+      @session.execute_script("var el = document.getElementById('test_field'); el.focus(); el.setSelectionRange(0, 0);")
+      @session.first('//input').set('')
+      @session.first('//input').value.should == ''
+    end
   end
 
   describe "#tag_name" do


### PR DESCRIPTION
Previously, if the input element already had focus but the cursor was somewhere other than at the end, `Selenium::Node#set` would not properly remove all of the input's previous content because the characters after the cursor were not "backspaced."

With this change, we first move to end of the content by hitting the right arrow key repeatedly, before hitting backspace repeatedly.
