### PR TITLE
Catch the correct timeout exception during Server#boot

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -76,7 +76,7 @@ module Capybara
 
         Timeout.timeout(60) { @server_thread.join(0.1) until responsive? }
       end
-    rescue TimeoutError
+    rescue Timeout::Error
       raise "Rack application timed out during boot"
     else
       self


### PR DESCRIPTION
`TimeoutError` is actually `Capybara::TimeoutError`, which is unrelated to Ruby's Timeout.  I think this is left over from back when we used to use `Capybara.timeout {... }` while booting the server.

`Capybara::TimeoutError` could perhaps be removed now - it's only used as the superclass of `InfiniteRedirectError`.  WDYT?
