### PR TITLE
Require ruby 1.9 or higher

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.name = "capybara"
   s.rubyforge_project = "capybara"
   s.version = Capybara::VERSION
+  s.required_ruby_version = ">= 1.9.0"
 
   s.authors = ["Jonas Nicklas"]
   s.email = ["jonas.nicklas@gmail.com"]


### PR DESCRIPTION
As discussed in #781, see http://docs.rubygems.org/read/chapter/20#required_ruby_version for more info in `required_ruby_version`.
