### PR TITLE
Clean up ugly regex to use POSIX character class

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -13,10 +13,7 @@ module Capybara
       # @return [String]         Normalized text
       #
       def normalize_whitespace(text)
-        # http://en.wikipedia.org/wiki/Whitespace_character#Unicode
-        # We should have a better reference.
-        # See also http://stackoverflow.com/a/11758133/525872
-        text.to_s.gsub(/[\s\u0085\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+/, ' ').strip
+        text.to_s.gsub(/[[:space:]]+/, ' ').strip
       end
 
       ##


### PR DESCRIPTION
`[[:space:]]` works like `\s` in regexes, except it is encoding aware.  See http://www.ruby-doc.org/core-1.9.3/Regexp.html#label-Character+Classes

This avoids an issue I was seeing in 1.8 where the unicode characters were being misparsed and it was erroneously stripping several letters and most digits.
