### PR TITLE
Color values are serialized in lowercase

### DIFF
--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -63,7 +63,7 @@ Capybara::SpecHelper.spec '#click_button' do
       end
 
       it "should serialise and submit color fields" do
-        @results['html5_color'].should == '#FFFFFF'
+        @results['html5_color'].upcase.should == '#FFFFFF'
       end
     end
 


### PR DESCRIPTION
According to the spec [1], color values are serialized in lowercase.
capybara-webkit returns lowercase values when compiled against Qt 5,
while Firefox and Qt 4 return the initial, uppercase value.

[1] http://goo.gl/2GK9o
