### PR TITLE
Add last finder

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -144,6 +144,21 @@ module Capybara
         all(*args).first
       end
 
+      ##
+      #
+      # Find the last element on the page matching the given selector
+      # and options, or nil if no element matches.
+      #
+      # @overload last([kind], locator, options)
+      #   @param [:css, :xpath] kind                 The type of selector
+      #   @param [String] locator                    The selector
+      #   @param [Hash] options                      Additional options; see {#all}
+      # @return [Capybara::Element]                  The found element or nil
+      #
+      def last(*args)
+        all(*args).last
+      end
+
     private
 
       def resolve_query(query, exact=nil)

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -25,7 +25,7 @@ module Capybara
   #
   class Session
     NODE_METHODS = [
-      :all, :first, :attach_file, :text, :check, :choose,
+      :all, :first, :last, :attach_file, :text, :check, :choose,
       :click_link_or_button, :click_button, :click_link, :field_labeled,
       :fill_in, :find, :find_button, :find_by_id, :find_field, :find_link,
       :has_content?, :has_text?, :has_css?, :has_no_content?, :has_no_text?,

--- a/lib/capybara/spec/session/last_spec.rb
+++ b/lib/capybara/spec/session/last_spec.rb
@@ -1,0 +1,88 @@
+Capybara::SpecHelper.spec '#last' do
+  before do
+    @session.visit('/with_html')
+  end
+
+  it "should find the last element using the given locator" do
+    @session.last('//h2').text.should == 'Header Class Test Five'
+    @session.last("//input[@id='test_field']")[:value].should == 'monkey'
+  end
+
+  it "should return nil when nothing was found" do
+    @session.last('//div[@id="nosuchthing"]').should be_nil
+  end
+
+  it "should accept an XPath instance" do
+    @session.visit('/form')
+    @xpath = XPath::HTML.fillable_field('First Name')
+    @session.last(@xpath).value.should == 'John'
+  end
+
+  context "with css selectors" do
+    it "should find the last element using the given selector" do
+      @session.last(:css, 'h2').text.should == 'Header Class Test Five'
+      @session.last(:css, "input[id='test_field']")[:value].should == 'monkey'
+    end
+  end
+
+  context "with xpath selectors" do
+    it "should find the last element using the given locator" do
+      @session.last(:xpath, '//h2').text.should == 'Header Class Test Five'
+      @session.last(:xpath, "//input[@id='test_field']")[:value].should == 'monkey'
+    end
+  end
+
+  context "with css as default selector" do
+    before { Capybara.default_selector = :css }
+    it "should find the last element using the given locator" do
+      @session.last('h2').text.should == 'Header Class Test Five'
+      @session.last("input[id='test_field']")[:value].should == 'monkey'
+    end
+  end
+
+  context "with visible filter" do
+    it "should only find visible nodes when true" do
+      @session.last(:css, "a#invisible", :visible => true).should be_nil
+    end
+
+    it "should find nodes regardless of whether they are invisible when false" do
+      @session.last(:css, "a#invisible", :visible => false).should_not be_nil
+      @session.last(:css, "a#visible", :visible => false).should_not be_nil
+    end
+
+    it "should find nodes regardless of whether they are invisible when :all" do
+      @session.last(:css, "a#invisible", :visible => :all).should_not be_nil
+      @session.last(:css, "a#visible", :visible => :all).should_not be_nil
+    end
+
+    it "should find only hidden nodes when :hidden" do
+      @session.last(:css, "a#invisible", :visible => :hidden).should_not be_nil
+      @session.last(:css, "a#visible", :visible => :hidden).should be_nil
+    end
+
+    it "should find only visible nodes when :visible" do
+      @session.last(:css, "a#invisible", :visible => :visible).should be_nil
+      @session.last(:css, "a#visible", :visible => :visible).should_not be_nil
+    end
+
+    it "should default to Capybara.ignore_hidden_elements" do
+      Capybara.ignore_hidden_elements = true
+      @session.last(:css, "a#invisible").should be_nil
+      Capybara.ignore_hidden_elements = false
+      @session.last(:css, "a#invisible").should_not be_nil
+      @session.last(:css, "a").should_not be_nil
+    end
+  end
+
+  context "within a scope" do
+    before do
+      @session.visit('/with_scope')
+    end
+
+    it "should find the last element using the given locator" do
+      @session.within(:xpath, "//div[@id='for_bar']") do
+        @session.last('.//form').should_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add an official `last` finder, which can be used as such:

``` ruby
last('.item').click
```

A bit nicer than `all('.item').last.click`.
