### PR TITLE
Implemented Capybara.before_action & Capybara.after_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,19 @@ that this may break with more complicated expressions:
 result = page.evaluate_script('4 + 4');
 ```
 
+Some javascript frameworks (like [Ember.js](http://www.emberjs.com/)) use the concept of a run loop. For these kinds 
+of frameworks it can beneficial to start a run loop before a Capybara action and end the run loop directly after the
+Capybara action. Capybara supports this by setting the `Capybara.before_action` and the `Capybara.after_action`. You can set these in your `spec_helper.rb`.
+
+```ruby
+Capybara.before_action = "Ember.run.start();"
+Capybara.before_action = "Ember.run.end();"
+```
+
+To use this feature, the driver you use *MUST* support the `page_execute`. If you drivers doesn't support it, the
+directives are ignored.
+
+
 ### Debugging
 
 It can be useful to take a snapshot of the page as it currently is and take a

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -18,6 +18,7 @@ module Capybara
     attr_accessor :asset_host, :app_host, :run_server, :default_host, :always_include_port
     attr_accessor :server_host, :server_port, :exact, :match, :exact_options, :visible_text_only
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
+    attr_accessor :before_action, :after_action
     attr_accessor :save_and_open_page_path, :automatic_reload, :raise_server_errors
     attr_writer :default_driver, :current_driver, :javascript_driver, :session_name
     attr_accessor :app
@@ -39,6 +40,8 @@ module Capybara
     # [run_server = Boolean]              Whether to start a Rack server for the given Rack app (Default: true)
     # [default_selector = :css/:xpath]    Methods which take a selector use the given type by default (Default: CSS)
     # [default_wait_time = Integer]       The number of seconds to wait for asynchronous processes to finish (Default: 2)
+    # [before_action = String]            The Javascript command that is executed before every action (Default: nil)
+    # [after_action = String]             The Javascript command that is executed after every action (Default: nil)
     # [ignore_hidden_elements = Boolean]  Whether to ignore hidden elements on the page (Default: false)
     # [automatic_reload = Boolean]        Whether to automatically reload elements as Capybara is waiting (Default: true)
     # [save_and_open_page_path = String]  Where to put pages saved through save_and_open_page (Default: Dir.pwd)

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -3,10 +3,24 @@ Capybara::SpecHelper.spec '#click_button' do
     @session.visit('/form')
   end
 
+  it_behaves_like "acknowledge Capybara.before_action" do
+    subject do
+      @session.visit('/with_js')
+      @session.click_button('Fire Ajax Request')
+    end
+
+  end
+
+  it_behaves_like "acknowledge Capybara.after_action" do
+    subject do
+      @session.visit('/with_js')
+      @session.click_button('Fire Ajax Request')
+    end
+  end
+
   it "should wait for asynchronous load", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.click_button('New Here')
   end
 
   it "casts to string" do

--- a/lib/capybara/spec/session/click_link_or_button_spec.rb
+++ b/lib/capybara/spec/session/click_link_or_button_spec.rb
@@ -23,6 +23,22 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
     extract_results(@session)['first_name'].should == 'John'
   end
 
+  it_behaves_like "acknowledge Capybara.before_action" do
+    subject do
+      @session.visit('/with_js')
+      @session.click_link_or_button('Click me')
+    end
+
+  end
+
+  it_behaves_like "acknowledge Capybara.after_action" do
+    subject do
+      @session.visit('/with_js')
+      @session.click_link_or_button('Click me')
+    end
+  end
+
+
   it "should wait for asynchronous load", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -3,6 +3,22 @@ Capybara::SpecHelper.spec '#click_link' do
     @session.visit('/with_html')
   end
 
+  it_behaves_like "acknowledge Capybara.before_action" do
+    subject do
+      @session.visit('/with_js')
+      @session.click_link('Click me')
+    end
+
+  end
+
+  it_behaves_like "acknowledge Capybara.after_action" do
+    subject do
+      @session.visit('/with_js')
+      @session.click_link('Click me')
+    end
+  end
+
+
   it "should wait for asynchronous load", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')

--- a/lib/capybara/spec/shared_examples.rb
+++ b/lib/capybara/spec/shared_examples.rb
@@ -1,0 +1,55 @@
+shared_examples "acknowledge Capybara.before_action" do
+  before do
+    Capybara.before_action = "before_action_is_called = true"
+  end
+
+  context "Capybara.before_action is specified" do
+
+    context "on a driver capable of execute_script" do
+
+      before do
+        @session.evaluate_script("before_action_is_called = false" )
+      end
+
+
+      it "calls the before action", :requires => [:js] do
+        expect { subject}.to change{@session.evaluate_script('before_action_is_called')}.from(false).to(true)
+      end
+    end
+
+    context "on a driver not capable of execute_script" do
+      it "calls the before action" do
+        expect { subject}.to_not raise_error(Capybara::NotSupportedByDriverError)
+      end
+    end
+
+  end
+
+end
+
+shared_examples "acknowledge Capybara.after_action" do
+
+  before do
+    Capybara.after_action = "after_action_is_called = true"
+  end
+
+    context "on a driver capable of execute_script" do
+
+      before do
+        @session.evaluate_script("after_action_is_called = false" )
+      end
+
+
+      it "calls the after action", :requires => [:js] do
+        expect { subject}.to change{@session.evaluate_script('after_action_is_called')}.from(false).to(true)
+      end
+    end
+
+    context "on a driver not capable of execute_script" do
+      it "calls the before action" do
+        expect { subject}.to_not raise_error(Capybara::NotSupportedByDriverError)
+      end
+    end
+
+
+end

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "rspec"
 require "capybara"
 require "capybara/rspec" # Required here instead of in rspec_spec to avoid RSpec deprecation warning
 require "capybara/spec/test_app"
+require "capybara/spec/shared_examples"
 require "nokogiri"
 
 module Capybara


### PR DESCRIPTION
Use Capybara.before_action and Capybara.after_action to start & stop a run loop in some of the frameworks that have a run loop.
