### PR TITLE
Delegate node equality to driver

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -70,6 +70,10 @@ module Capybara
       rescue NotSupportedByDriverError
         %(#<#{self.class} tag="#{tag_name}">)
       end
+
+      def ==(other)
+        raise NotSupportedByDriverError
+      end
     end
   end
 end

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -451,11 +451,7 @@ module Capybara
       end
 
       def ==(other)
-        if other.respond_to?(:native)
-          self.eql?(other) or native == other.native
-        else
-          self.eql?(other)
-        end
+        self.eql?(other) or base == other.base
       end
 
     private

--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -97,6 +97,10 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     native.xpath(locator).map { |n| self.class.new(driver, n) }
   end
 
+  def ==(other)
+    native == other.native
+  end
+
 protected
 
   def unnormalized_text

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -75,6 +75,10 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
     native.find_elements(:xpath, locator).map { |n| self.class.new(driver, n) }
   end
 
+  def ==(other)
+    native == other.native
+  end
+
 private
 
   # a reference to the select node if this is an option node


### PR DESCRIPTION
The native representation of a node may not be equal across driver
implementations.  Instead, let the driver define equality.
