### PR TITLE
Add magic comment for Ruby2.0.0

### DIFF
--- a/lib/capybara/spec/session/screenshot.rb
+++ b/lib/capybara/spec/session/screenshot.rb
@@ -1,3 +1,4 @@
+#coding: US-ASCII
 Capybara::SpecHelper.spec "#save_screenshot" do
   let(:image_path) { File.join(Dir.tmpdir, 'capybara-screenshot.png') }
 


### PR DESCRIPTION
Ruby2.0.0 default encoding is UTF-8 instead of US_ASCII
