### PR TITLE
Default to focusmanager.testmode=true in Firefox profile

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -1,3 +1,5 @@
+require 'selenium-webdriver'
+
 class Capybara::Selenium::Driver < Capybara::Driver::Base
   DEFAULT_OPTIONS = {
     :browser => :firefox


### PR DESCRIPTION
This is the change from pull request #951 rebased against master with one more change to restore a require statement that was removed in the interim.

I'm submitting it as a new PR to trigger a new Travis CI build.
