### PR TITLE
Support Gem::Version properly

### DIFF
--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -3,7 +3,7 @@ require 'capybara/dsl'
 
 Capybara.app = Rack::Builder.new do
   map "/" do
-    if Rails.version.to_f >= 3.0
+    if Rails.version.to_s >= "3.0"
       run Rails.application
     else # Rails 2
       use Rails::Rack::Static


### PR DESCRIPTION
I haven't tested this with rails < 4-master, but this fixes breakage where Rails.version now returns a Gem::Version and these comparisons fail there.  This is the offending commit afaict: https://github.com/rails/rails/commit/c07e1515f7c66f5599cbb3c7e9fe42e166bf3edc
