### PR TITLE
Ignore form submit clicks when no associated form

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -52,7 +52,8 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
       driver.follow(method, self[:href].to_s)
     elsif (tag_name == 'input' and %w(submit image).include?(type)) or
         ((tag_name == 'button') and type.nil? or type == "submit")
-      Capybara::RackTest::Form.new(driver, form).submit(self)
+      associated_form = form
+      Capybara::RackTest::Form.new(driver, associated_form).submit(self) if associated_form
     end
   end
 

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -225,6 +225,12 @@ Capybara::SpecHelper.spec '#click_button' do
     end
   end
 
+  context "with submit button not associated with any form" do
+    it "should not error when clicked" do
+      lambda { @session.click_button('no_form_button') }.should_not raise_error
+    end
+  end
+
   context "with alt given on an image button" do
     it "should submit the associated form" do
       @session.click_button('oh hai thar')
@@ -236,6 +242,7 @@ Capybara::SpecHelper.spec '#click_button' do
       extract_results(@session)['first_name'].should == 'John'
     end
   end
+  
 
   context "with value given on an image button" do
     it "should submit the associated form" do

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -283,6 +283,8 @@
   <button type="submit" name="form[other_form_button]" value="other_form_button" form="form1">Form1</button>
 </form>
 
+<button type="submit" name="form[no_form_button]" value="no_form_button">No Form</button>
+
 <textarea name="form[outside_textarea]" form="form1">Some text here</textarea>
 <select name="form[outside_select]" form="form1">
   <option>Lisp</option>
@@ -402,3 +404,5 @@
     <input type="submit" name="form[no_action]" value="No Action" />
   </p>
 </form>
+
+


### PR DESCRIPTION
This ignores clicks on form submitting elements when there is no associated form in racktest (as browsers do)
