### PR TITLE
within to send new_scope on yield (1.1)

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -189,7 +189,7 @@ module Capybara
                   end
       begin
         scopes.push(new_scope)
-        yield
+        yield(new_scope)
       ensure
         scopes.pop
       end


### PR DESCRIPTION
Hi,

(Same as #1076 but for 1.1 because I am not sure yet we can upgrade to 2.0 easily)

because I need the scope to write an rspec matcher such as ....

``` ruby
    within(level_selector) do |scope|
        expect(scope.text).to have_content(header_text)
    end
```

the only solution I found was to add this to capybara.

thanks
