### PR TITLE
== doesn't raise an exception for unrelated object

### DIFF
--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -114,6 +114,10 @@ Capybara::SpecHelper.spec "node" do
       (@session.find('//h1') === @session.find('//h1')).should be_true
       (@session.find('//h1').eql? @session.find('//h1')).should be_false
     end
+
+    it "returns false for unrelated object" do
+      (@session.find('//h1') == "Not Capybara::Node::Base").should be_false
+    end
   end
 
   describe "#trigger", :requires => [:js, :trigger] do

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -573,14 +573,4 @@ describe Capybara::RSpecMatchers do
       end.to raise_error(/expected to find table "No such Table"/)
     end
   end
-
-  describe "==" do
-    before do
-      visit('/with_html')
-    end
-
-    it "returns false for unrelated object" do
-      page.find("html").should_not == "Not Capybara::Node::Base"
-    end
-  end
 end


### PR DESCRIPTION
Normally, `==` method doesn't raise any exception if passed object isn't equal object.
It's better that `Capybara::Node::Matchers` follows the convention.
