### PR TITLE
Clean up Capybara::RackTest::Node#set

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -15,35 +15,14 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     if (Array === value) && !self[:multiple]
       raise ArgumentError.new "Value cannot be an Array when 'multiple' attribute is not present. Not a #{value.class}"
     end
-    if tag_name == 'input' and type == 'radio'
-      other_radios_xpath = XPath.generate { |x| x.anywhere(:input)[x.attr(:name).equals(self[:name])] }.to_s
-      driver.dom.xpath(other_radios_xpath).each { |node| node.remove_attribute("checked") }
-      native['checked'] = 'checked'
-    elsif tag_name == 'input' and type == 'checkbox'
-      if value && !native['checked']
-        native['checked'] = 'checked'
-      elsif !value && native['checked']
-        native.remove_attribute('checked')
-      end
-    elsif tag_name == 'input'
-      if (type == 'text' || type == 'password') && self[:maxlength] &&
-        !self[:maxlength].empty?
-        # Browser behavior for maxlength="0" is inconsistent, so we stick with
-        # Firefox, allowing no input
-        value = value[0...self[:maxlength].to_i]
-      end
-      if Array === value #Assert multiple attribute is present
-        value.each do |v|
-          new_native = native.clone
-          new_native.remove_attribute('value')
-          native.add_next_sibling(new_native)
-          new_native['value'] = v.to_s
-        end
-        native.remove
-      else
-        native['value'] = value.to_s
-      end
-    elsif tag_name == "textarea"
+
+    if radio?
+      set_radio(value)
+    elsif checkbox?
+      set_checkbox(value)
+    elsif input_field?
+      set_input(value)
+    elsif textarea?
       native.content = value.to_s
     end
   end
@@ -134,5 +113,62 @@ private
 
   def form
     native.ancestors('form').first
+  end
+
+  def set_radio(value)
+    other_radios_xpath = XPath.generate { |x| x.anywhere(:input)[x.attr(:name).equals(self[:name])] }.to_s
+    driver.dom.xpath(other_radios_xpath).each { |node| node.remove_attribute("checked") }
+    native['checked'] = 'checked'
+  end
+
+  def set_checkbox(value)
+    if value && !native['checked']
+      native['checked'] = 'checked'
+    elsif !value && native['checked']
+      native.remove_attribute('checked')
+    end
+  end
+
+  def set_input(value)
+    if text_or_password? && attribute_is_not_blank?(:maxlength)
+      # Browser behavior for maxlength="0" is inconsistent, so we stick with
+      # Firefox, allowing no input
+      value = value[0...self[:maxlength].to_i]
+    end
+    if Array === value #Assert multiple attribute is present
+      value.each do |v|
+        new_native = native.clone
+        new_native.remove_attribute('value')
+        native.add_next_sibling(new_native)
+        new_native['value'] = v.to_s
+      end
+      native.remove
+    else
+      native['value'] = value.to_s
+    end
+  end
+
+  def attribute_is_not_blank?(attribute)
+    self[attribute] && !self[attribute].empty?
+  end
+
+  def checkbox?
+    input_field? && type == 'checkbox'
+  end
+
+  def input_field?
+    tag_name == 'input'
+  end
+
+  def radio?
+    input_field? && type == 'radio'
+  end
+
+  def textarea?
+    tag_name == "textarea"
+  end
+
+  def text_or_password?
+    input_field? && (type == 'text' || type == 'password')
   end
 end


### PR DESCRIPTION
Splits one big method into many to improve readability. Tests pass.
