### PR TITLE
Permit nested features

### DIFF
--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -7,10 +7,12 @@ module Capybara
         alias :xscenario :xit
         alias :given :let
         alias :given! :let!
+        alias :feature :describe
       end
     end
   end
 end
+
 
 def self.feature(*args, &block)
   options = if args.last.is_a?(Hash) then args.pop else {} end

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -34,6 +34,21 @@ feature "Capybara's feature DSL" do
   scenario "doesn't pollute the Object namespace" do
     Object.new.respond_to?(:feature, true).should be_false
   end
+
+  feature 'nested features' do
+    scenario 'work as expected' do
+      visit '/'
+      page.should have_content 'Hello world!'
+    end
+
+    scenario 'are marked in the metadata as capybara_feature' do
+      example.metadata[:capybara_feature].should be_true
+    end
+
+    scenario 'have a type of :feature' do
+      example.metadata[:type].should eq :feature
+    end
+  end
 end
 
 feature "given and given! aliases to let and let!" do


### PR DESCRIPTION
In 2.1.0 using nested features such as: 

```
feature 'big main feature' do
  feature 'sub feature' do
    scenario 'behaves well' do
       .......
    end
  end
end
```

results in a NoMethodError

```
/Users/dev/devel/capybara/spec/rspec/features_spec.rb:38:in `block in <top (required)>': undefined method `feature' for #<Class:0x007fb6c69049b0> (NoMethodError)
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/example_group.rb:245:in `module_eval'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/example_group.rb:245:in `subclass'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/example_group.rb:231:in `describe'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/dsl.rb:18:in `describe'
    from /Users/dev/devel/capybara/lib/capybara/rspec/features.rb:22:in `feature'
    from /Users/dev/devel/capybara/spec/rspec/features_spec.rb:8:in `<top (required)>'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/configuration.rb:896:in `load'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/configuration.rb:896:in `each'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/runner.rb:80:in `run'
    from /Users/dev/.rvm/gems/ruby-1.9.3-p392@oceans/gems/rspec-core-2.14.1/lib/rspec/core/runner.rb:17:in `block in autorun'
```

This might not the most common use-case but rspec does permit nested `describe`s so capybara should probably behave similarly.

In the future if `self.feature` becomes more complex it might be better to move it to another module and then extend it instead.
