### PR TITLE
Adding documentation for Capybara::Result to be more explicit about what

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -105,7 +105,7 @@ module Capybara
       #   @option options [Boolean] visible          Only find elements that are visible on the page. Setting this to false
       #                                              (the default, unless Capybara.ignore_hidden_elements = true), finds
       #                                              invisible _and_ visible elements.
-      # @return [Array[Capybara::Element]]           The found elements
+      # @return [Capybara::Result]                   A collection of found elements
       #
       def all(*args)
         query = Capybara::Query.new(*args)

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -1,6 +1,23 @@
 require 'forwardable'
 
 module Capybara
+
+  ##
+  # A {Capybara::Result} represents a collection of {Capybara::Element} on the page. It is possible to interact with this
+  # collection similar to an Array because it implements Enumerable and offers the following Array methods through delegation:
+  #
+  # * []
+  # * each()
+  # * at()
+  # * size()
+  # * count()
+  # * length()
+  # * first()
+  # * last()
+  # * empty?()
+  #
+  # @see Capybara::Element
+  #
   class Result
     include Enumerable
     extend Forwardable


### PR DESCRIPTION
Node#all returns.

@jnicklas - As discussed on the [mailing list](https://groups.google.com/forum/?fromgroups=#!topic/ruby-capybara/1JEwsbqJQ8s)
