### PR TITLE
Add :tag_name option to the have_field Rspec matcher

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -300,10 +300,15 @@ module Capybara
       #
       #     page.has_field?('Email', :type => 'email')
       #
-      # @param [String] locator           The label, name or id of a field to check for
-      # @option options [String] :with    The text content of the field
-      # @option options [String] :type    The type attribute of the field
-      # @return [Boolean]                 Whether it exists
+      # And also to filter by the field tag name:
+      #
+      #     page.has_field?('Description', :tag_name => 'textarea')
+      #
+      # @param [String] locator             The label, name or id of a field to check for
+      # @option options [String] :with      The text content of the field
+      # @option options [String] :type      The type attribute of the field
+      # @option options [String] :tag_name  The tag name of the field
+      # @return [Boolean]                   Whether it exists
       #
       def has_field?(locator, options={})
         has_selector?(:field, locator, options)
@@ -314,10 +319,11 @@ module Capybara
       # Checks if the page or current node has no form field with the given
       # label, name or id. See {Capybara::Node::Matchers#has_field?}.
       #
-      # @param [String] locator           The label, name or id of a field to check for
-      # @option options [String] :with    The text content of the field
-      # @option options [String] :type    The type attribute of the field
-      # @return [Boolean]                 Whether it doesn't exist
+      # @param [String] locator             The label, name or id of a field to check for
+      # @option options [String] :with      The text content of the field
+      # @option options [String] :type      The type attribute of the field
+      # @option options [String] :tag_name  The tag name of the field
+      # @return [Boolean]                   Whether it doesn't exist
       #
       def has_no_field?(locator, options={})
         has_no_selector?(:field, locator, options)

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -43,6 +43,8 @@ module Capybara
         attr_name = name.to_s
         if attr_name == 'value'
           value
+        elsif attr_name == 'tag_name'
+          native.name
         elsif 'input' == tag_name and 'checkbox' == native[:type] and 'checked' == attr_name
           native['checked'] == 'checked'
         else

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -85,6 +85,7 @@ Capybara.add_selector(:field) do
   filter(:unchecked) { |node, value| (value ^ node.checked?) }
   filter(:with) { |node, with| node.value == with }
   filter(:type) { |node, type| node[:type] == type }
+  filter(:tag_name) { |node, tag_name| node[:tag_name] == tag_name}
 end
 
 Capybara.add_selector(:fieldset) do

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -10,7 +10,11 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def [](name)
-    native.attribute(name.to_s)
+    if name == :tag_name
+      native.tag_name
+    else 
+      native.attribute(name.to_s)
+    end
   rescue Selenium::WebDriver::Error::WebDriverError
     nil
   end

--- a/lib/capybara/spec/session/has_field_spec.rb
+++ b/lib/capybara/spec/session/has_field_spec.rb
@@ -50,6 +50,20 @@ Capybara::SpecHelper.spec '#has_field' do
       @session.should_not have_field('Description', :type => '')
     end
   end
+
+  context 'with tag_name' do
+    it "should be true if a field with the given tag_name is on the page" do
+      @session.should have_field('First Name', :tag_name => 'input')
+      @session.should have_field('Description', :tag_name => 'textarea')
+      @session.should have_field('Languages', :tag_name => 'select')
+    end
+
+    it "should be false if the given field with tag_name is not on the page" do
+      @session.should_not have_field('First Name', :tag_name => 'select')
+      @session.should_not have_field('Description', :tag_name => 'input')
+      @session.should_not have_field('Languages', :tag_name => 'textarea')
+    end
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_field' do
@@ -101,6 +115,20 @@ Capybara::SpecHelper.spec '#has_no_field' do
       @session.should have_no_field('First Name', :type => 'email')
       @session.should have_no_field('Html5 Email', :type => 'tel')
       @session.should have_no_field('Description', :type => '')
+    end
+  end
+
+  context 'with tag_name' do
+    it "should be true if a field with the given tag_name is not on the page" do
+      @session.should have_no_field('First Name', :tag_name => 'select')
+      @session.should have_no_field('Description', :tag_name => 'input')
+      @session.should have_no_field('Languages', :tag_name => 'textarea')
+    end
+
+    it "should be false if the given field with tag_name is on the page" do
+      @session.should_not have_no_field('First Name', :tag_name => 'input')
+      @session.should_not have_no_field('Description', :tag_name => 'textarea')
+      @session.should_not have_no_field('Languages', :tag_name => 'select')
     end
   end
 end


### PR DESCRIPTION
Following the discussion on https://github.com/jnicklas/capybara/issues/981 I took the liberty to implement an option to have_field() allowing to filter by tag name ('input', 'textarea', 'select'), ex:

`expect(page).to have_field('Description', :tag_name => 'textarea')`
