### PR TITLE
Add a matcher for meta tags

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -458,6 +458,23 @@ module Capybara
         self.eql?(other) or (other.respond_to?(:base) and base == other.base)
       end
 
+      ##
+      #
+      # Checks if the page or current node has a meta tag with the given name:
+      #
+      #    page.has_meta?('description')
+      #    page.has_meta?('description', :content => 'People')
+      #
+      # @param [String] name                           The name of a meta tag
+      # @return [Boolean]                              Whether it exist
+      #
+      def has_meta?(name, options={})
+        locator = %![name="#{name}"]!
+        locator += %![content="#{options.delete(:content)}"]! if options[:content]
+
+        has_selector?(:meta, locator, { :visible => false }.merge(options))
+      end
+
     private
 
       def text_found?(*args)

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -34,7 +34,8 @@ module Capybara
       :has_no_field?, :has_checked_field?, :has_unchecked_field?,
       :has_no_table?, :has_table?, :unselect, :has_select?, :has_no_select?,
       :has_selector?, :has_no_selector?, :click_on, :has_no_checked_field?,
-      :has_no_unchecked_field?, :query, :assert_selector, :assert_no_selector
+      :has_no_unchecked_field?, :query, :assert_selector, :assert_no_selector,
+      :has_meta?
     ]
     SESSION_METHODS = [
       :body, :html, :current_url, :current_host, :evaluate_script, :source,


### PR DESCRIPTION
Add the `has_meta?` method to allow testing for existence of meta tags:

``` ruby
page.has_meta?('description')
page.has_meta?('description', :content => 'People')
```
