### PR TITLE
Fix intermittent #find failures

### DIFF
--- a/lib/capybara/node/base.rb
+++ b/lib/capybara/node/base.rb
@@ -73,14 +73,17 @@ module Capybara
       #
       def synchronize(seconds=Capybara.default_wait_time)
         start_time = Time.now
+        first_fail_time = nil
 
         begin
           yield
         rescue => e
+          first_fail_time ||= Time.now
+
           raise e if @unsynchronized
           raise e unless driver.wait?
           raise e unless driver.invalid_element_errors.include?(e.class) || e.is_a?(Capybara::ElementNotFound)
-          raise e if (Time.now - start_time) >= seconds
+          raise e if (Time.now - first_fail_time) > seconds
           sleep(0.05)
           raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if Time.now == start_time
           reload if Capybara.automatic_reload


### PR DESCRIPTION
Previously, Capybara::Node::Base#synchronize would record the time the
method was called, yield, then re-raise misc element-related errors
(ex. element not found) if the time the block took was more than
Capybara#default_wait_time, or it had tried several times that amounted
to #default_wait_time.

In practice, selenium sometimes takes seconds to return on the first
block, ex. when clicking a link that triggers behavior resulting in a
cpu spike. The amount of time taken varies significantly depending on
available resources, and setting the #default_wait_time to a high number
is hacky.

This changes #synchronize to record the time of the first failure, and
retry after that for #default_wait_time. This way, the amount of time
ex. click_link takes has no bearing on the amount of time it will retry
for once selenium becomes responsive. Developers can then set a lower
default_wait_time for faster failures overall, while also being
unaffected by random selenium lags resulting from client actions.
