### PR TITLE
source_spec calls Session#source directly

### DIFF
--- a/lib/capybara/spec/session/source_spec.rb
+++ b/lib/capybara/spec/session/source_spec.rb
@@ -6,7 +6,7 @@ Capybara::SpecHelper.spec '#source' do
 
   it "should return the original, unmodified source of the page", :requires => [:js, :source] do
     @session.visit('/with_js')
-    @session.send(method).should include('This is text')
-    @session.send(method).should_not include('I changed it')
+    @session.source.should include('This is text')
+    @session.source.should_not include('I changed it')
   end
 end


### PR DESCRIPTION
Previously, testing of body and source methods was meta-programmed,
providing a `method' which needed to be called.  Since this has been
removed, there is no`method' to call, so instead call source directly.
