### PR TITLE
Fix random timeouts during Server#boot

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -36,7 +36,6 @@ module Capybara
     def initialize(app, port=Capybara.server_port)
       @app = app
       @middleware = Middleware.new(@app)
-      @server_thread = nil # supress warnings
       @port = port
       @port ||= Capybara::Server.ports[@app.object_id]
       @port ||= find_available_port
@@ -55,8 +54,6 @@ module Capybara
     end
 
     def responsive?
-      return false if @server_thread && @server_thread.join(0)
-
       res = Net::HTTP.start(host, @port) { |http| http.get('/__identify__') }
 
       if res.is_a?(Net::HTTPSuccess) or res.is_a?(Net::HTTPRedirection)
@@ -70,11 +67,11 @@ module Capybara
       unless responsive?
         Capybara::Server.ports[@app.object_id] = @port
 
-        @server_thread = Thread.new do
+        server_thread = Thread.new do
           Capybara.server.call(@middleware, @port)
         end
 
-        Timeout.timeout(60) { @server_thread.join(0.1) until responsive? }
+        Timeout.timeout(60) { server_thread.join(0.1) until responsive? }
       end
     rescue TimeoutError
       raise "Rack application timed out during boot"


### PR DESCRIPTION
Rack::Handler::Thin.run() (and, by extension, Capybara.server.call())
can return immediately if another Thin handler is already running.  This
results in a race condition where `@server_thread` can finish running
before we evaluate `responsive?`.   The easiest solution seems to be to
just remove the check that `@server_thread` is alive - it's quite possible
that EventMachine has merged the new server into a previous one, so we don't
particularly care about the state of our own thread.

---

I was having trouble running Capybara's tests successfully - I would keep getting timeout errors while booting, particularly in current_url_spec.rb and server_spec.rb (both of which create multiple Capybara::Servers), and eventually traced it down to this.  Has anyone else had trouble with that or is it just me?
