### PR TITLE
Remove :focus tag from fill_in_spec test

### DIFF
--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -109,7 +109,7 @@ Capybara::SpecHelper.spec "#fill_in" do
     extract_results(@session)['first_name'].should == 'Harry'
   end
 
-  it "casts to string if field has maxlength", :focus => true do
+  it "casts to string if field has maxlength" do
     @session.fill_in(:'form_zipcode', :with => 1234567)
     @session.click_button('awesome')
     extract_results(@session)['zipcode'].should == '12345'


### PR DESCRIPTION
Capybara 2.1.0 and above has a :focus tag on one of the fill_in_spec tests.  This removes it.
