### PR TITLE
Avoid NoMethodError when calling Capybara::Selenium::Driver#quit 

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -137,7 +137,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   end
 
   def quit
-    @browser.quit
+    @browser.quit if @browser
   rescue Errno::ECONNREFUSED
     # Browser must have already gone
   end


### PR DESCRIPTION
If driver if not started, and we call the quit method, we got an ugly
# <NoMethodError: undefined method `quit' for nil:NilClass>

.../capybara-2.1.0/lib/capybara/selenium/driver.rb:140:in `quit'

Useful for those like me who use Capybara APIs

Cheers
