### PR TITLE
Support rspec 3

### DIFF
--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -7,6 +7,12 @@ require 'capybara/rspec/features'
 RSpec.configure do |config|
   config.include Capybara::DSL, :type => :feature
   config.include Capybara::RSpecMatchers, :type => :feature
+
+  # A work-around to support accessing the current example that works in both
+  # RSpec 2 and RSpec 3.
+  fetch_current_example = RSpec.respond_to?(:current_example) ?
+    proc { RSpec.current_example } : proc { |context| context.example }
+
   # The before and after blocks must run instantaneously, because Capybara
   # might not actually be used in all examples where it's included.
   config.after do
@@ -17,6 +23,7 @@ RSpec.configure do |config|
   end
   config.before do
     if self.class.include?(Capybara::DSL)
+      example = fetch_current_example.call(self)
       Capybara.current_driver = Capybara.javascript_driver if example.metadata[:js]
       Capybara.current_driver = example.metadata[:driver] if example.metadata[:driver]
     end


### PR DESCRIPTION
This change addresses issue #1122. This will allow RSpec 3 development to continue working against capybara. This is because `example` will no longer be explicitly available in hooks.
