### PR TITLE
Move :wait to helper method to not create unneeded Query instances

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -75,6 +75,16 @@ module Capybara
       end
     end
 
+
+    def extract_wait(*args)
+      options = args.last
+      if options.is_a?(Hash) && options.has_key?(:wait)
+        options[:wait] or 0
+      else
+        Capybara.default_wait_time
+      end
+    end
+
     ##
     #
     # Generates a failure message given a description of the query and count

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -27,7 +27,8 @@ module Capybara
       #
       def find(*args)
         query = Capybara::Query.new(*args)
-        synchronize(query.wait) do
+        wait = Capybara::Helpers.extract_wait(*args)
+        synchronize(wait) do
           if query.match == :smart or query.match == :prefer_exact
             result = resolve_query(query, true)
             result = resolve_query(query, false) if result.size == 0 and not query.exact?

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -86,8 +86,9 @@ module Capybara
       #
       def assert_selector(*args)
         query = Capybara::Query.new(*args)
-        synchronize(query.wait) do
-          result = all(*args)
+        wait = Capybara::Helpers.extract_wait(*args)
+        synchronize(wait) do
+          result = resolve_query(query)
           result.matches_count? or raise Capybara::ExpectationNotMet, result.failure_message
         end
         return true
@@ -103,8 +104,9 @@ module Capybara
       #
       def assert_no_selector(*args)
         query = Capybara::Query.new(*args)
-        synchronize(query.wait) do
-          result = all(*args)
+        wait = Capybara::Helpers.extract_wait(*args)
+        synchronize(wait) do
+          result = resolve_query(query)
           result.matches_count? and raise Capybara::ExpectationNotMet, result.negative_failure_message
         end
         return true
@@ -217,8 +219,8 @@ module Capybara
       #   @return [Boolean]                          Whether it exists
       #
       def has_text?(*args)
-        query = Capybara::Query.new(*args)
-        synchronize(query.wait) do
+        wait = Capybara::Helpers.extract_wait(*args)
+        synchronize(wait) do
           raise ExpectationNotMet unless text_found?(*args)
         end
         return true
@@ -236,8 +238,8 @@ module Capybara
       # @return [Boolean]  Whether it doesn't exist
       #
       def has_no_text?(*args)
-        query = Capybara::Query.new(*args)
-        synchronize(query.wait) do
+        wait = Capybara::Helpers.extract_wait(*args)
+        synchronize(wait) do
           raise ExpectationNotMet if text_found?(*args)
         end
         return true

--- a/lib/capybara/query.rb
+++ b/lib/capybara/query.rb
@@ -69,14 +69,6 @@ module Capybara
       end
     end
 
-    def wait
-      if options.has_key?(:wait)
-        @options[:wait] or 0
-      else
-        Capybara.default_wait_time
-      end
-    end
-
     def exact?
       if options.has_key?(:exact)
         @options[:exact]

--- a/lib/capybara/spec/session/assert_selector.rb
+++ b/lib/capybara/spec/session/assert_selector.rb
@@ -133,7 +133,6 @@ Capybara::SpecHelper.spec '#assert_no_selector' do
 
   context "with wait", :requires => [:js] do
     it "should not find element if it appears after given wait duration" do
-      p Capybara.default_wait_time
       @session.visit('/with_js')
       @session.click_link('Click me')
       @session.assert_no_selector(:css, "a#has-been-clicked", :text => "Has been clicked", :wait => 0.1)


### PR DESCRIPTION
This pull request makes changes into code added by https://github.com/jnicklas/capybara/pull/1111

Currently additional instances of Query are created unnecessarily in `assert_selector`, `assert_no_selector`, `has_text?`, `has_no_text?`. They are used for the sole purpose of getting `wait`.

I believe it's better to extract method to Helpers than to create additional instances of Query when they are not needed at all (especially in `has_text?` and `has_no_text?`)

Also I removed unneeded print in spec added by #1111
