### PR TITLE
Use Array coercion on uploaded files - fixes #848

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -138,7 +138,7 @@ module Capybara
       # @param [String] path          The path of the file that will be attached, or an array of paths
       #
       def attach_file(locator, path)
-        (String === path ? [path] : path).each do |p|
+        Array(path).each do |p|
           raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s)
         end
         find(:file_field, locator).set(path)


### PR DESCRIPTION
This allows classes that aren't String but are similar enough
(like Pathname) to be used as upload paths.
