### PR TITLE
Remove broken :content selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,6 @@ certain elements, and working with and manipulating those elements.
 ```ruby
 page.has_selector?('table tr')
 page.has_selector?(:xpath, '//table/tr')
-page.has_no_selector?(:content)
 
 page.has_xpath?('//table/tr')
 page.has_css?('table tr.foo')
@@ -416,7 +415,6 @@ You can use these with RSpec's magic matchers:
 ```ruby
 page.should have_selector('table tr')
 page.should have_selector(:xpath, '//table/tr')
-page.should have_no_selector(:content)
 
 page.should have_xpath('//table/tr')
 page.should have_css('table tr.foo')

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -144,10 +144,6 @@ Capybara.add_selector(:file_field) do
   xpath { |locator| XPath::HTML.file_field(locator) }
 end
 
-Capybara.add_selector(:content) do
-  xpath { |content| XPath::HTML.content(content) }
-end
-
 Capybara.add_selector(:table) do
   xpath { |locator| XPath::HTML.table(locator) }
 end


### PR DESCRIPTION
Content method [was removed from XPath gem a year ago](Content method was removed from XPath gem a year ago)

I've also removed it from README file
