### PR TITLE
Push nil scope when switching windows and frames to fix issue 1103

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -262,9 +262,12 @@ module Capybara
     #   @param [String] name           name of a frame
     #
     def within_frame(frame_handle)
+      scopes.push(nil)
       driver.within_frame(frame_handle) do
         yield
       end
+    ensure
+      scopes.pop
     end
 
     ##
@@ -275,7 +278,10 @@ module Capybara
     # @param [String] handle of the window
     #
     def within_window(handle, &blk)
+      scopes.push(nil)
       driver.within_window(handle, &blk)
+    ensure
+      scopes.pop
     end
 
     ##
@@ -382,7 +388,7 @@ module Capybara
     end
 
     def current_scope
-      scopes.last
+      scopes.last || document
     end
 
   private

--- a/lib/capybara/spec/session/within_frame_spec.rb
+++ b/lib/capybara/spec/session/within_frame_spec.rb
@@ -42,7 +42,7 @@ Capybara::SpecHelper.spec '#within_frame', :requires => [:frames] do
       end    
     end
   end
-  it "should reset scope when changing frames", tw: true do
+  it "should reset scope when changing frames" do
     @session.within(:css, '#divInMainWindow') do
       @session.within_frame 'parentFrame' do
         @session.has_selector?(:css, "iframe#childFrame").should be_true

--- a/lib/capybara/spec/session/within_window_spec.rb
+++ b/lib/capybara/spec/session/within_window_spec.rb
@@ -35,4 +35,11 @@ Capybara::SpecHelper.spec '#within_window', :requires => [:windows] do
     end
     @session.find("//*[@id='divInMainWindow']").text.should eql 'This is the text for divInMainWindow'
   end
+  it "should reset scope when switching windows" do
+    @session.within(:css, '#divInMainWindow') do
+      @session.within_window("secondPopup") do
+        @session.find("//*[@id='divInPopupTwo']").text.should eql 'This is the text of divInPopupTwo'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pushes a nil scope onto the scopes stack when switching windows and frames, and then interprets that nil as document while current_scope is called.  This has the effect of changing the scope to be the document in the switched to frame or window.  Hopefully this works across multiple drivers, the other option would be to make each drivers within_frame and within_window responsible for updating the scope.
