### PR TITLE
Tiny rdoc fix in Capybara::Node::Actions [ci skip]

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -19,7 +19,7 @@ module Capybara
       # Finds a link by id or text and clicks it. Also looks at image
       # alt text inside the link.
       #
-      # @param [String] locator      Text, id or text of link
+      # @param [String] locator      Text or id of link
       # @param options
       # @option options [String] :href    The value the href attribute must be
       #


### PR DESCRIPTION
'Text' was specified twice in the param of click_link's RDoc.  Remove it.
