### PR TITLE
Remove info about thin from rdoc

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -116,7 +116,7 @@ module Capybara
     #       Rack::Handler::Mongrel.run(app, :Port => port)
     #     end
     #
-    # By default, Capybara will try to run thin, falling back to webrick.
+    # By default, Capybara will try to run webrick.
     #
     # @yield [app, port]                      This block recieves a rack app and port and should run a Rack handler
     #


### PR DESCRIPTION
Capybara doesn't use thin from version 2.0.2
