### PR TITLE
cleanup Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
-source :rubygems
+source 'https://rubygems.org'
 
-gem 'bundler', '~> 1.0'
 gemspec
 
 @dependencies.delete_if {|d| d.name == "xpath" }


### PR DESCRIPTION
- removed deprecated :rubygems shortcut
- removed bundler - you already are using it
