### PR TITLE
Remove Capybara::TimeoutError

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -12,9 +12,8 @@ module Capybara
   class FileNotFound < CapybaraError; end
   class UnselectNotAllowed < CapybaraError; end
   class NotSupportedByDriverError < CapybaraError; end
-  class TimeoutError < CapybaraError; end
   class LocateHiddenElementError < CapybaraError; end
-  class InfiniteRedirectError < TimeoutError; end
+  class InfiniteRedirectError < CapybaraError; end
 
   class << self
     attr_accessor :asset_root, :app_host, :run_server, :default_host, :always_include_port


### PR DESCRIPTION
It's no longer necessary, we rely on Ruby's Timeout::Error instead
