### PR TITLE
Update REAME.md to have clearer RSpec section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ describe 'some stuff which requires js', :js => true do
 end
 ```
 
+**Note**: `:js => true` should not be placed on an `it` block, but on a `describe` or `context` block.
+
 Finally, Capybara also comes with a built in DSL for creating descriptive acceptance tests:
 
 ```ruby


### PR DESCRIPTION
I ran into a problem for hours when I had a test like this:

```
describe "something" do
  it "uses js", :js => true do
    # insert js test here
  end
end
```
