### PR TITLE
Update lib/capybara/node/matchers.rb

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -13,7 +13,7 @@ module Capybara
       # By default it will check if the expression occurs at least once,
       # but a different number can be specified.
       #
-      #     page.has_selector?('p#foo', :count => 4)
+      #     page.has_selector?('p.foo', :count => 4)
       #
       # This will check if the expression occurs exactly 4 times.
       #


### PR DESCRIPTION
The example given for has_selector? with a count is misleading. As it specifies "p#foo", this is referring to a p element with an id of "foo". This should only appear once on a page.
