### PR TITLE
Enable focusmanager.testmode in Selenium tests.

### DIFF
--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -1,4 +1,11 @@
 require 'spec_helper'
+require 'selenium-webdriver'
+
+Capybara.register_driver :selenium do |app|
+  profile = Selenium::WebDriver::Firefox::Profile.new
+  profile["focusmanager.testmode"] = true
+  Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => profile)
+end
 
 module TestSessions
   Selenium = Capybara::Session.new(:selenium, TestApp)


### PR DESCRIPTION
This forces Firefox to emit change events even when it's in the background.

Note that this only changes the setting for Capybara's own tests. It is an
alternative to pull request #1058, which changed the default for the Selenium
driver.
