### PR TITLE
Don't parse current_host when building mock session

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -94,7 +94,7 @@ protected
 
   def build_rack_mock_session
     reset_host! unless current_host
-    Rack::MockSession.new(app, URI.parse(current_host).host)
+    Rack::MockSession.new(app, current_host)
   end
 
   def request_path


### PR DESCRIPTION
Because the current_host is now being explicitly set to the host instead
of the full URI (as it was in Capybara 1.x) when URI.parse is being used
the result will always be `nil` when parsing the host from an incomplete
URI.
