### PR TITLE
Alias Capybara::Node::Element#set to Capybara::Node::Element#value=

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -94,6 +94,8 @@ module Capybara
         synchronize { base.set(value) }
       end
 
+      alias :value= :set
+
       ##
       #
       # Select this node if is an option element inside a select tag


### PR DESCRIPTION
This makes #value act more like a Ruby attr_accessor.

``` ruby
find('input').value                #=> ''
find('input').value = 'new value'
find('input').value                #=> 'new value'
```

I wasn't sure if tests were necessary for a one-line method aliasing, please let
me know if they are and I'll add some.

Cheers,
Andrew
