### PR TITLE
Send a backspace before clearing fields with JavaScript.

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -38,6 +38,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
       native.send_keys(*path_names)
     elsif tag_name == 'textarea' or tag_name == 'input'
       #script can change a readonly element which user input cannot, so dont execute if readonly
+      native.send_keys(:backspace)
       driver.browser.execute_script "arguments[0].value = ''", native unless self[:readonly]
       native.send_keys(value.to_s)
     end


### PR DESCRIPTION
This ensures that appropriate events are fired in the browser without causing performance problems.

Fixes jnicklas/capybara#1028
