### PR TITLE
Remove advice to use sudo when installing the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GitHub): http://groups.google.com/group/ruby-capybara
 To install, type
 
 ```bash
-sudo gem install capybara
+gem install capybara
 ```
 
 If you are using Rails, add this line to your test helper file:


### PR DESCRIPTION
Installing gems with sudo strikes me as a bad thing.
