### PR TITLE
Add #title method to Capybara::Node::Document

### DIFF
--- a/lib/capybara/node/document.rb
+++ b/lib/capybara/node/document.rb
@@ -20,6 +20,10 @@ module Capybara
       def text
         find(:xpath, '/html').text
       end
+      
+      def title
+        session.driver.title
+      end
     end
   end
 end

--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -89,6 +89,10 @@ class Capybara::RackTest::Browser
   rescue Rack::Test::Error
     ""
   end
+  
+  def title
+    dom.xpath("//title").text
+  end
 
 protected
 

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -73,6 +73,10 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
   def dom
     browser.dom
   end
+  
+  def title
+    browser.title
+  end
 
   def reset!
     @browser = nil

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -38,6 +38,10 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     browser.page_source
   end
 
+  def title
+    browser.title
+  end
+  
   def current_url
     browser.current_url
   end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -37,7 +37,7 @@ module Capybara
       :has_no_unchecked_field?, :query, :assert_selector, :assert_no_selector
     ]
     SESSION_METHODS = [
-      :body, :html, :current_url, :current_host, :evaluate_script, :source,
+      :body, :html, :current_url, :current_host, :evaluate_script, :source, :title,
       :visit, :within, :within_fieldset, :within_table, :within_frame,
       :within_window, :current_path, :save_page, :save_and_open_page,
       :save_screenshot, :reset_session!, :response_headers, :status_code
@@ -135,6 +135,14 @@ module Capybara
     #
     def current_url
       driver.current_url
+    end
+    
+    ##
+    #
+    # @return [String] Title of the current page
+    #
+    def title
+      driver.title
     end
 
     ##

--- a/lib/capybara/spec/session/title_spec.rb
+++ b/lib/capybara/spec/session/title_spec.rb
@@ -1,0 +1,16 @@
+Capybara::SpecHelper.spec '#title' do
+
+  it "should print the title of the page" do
+    @session.visit('/with_title')
+    @session.title.should == 'Test Title'
+  end
+
+  context "with css as default selector" do
+    before { Capybara.default_selector = :css }
+    it "should print the title of the page" do
+      @session.visit('/with_title')
+      @session.title.should == 'Test Title'
+    end
+    after { Capybara.default_selector = :xpath }
+  end
+end

--- a/lib/capybara/spec/views/with_title.erb
+++ b/lib/capybara/spec/views/with_title.erb
@@ -1,0 +1,1 @@
+<title>Test Title</title>


### PR DESCRIPTION
As it was decided here https://github.com/jnicklas/capybara/pull/898 , this adds the #title method to Capybara document. So, in tests we can use @session.title.should == 'Test Title'
