### PR TITLE
Eliminate Warning

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -49,11 +49,7 @@ module Capybara
     def initialize(mode, app=nil)
       @mode = mode
       @app = app
-      if Capybara.run_server and @app and driver.needs_server?
-        @server = Capybara::Server.new(@app).boot
-      else
-        @server = nil
-      end
+      @server = (Capybara.run_server and @app and driver.needs_server?) ? Capybara::Server.new(@app).boot : nil
       @touched = false
     end
 


### PR DESCRIPTION
Simple one-liner fix to remove warnings about @server being
uninitialized when run as part of test suites with -w enabled
