### PR TITLE
Prevent nested synchronize calls on different nodes from affecting each other

### DIFF
--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -135,10 +135,6 @@ module Capybara
         # no op
       end
 
-      def unsynchronized
-        yield # simple nodes don't need to wait
-      end
-
       def title
         native.xpath("//title").first.text
       end

--- a/lib/capybara/query.rb
+++ b/lib/capybara/query.rb
@@ -36,20 +36,18 @@ module Capybara
     end
 
     def matches_filters?(node)
-      node.unsynchronized do
-        if options[:text]
-          regexp = options[:text].is_a?(Regexp) ? options[:text] : Regexp.escape(options[:text])
-          return false if not node.text(visible).match(regexp)
-        end
-        case visible
-          when :visible then return false unless node.visible?
-          when :hidden then return false if node.visible?
-        end
-        selector.custom_filters.each do |name, block|
-          return false if options.has_key?(name) and not block.call(node, options[name])
-        end
-        true
+      if options[:text]
+        regexp = options[:text].is_a?(Regexp) ? options[:text] : Regexp.escape(options[:text])
+        return false if not node.text(visible).match(regexp)
       end
+      case visible
+        when :visible then return false unless node.visible?
+        when :hidden then return false if node.visible?
+      end
+      selector.custom_filters.each do |name, block|
+        return false if options.has_key?(name) and not block.call(node, options[name])
+      end
+      true
     end
 
     def matches_count?(count)

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -46,6 +46,7 @@ module Capybara
     DSL_METHODS = NODE_METHODS + SESSION_METHODS
 
     attr_reader :mode, :app, :server
+    attr_accessor :synchronized
 
     def initialize(mode, app=nil)
       @mode = mode


### PR DESCRIPTION
This should prevent race conditions when calls to `synchronize` are nested.
