### PR TITLE
Add *args option to execute_script

### DIFF
--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -15,11 +15,11 @@ class Capybara::Driver::Base
     raise NotImplementedError
   end
 
-  def execute_script(script)
+  def execute_script(script, *args)
     raise Capybara::NotSupportedByDriverError
   end
 
-  def evaluate_script(script)
+  def evaluate_script(script, *args)
     raise Capybara::NotSupportedByDriverError
   end
 

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -32,7 +32,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
       path_names = value.to_s.empty? ? [] : value
       native.send_keys(*path_names)
     elsif tag_name == 'textarea' or tag_name == 'input'
-      driver.browser.execute_script "arguments[0].value = ''", native
+      driver.execute_script("arguments[0].value = ''", native)
       native.send_keys(value.to_s)
     end
   end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -275,10 +275,12 @@ module Capybara
     # +evaluate_script+ whenever possible.
     #
     # @param [String] script   A string of JavaScript to execute
+    # @param [Capybara::Node::Element, Integer, Float, Boolean, NilClass, String, Array] *args Arguments will be available in the given script in the 'arguments' pseudo-array.    
     #
-    def execute_script(script)
+    def execute_script(script, *args)
       @touched = true
-      driver.execute_script(script)
+      args.map! { |e| e.kind_of?(Capybara::Node::Element) ? e.native : e }
+      driver.execute_script(script, *args)
     end
 
     ##
@@ -288,11 +290,13 @@ module Capybara
     # be a better alternative.
     #
     # @param  [String] script   A string of JavaScript to evaluate
+    # @param [Capybara::Node::Element,Integer, Float, Boolean, NilClass, String, Array] *args Arguments will be available in the given script in the 'arguments' pseudo-array.
     # @return [Object]          The result of the evaluated JavaScript (may be driver specific)
     #
-    def evaluate_script(script)
+    def evaluate_script(script, *args)
       @touched = true
-      driver.evaluate_script(script)
+      args.map! { |e| e.kind_of?(Capybara::Node::Element) ? e.native : e }
+      driver.evaluate_script(script, *args)
     end
 
     ##

--- a/lib/capybara/spec/session/evaluate_script_spec.rb
+++ b/lib/capybara/spec/session/evaluate_script_spec.rb
@@ -3,4 +3,24 @@ Capybara::SpecHelper.spec "#evaluate_script", :requires => [:js] do
     @session.visit('/with_js')
     @session.evaluate_script("1+3").should == 4
   end
+
+  it "should support arguments" do
+    @session.visit('/with_js')
+    @session.evaluate_script("arguments[0] + arguments[1]", 1, 3).should == 4
+  end
+
+  it "should support Capybara::Node::Element arguments" do
+    @session.visit('/with_js')
+    element = @session.find("//p[@id='eval_p']")
+    @session.evaluate_script("$(arguments[0]).text()", element).should == "Some text"
+  end
+
+  it "should cast returned native arguments to Capybara::Node::Element or Capybara::Driver::Node" do
+    @session.visit('/with_js')
+    elem = @session.evaluate_script("$(arguments[0])[0]", '#eval_input')
+    correct_class = elem.is_a?(Capybara::Driver::Node) || elem.class == Capybara::Node::Element
+    correct_class.should == true
+    elem.set("New text")
+    @session.find("//input[@id='eval_input']").value.should == "New text"
+  end
 end

--- a/lib/capybara/spec/session/execute_script_spec.rb
+++ b/lib/capybara/spec/session/execute_script_spec.rb
@@ -4,4 +4,10 @@ Capybara::SpecHelper.spec "#execute_script", :requires => [:js] do
     @session.execute_script("$('#change').text('Funky Doodle')").should be_nil
     @session.should have_css('#change', :text => 'Funky Doodle')
   end
+
+  it "should support arguments" do
+    @session.visit('/with_js')
+    @session.execute_script("$(arguments[0]).text(arguments[1])", '#change', 'Funky Doodle').should be_nil
+    @session.should have_css('#change', :text => 'Funky Doodle')
+  end
 end

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -18,6 +18,9 @@
       <p>It should be dropped here.</p>
     </div>
 
+    <p id="eval_p">Some text</p>
+    <input id="eval_input" type="text" value="Default value" />
+
     <p><a href="#" id="clickable">Click me</a></p>
 
     <p>


### PR DESCRIPTION
This PR aims to do nearly the same as https://github.com/jnicklas/capybara/pull/564

However, this one:
- adds tests
- casts args of type `Capybara::Node::Element` to native
- casts returned value to `Capybara::Driver::Node` (I don't know how to create proper `Capybara::Node::Element` from driver.rb)

Parameters [are supported by PhantomJS](https://github.com/ariya/phantomjs/pull/231) so it will be possible to add this functionality to at least Poltergeist.

I made it a PR as it changes public API.
