### PR TITLE
Add API for operation with modal (simple) dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,44 @@ that this may break with more complicated expressions:
 result = page.evaluate_script('4 + 4');
 ```
 
+### Modals
+
+In drivers which support it, you can accept, dismiss and respond to alerts, confirms and prompts.
+
+You can accept or dismiss alert messages by wrapping the code that produces an alert in a block:
+
+```ruby
+accept_alert do
+  click_link('Show Alert')
+end
+```
+
+You can accept or dismiss a confirmation by wrapping it in a block, as well:
+
+```ruby
+dismiss_confirm do
+  click_link('Show Confirm')
+end
+```
+
+You can accept or dismiss prompts as well. Additionally, you can respond to a prompt:
+
+```ruby
+respond_to_prompt 'Linus Torvalds' do
+  click_link('Show Prompt About Linux')
+end
+```
+
+All modal methods return the message that was presented. So, you can access the prompt message
+by assigning the return to a variable:
+
+```ruby
+message = respond_to_prompt 'Linus Torvalds' do
+  click_link('Show Prompt About Linux')
+end
+expect(message).to eq('Who is the chief architect of Linux?')
+```
+
 ### Debugging
 
 It can be useful to take a snapshot of the page as it currently is and take a

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -55,6 +55,14 @@ class Capybara::Driver::Base
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#within_window'
   end
 
+  def accept_modal(type, options={}, &blk)
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#accept_modal'
+  end
+
+  def dismiss_modal(type, &blk)
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#dismiss_modal'
+  end
+
   def invalid_element_errors
     []
   end

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -146,6 +146,21 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     browser.switch_to.window(handle, &blk)
   end
 
+  def accept_modal(type, options={}, &blk)
+    yield
+    modal.send_keys options[:response] if options[:response]
+    message = modal.text
+    modal.accept
+    message
+  end
+
+  def dismiss_modal(type, &blk)
+    yield
+    message = modal.text
+    modal.dismiss
+    message
+  end
+
   def quit
     @browser.quit if @browser
   rescue Errno::ECONNREFUSED
@@ -156,6 +171,12 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def invalid_element_errors
     [Selenium::WebDriver::Error::StaleElementReferenceError, Selenium::WebDriver::Error::UnhandledError, Selenium::WebDriver::Error::ElementNotVisibleError]
+  end
+
+private
+
+  def modal
+    @browser.switch_to.alert
   end
 
 end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -45,7 +45,11 @@ module Capybara
       :save_and_open_screenshot, :reset_session!, :response_headers,
       :status_code, :title, :has_title?, :has_no_title?, :current_scope
     ]
-    DSL_METHODS = NODE_METHODS + SESSION_METHODS
+    MODAL_METHODS = [
+      :accept_alert, :accept_confirm, :dismiss_confirm, :accept_prompt,
+      :dismiss_prompt, :respond_to_prompt
+    ]
+    DSL_METHODS = NODE_METHODS + SESSION_METHODS + MODAL_METHODS
 
     attr_reader :mode, :app, :server
     attr_accessor :synchronized
@@ -365,6 +369,56 @@ module Capybara
     def evaluate_script(script)
       @touched = true
       driver.evaluate_script(script)
+    end
+
+    ##
+    #
+    # Execute the block, accepting a alert.
+    #
+    def accept_alert(&blk)
+      driver.accept_modal(:alert, &blk)
+    end
+
+    ##
+    #
+    # Execute the block, accepting a confirm.
+    #
+    def accept_confirm(&blk)
+      driver.accept_modal(:confirm, &blk)
+    end
+
+    ##
+    #
+    # Execute the block, dismissing a confirm.
+    #
+    def dismiss_confirm(&blk)
+      driver.dismiss_modal(:confirm, &blk)
+    end
+
+    ##
+    #
+    # Execute the block, accepting a prompt.
+    #
+    def accept_prompt(&blk)
+      driver.accept_modal(:prompt, &blk)
+    end
+
+    ##
+    #
+    # Execute the block, dismissing a prompt.
+    #
+    def dismiss_prompt(&blk)
+      driver.dismiss_modal(:prompt, &blk)
+    end
+
+    ##
+    #
+    # Execute the block, responding with the provided value.
+    #
+    # @param [String] response   Response to provide to the prompt
+    #
+    def respond_to_prompt(response, &blk)
+      driver.accept_modal(:prompt, {response: response}, &blk)
     end
 
     ##

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -67,4 +67,30 @@ $(function() {
     e.preventDefault();
     $(this).after('<a id="has-been-right-clicked" href="#">Has been right clicked</a>');
   });
+  $('#open-alert').click(function() {
+    alert('Alert opened');
+    $(this).attr('opened', 'true');
+  });
+  $('#open-delayed-alert').click(function() {
+    var link = this;
+    setTimeout(function() {
+      alert('Delayed alert opened');
+      $(link).attr('opened', 'true');
+    }, 250);
+  });
+  $('#open-confirm').click(function() {
+    if(confirm('Confirm opened')) {
+      $(this).attr('confirmed', 'true');
+    } else {
+      $(this).attr('confirmed', 'false');
+    }
+  });
+  $('#open-prompt').click(function() {
+    var response = prompt('Prompt opened');
+    if(response === null) {
+      $(this).attr('response', 'dismissed');
+    } else {
+      $(this).attr('response', response);
+    }
+  });
 });

--- a/lib/capybara/spec/session/accept_alert_spec.rb
+++ b/lib/capybara/spec/session/accept_alert_spec.rb
@@ -1,0 +1,35 @@
+Capybara::SpecHelper.spec '#accept_alert', :requires => [:modals] do
+  before do
+    @session.visit('/with_js')
+  end
+
+  it "should accept the alert" do
+    @session.accept_alert do
+      @session.click_link('Open alert')
+    end
+    expect(@session).to have_xpath("//a[@id='open-alert' and @opened='true']")
+  end
+
+  it "should return the message presented" do
+    message = @session.accept_alert do
+      @session.click_link('Open alert')
+    end
+    expect(message).to eq('Alert opened')
+  end
+
+  context "with an asynchronous alert" do
+    it "should accept the alert" do
+      @session.accept_alert do
+        @session.click_link('Open delayed alert')
+      end
+      expect(@session).to have_xpath("//a[@id='open-delayed-alert' and @opened='true']")
+    end
+
+    it "should return the message presented" do
+      message = @session.accept_alert do
+        @session.click_link('Open delayed alert')
+      end
+      expect(message).to eq('Delayed alert opened')
+    end
+  end
+end

--- a/lib/capybara/spec/session/accept_confirm_spec.rb
+++ b/lib/capybara/spec/session/accept_confirm_spec.rb
@@ -1,0 +1,19 @@
+Capybara::SpecHelper.spec '#accept_confirm', :requires => [:modals] do
+  before do
+    @session.visit('/with_js')
+  end
+
+  it "should accept the confirm" do
+    @session.accept_confirm do
+      @session.click_link('Open confirm')
+    end
+    expect(@session).to have_xpath("//a[@id='open-confirm' and @confirmed='true']")
+  end
+
+  it "should return the message presented" do
+    message = @session.accept_confirm do
+      @session.click_link('Open confirm')
+    end
+    expect(message).to eq('Confirm opened')
+  end
+end

--- a/lib/capybara/spec/session/accept_prompt_spec.rb
+++ b/lib/capybara/spec/session/accept_prompt_spec.rb
@@ -1,0 +1,19 @@
+Capybara::SpecHelper.spec '#accept_prompt', :requires => [:modals] do
+  before do
+    @session.visit('/with_js')
+  end
+
+  it "should accept the prompt with no message" do
+    @session.accept_prompt do
+      @session.click_link('Open prompt')
+    end
+    expect(@session).to have_xpath("//a[@id='open-prompt' and @response='']")
+  end
+
+  it "should return the message presented" do
+    message = @session.accept_prompt do
+      @session.click_link('Open prompt')
+    end
+    expect(message).to eq('Prompt opened')
+  end
+end

--- a/lib/capybara/spec/session/dismiss_confirm_spec.rb
+++ b/lib/capybara/spec/session/dismiss_confirm_spec.rb
@@ -1,0 +1,19 @@
+Capybara::SpecHelper.spec '#dismiss_confirm', :requires => [:modals] do
+  before do
+    @session.visit('/with_js')
+  end
+
+  it "should dismiss the confirm" do
+    @session.dismiss_confirm do
+      @session.click_link('Open confirm')
+    end
+    expect(@session).to have_xpath("//a[@id='open-confirm' and @confirmed='false']")
+  end
+
+  it "should return the message presented" do
+    message = @session.dismiss_confirm do
+      @session.click_link('Open confirm')
+    end
+    expect(message).to eq('Confirm opened')
+  end
+end

--- a/lib/capybara/spec/session/dismiss_prompt_spec.rb
+++ b/lib/capybara/spec/session/dismiss_prompt_spec.rb
@@ -1,0 +1,19 @@
+Capybara::SpecHelper.spec '#dismiss_prompt', :requires => [:modals] do
+  before do
+    @session.visit('/with_js')
+  end
+
+  it "should dismiss the prompt" do
+    @session.dismiss_prompt do
+      @session.click_link('Open prompt')
+    end
+    expect(@session).to have_xpath("//a[@id='open-prompt' and @response='dismissed']")
+  end
+
+  it "should return the message presented" do
+    message = @session.dismiss_prompt do
+      @session.click_link('Open prompt')
+    end
+    expect(message).to eq('Prompt opened')
+  end
+end

--- a/lib/capybara/spec/session/respond_to_prompt_spec.rb
+++ b/lib/capybara/spec/session/respond_to_prompt_spec.rb
@@ -1,0 +1,19 @@
+Capybara::SpecHelper.spec '#respond_to_prompt', :requires => [:modals] do
+  before do
+    @session.visit('/with_js')
+  end
+
+  it "should accept the prompt" do
+    @session.respond_to_prompt 'the response' do
+      @session.click_link('Open prompt')
+    end
+    expect(@session).to have_xpath("//a[@id='open-prompt' and @response='the response']")
+  end
+
+  it "should return the message presented" do
+    message = @session.respond_to_prompt 'the response' do
+      @session.click_link('Open prompt')
+    end
+    expect(message).to eq('Prompt opened')
+  end
+end

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -72,6 +72,22 @@
         
     <p id="click-test">Click me</p>
 
+    <p>
+      <a href="#" id="open-alert">Open alert</a>
+    </p>
+
+    <p>
+      <a href="#" id="open-delayed-alert">Open delayed alert</a>
+    </p>
+
+    <p>
+      <a href="#" id="open-confirm">Open confirm</a>
+    </p>
+
+    <p>
+      <a href="#" id="open-prompt">Open prompt</a>
+    </p>
+
     <script type="text/javascript">
       // a javascript comment
       var aVar = 123;

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -7,6 +7,7 @@ end
 
 Capybara::SpecHelper.run_specs TestClass.new, "DSL", :capybara_skip => [
   :js,
+  :modals,
   :screenshot,
   :frames,
   :windows,

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -6,6 +6,7 @@ end
 
 Capybara::SpecHelper.run_specs TestSessions::RackTest, "RackTest", :capybara_skip => [
   :js,
+  :modals,
   :screenshot,
   :frames,
   :windows,


### PR DESCRIPTION
Add an official notification API for handling alerts, confirms and prompts. See README for API usage.

The default naming is singular because Capybara ships with a Selenium driver which can only deal with a single alert/confirm/prompt at a time. While other drivers can support multiple notifications, I figured it would be best to stay consistent with Capybara core. I did, however, alias the methods in their plural form so that they would read better when dealing with multiple notifications.
