### PR TITLE
Support filling in `contenteditable` elements

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -38,11 +38,10 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
       #ensure we are focused on the element
       script = <<-JS
         var range = document.createRange();
-        range.setStart(arguments[0], 0);
+        range.selectNodeContents(arguments[0]);
         window.getSelection().addRange(range);
       JS
       driver.browser.execute_script script, native
-      native.clear
       native.send_keys(value.to_s)
     end
   end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -83,6 +83,13 @@ Capybara::SpecHelper.spec "node" do
       @session.find(:css,'#blank_content_editable').set('WYSIWYG')
       @session.find(:css,'#blank_content_editable').text.should == 'WYSIWYG'
     end
+
+    it 'should allow me to change the contents of a contenteditable elements child', :requires => [:js] do
+      pending "Selenium doesn't like editing nested contents"
+      @session.visit('/with_js')
+      @session.find(:css,'#existing_content_editable_child').set('WYSIWYG')
+      @session.find(:css,'#existing_content_editable_child').text.should == 'WYSIWYG'
+    end
   end
 
   describe "#tag_name" do

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -38,6 +38,9 @@
     <p>
       <div contenteditable='true' id='existing_content_editable'>Editable content</div>
       <div contenteditable='true' id='blank_content_editable' style='height: 1em;'></div>
+      <div contenteditable='true' style='height: 1em;'>
+        <div id='existing_content_editable_child' style='height: 1em;'>Content</div>
+      </div>
     </p>
 
     <p>


### PR DESCRIPTION
Allow elements that are content-editable to be set, and allow them to be filled in with `fill_in 'element', with: 'content'`.

There are commits to xpath to make this possible too, I don't know how Github handles those.

Would you like me to update the Readme to indicate this is possible too?
