### PR TITLE
Add double_click and right_click to element - support in selenium

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -40,7 +40,15 @@ module Capybara
       def click
         raise NotImplementedError
       end
-
+      
+      def right_click
+        raise NotImplmentedError
+      end
+      
+      def double_click
+        raise NotImplementedError
+      end
+      
       def hover
         raise NotImplementedError
       end

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -120,6 +120,22 @@ module Capybara
 
       ##
       #
+      # Right Click the Element
+      #
+      def right_click
+        synchronize { base.right_click }
+      end
+
+      ##
+      #
+      # Double Click the Element
+      #
+      def double_click
+        synchronize { base.double_click }
+      end
+
+      ##
+      #
       # Hover on the Element
       #
       def hover

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -57,6 +57,14 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   def click
     native.click
   end
+  
+  def right_click
+    driver.browser.action.context_click(native).perform
+  end
+  
+  def double_click
+    driver.browser.action.double_click(native).perform
+  end
 
   def hover
     driver.browser.action.move_to(native).perform

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -60,4 +60,11 @@ $(function() {
       $('title').text('changed title')
     }, 250)
   });
+  $('#click-test').dblclick(function() {
+    $(this).after('<a id="has-been-double-clicked" href="#">Has been double clicked</a>');
+  });
+  $('#click-test').bind('contextmenu', function(e) {
+    e.preventDefault();
+    $(this).after('<a id="has-been-right-clicked" href="#">Has been right clicked</a>');
+  });
 });

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -185,6 +185,22 @@ Capybara::SpecHelper.spec "node" do
       @session.find(:css, '.hidden_until_hover', :visible => false).should be_visible
     end
   end
+  
+  describe '#double_click', :requires => [:js] do
+    it "should double click an element" do
+      @session.visit('/with_js')
+      @session.find(:css, '#click-test').double_click
+      @session.find(:css, '#has-been-double-clicked').should be
+    end
+  end
+
+  describe '#right_click', :requires => [:js] do
+    it "should double click an element" do
+      @session.visit('/with_js')
+      @session.find(:css, '#click-test').right_click
+      @session.find(:css, '#has-been-right-clicked').should be
+    end
+  end  
 
   describe '#reload', :requires => [:js] do
     context "without automatic reload" do

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -61,6 +61,8 @@
     <p>
       <a href="#" id="change-title">Change title</a>
     </p>
+        
+    <p id="click-test">Click me</p>
 
     <script type="text/javascript">
       // a javascript comment


### PR DESCRIPTION
This adds double_click and right_click to the Node API with tests and support for Selenium
