### PR TITLE
'textarea' and 'select' as a :type in Rspec matcher have_field()

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -300,6 +300,8 @@ module Capybara
       #
       #     page.has_field?('Email', :type => 'email')
       #
+      # Note: 'textarea' and 'select' are valid type values, matching the associated tag names.
+      #
       # @param [String] locator           The label, name or id of a field to check for
       # @option options [String] :with    The text content of the field
       # @option options [String] :type    The type attribute of the field

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -84,7 +84,13 @@ Capybara.add_selector(:field) do
   filter(:checked) { |node, value| not(value ^ node.checked?) }
   filter(:unchecked) { |node, value| (value ^ node.checked?) }
   filter(:with) { |node, with| node.value == with }
-  filter(:type) { |node, type| node[:type] == type }
+  filter(:type) do |node, type|
+    if ['textarea', 'select'].include?(type)
+      node.tag_name == type
+    else
+      node[:type] == type
+    end
+  end
 end
 
 Capybara.add_selector(:fieldset) do

--- a/lib/capybara/spec/session/has_field_spec.rb
+++ b/lib/capybara/spec/session/has_field_spec.rb
@@ -42,12 +42,16 @@ Capybara::SpecHelper.spec '#has_field' do
       @session.should have_field('First Name', :type => 'text')
       @session.should have_field('Html5 Email', :type => 'email')
       @session.should have_field('Html5 Tel', :type => 'tel')
+      @session.should have_field('Description', :type => 'textarea')
+      @session.should have_field('Languages', :type => 'select')
     end
 
     it "should be false if the given field is not on the page" do
-      @session.should_not have_field('First Name', :type => 'email')
+      @session.should_not have_field('First Name', :type => 'textarea')
       @session.should_not have_field('Html5 Email', :type => 'tel')
       @session.should_not have_field('Description', :type => '')
+      @session.should_not have_field('Description', :type => 'email')
+      @session.should_not have_field('Languages', :type => 'textarea')
     end
   end
 end
@@ -95,12 +99,16 @@ Capybara::SpecHelper.spec '#has_no_field' do
       @session.should_not have_no_field('First Name', :type => 'text')
       @session.should_not have_no_field('Html5 Email', :type => 'email')
       @session.should_not have_no_field('Html5 Tel', :type => 'tel')
+      @session.should_not have_no_field('Description', :type => 'textarea')
+      @session.should_not have_no_field('Languages', :type => 'select')
     end
 
     it "should be true if the given field is not on the page" do
-      @session.should have_no_field('First Name', :type => 'email')
+      @session.should have_no_field('First Name', :type => 'textarea')
       @session.should have_no_field('Html5 Email', :type => 'tel')
       @session.should have_no_field('Description', :type => '')
+      @session.should have_no_field('Description', :type => 'email')
+      @session.should have_no_field('Languages', :type => 'textarea')
     end
   end
 end


### PR DESCRIPTION
Possibility to use 'textarea' and 'select' as a :type in Rspec matcher have_field(). (New implementation of https://github.com/jnicklas/capybara/pull/992)
