### PR TITLE
Remove broken :content selector

### DIFF
--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -144,10 +144,6 @@ Capybara.add_selector(:file_field) do
   xpath { |locator| XPath::HTML.file_field(locator) }
 end
 
-Capybara.add_selector(:content) do
-  xpath { |content| XPath::HTML.content(content) }
-end
-
 Capybara.add_selector(:table) do
   xpath { |locator| XPath::HTML.table(locator) }
 end


### PR DESCRIPTION
Content method [was removed from XPath gem a year ago](https://github.com/jnicklas/xpath/commit/1691851b49ce5db484d79e4569848dad1571cf3a)
