### PR TITLE
Changed the ordering in the text matchers methods because i had problems on ruby 1.8.7.

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -200,7 +200,7 @@ module Capybara
       # @param [String] content       The text to check for
       # @return [Boolean]             Whether it exists
       #
-      def has_text?(type=nil, content)
+      def has_text?(content, type=nil)
         synchronize do
           unless Capybara::Helpers.normalize_whitespace(text(type)).match(Capybara::Helpers.to_regexp(content))
             raise ExpectationNotMet
@@ -223,7 +223,7 @@ module Capybara
       # @param [String] content       The text to check for
       # @return [Boolean]             Whether it doesn't exist
       #
-      def has_no_text?(type=nil, content)
+      def has_no_text?(content, type=nil)
         synchronize do
           if Capybara::Helpers.normalize_whitespace(text(type)).match(Capybara::Helpers.to_regexp(content))
             raise ExpectationNotMet

--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -35,19 +35,19 @@ module Capybara
     class HaveText < Matcher
       attr_reader :text, :type
 
-      def initialize(type, text)
-        @type = type
+      def initialize(text, type)
         @text = text
+        @type = type
       end
 
       def matches?(actual)
         @actual = wrap(actual)
-        @actual.has_text?(type, text)
+        @actual.has_text?(text, type)
       end
 
       def does_not_match?(actual)
         @actual = wrap(actual)
-        @actual.has_no_text?(type, text)
+        @actual.has_no_text?(text, type)
       end
 
       def failure_message_for_should
@@ -110,12 +110,12 @@ module Capybara
       HaveSelector.new(:css, css, options)
     end
 
-    def have_content(type=nil, text)
-      HaveText.new(type, text)
+    def have_content(text, type=nil)
+      HaveText.new(text, type)
     end
 
-    def have_text(type=nil, text)
-      HaveText.new(type, text)
+    def have_text(text, type=nil)
+      HaveText.new(text, type)
     end
 
     def have_title(title)


### PR DESCRIPTION
This is also the problem on REE at Travis:

https://travis-ci.org/jnicklas/capybara/jobs/5035304
