### PR TITLE
Add encoding header to the helpers definition file

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 module Capybara
   module Helpers
     class << self


### PR DESCRIPTION
Fixes "incompatible character encoding" error when running Capybara on JRuby platforms.
