### PR TITLE
Allows passing options through has_button? to has_selector?

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -280,8 +280,8 @@ module Capybara
       # @param [String] locator      The text, value or id of a button to check for
       # @return [Boolean]            Whether it exists
       #
-      def has_button?(locator)
-        has_selector?(:button, locator)
+      def has_button?(locator, options={})
+        has_selector?(:button, locator, options)
       end
 
       ##
@@ -292,8 +292,8 @@ module Capybara
       # @param [String] locator      The text, value or id of a button to check for
       # @return [Boolean]            Whether it doesn't exist
       #
-      def has_no_button?(locator)
-        has_no_selector?(:button, locator)
+      def has_no_button?(locator, options={})
+        has_no_selector?(:button, locator, options)
       end
 
       ##

--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -126,8 +126,8 @@ module Capybara
       HaveSelector.new(:link, locator, options)
     end
 
-    def have_button(locator)
-      HaveSelector.new(:button, locator)
+    def have_button(locator, options={})
+      HaveSelector.new(:button, locator, options)
     end
 
     def have_field(locator, options={})

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -9,8 +9,20 @@ Capybara::SpecHelper.spec '#has_button?' do
     @session.should have_button(:'crap321')
   end
 
+  it "should be true for disabled buttons if :disabled => true" do
+    @session.should have_button('Disabled button', :disabled => true)
+  end
+
   it "should be false if the given button is not on the page" do
     @session.should_not have_button('monkey')
+  end
+
+  it "should be false for disabled buttons by default" do
+    @session.should_not have_button('Disabled button')
+  end
+
+  it "should be false for disabled buttons if :disabled => false" do
+    @session.should_not have_button('Disabled button', :disabled => false)
   end
 end
 
@@ -24,7 +36,19 @@ Capybara::SpecHelper.spec '#has_no_button?' do
     @session.should_not have_no_button('crap321')
   end
 
+  it "should be true for disabled buttons if :disabled => true" do
+    @session.should_not have_no_button('Disabled button', :disabled => true)
+  end
+
   it "should be false if the given button is not on the page" do
     @session.should have_no_button('monkey')
+  end
+
+  it "should be false for disabled buttons by default" do
+    @session.should have_no_button('Disabled button')
+  end
+
+  it "should be false for disabled buttons if :disabled => false" do
+    @session.should have_no_button('Disabled button', :disabled => false)
   end
 end


### PR DESCRIPTION
Hi capybara team! :heart: 

I wanted to assert that there was a disabled button on a page, but I discovered that `has_button?` ignores disabled buttons. Then I found that finders take an option `:disabled`, and that `has_field?` passes options through so that you can do `has_field?(locator, :disabled => true)`. When I tried calling `has_button?("Button text", :disabled => true)` though, I got wrong number of arguments since `has_button?` doesn't currently pass an options hash through like `has_field?` does.

This pull request adds that functionality to `has_button?`, `has_no_button?`, and the associated RSpec matchers.

I noticed that `has_checked_field?`, `has_unchecked_field?` and their associated `no` methods are also missing an `options` argument-- I'd be happy to add that enhancement as well, but I wanted to make sure I was on the right track and that this was something you wanted to support before doing that.

Thank you!
