### PR TITLE
Cast value to string if input has maxlength option

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -149,7 +149,7 @@ private
     if text_or_password? && attribute_is_not_blank?(:maxlength)
       # Browser behavior for maxlength="0" is inconsistent, so we stick with
       # Firefox, allowing no input
-      value = value[0...self[:maxlength].to_i]
+      value = value.to_s[0...self[:maxlength].to_i]
     end
     if Array === value #Assert multiple attribute is present
       value.each do |v|


### PR DESCRIPTION
Hi

when we do

``` ruby
fill_in "test", :with => 1
```

``` html
<input type="text" name="test">
```

it works fine as 1 gets casted into string. When we do the same for

``` html
<input type="text" name="test" maxlength="100">
```

we get error

```
can't convert Range into Integer
```
