### PR TITLE
Allow protocol relative URLs, backported from #776

### DIFF
--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -81,6 +81,11 @@ shared_examples_for "click_link" do
       @session.body.should include('You landed')
     end
 
+    it "should follow protocol relative links" do
+      @session.click_link('Protocol')
+      @session.should have_content('Another World')
+    end
+
     it "should follow redirects" do
       @session.click_link('BackToMyself')
       @session.body.should include('This is a test')

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -45,6 +45,7 @@ banana</textarea>
   <a href="/with_html#anchor">Anchor on same page</a>
   <a href="with_html">Relative</a>
   <input type="text" value="" id="test_field">
+  <a href="//<%= request.host_with_port %>/foo">Protocol</a>
   <input type="text" checked="checked" id="checked_field">
   <a href="/redirect"><img width="20" height="20" alt="very fine image" /></a>
   <a href="/with_simple_html"><img width="20" height="20" alt="fine image" /></a>


### PR DESCRIPTION
This backports commit 01cb16e from issue #776 into the 1.1_stable branch.
