### PR TITLE
Make `Capybara.server_host` working properly

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -16,10 +16,10 @@ module Capybara
 
   class << self
     attr_accessor :asset_host, :app_host, :run_server, :default_host, :always_include_port
-    attr_accessor :server_host, :server_port, :exact, :match, :exact_options, :visible_text_only
+    attr_accessor :server_port, :exact, :match, :exact_options, :visible_text_only
     attr_accessor :default_selector, :default_wait_time, :ignore_hidden_elements
     attr_accessor :save_and_open_page_path, :automatic_reload, :raise_server_errors
-    attr_writer :default_driver, :current_driver, :javascript_driver, :session_name
+    attr_writer :default_driver, :current_driver, :javascript_driver, :session_name, :server_host
     attr_accessor :app
 
     ##
@@ -166,7 +166,7 @@ module Capybara
     #
     def run_default_server(app, port)
       require 'rack/handler/webrick'
-      Rack::Handler::WEBrick.run(app, :Port => port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0))
+      Rack::Handler::WEBrick.run(app, :Host => server_host, :Port => port, :AccessLog => [], :Logger => WEBrick::Log::new(nil, 0))
     end
 
     ##
@@ -212,6 +212,14 @@ module Capybara
       yield
     ensure
       @current_driver = previous_driver
+    end
+
+    ##
+    #
+    # @return [String]    The IP address bound by default server
+    #
+    def server_host
+      @server_host || '127.0.0.1'
     end
 
     ##

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -31,13 +31,13 @@ module Capybara
       end
     end
 
-    attr_reader :app, :port
+    attr_reader :app, :port, :host
 
-    def initialize(app, port=Capybara.server_port)
+    def initialize(app, port=Capybara.server_port, host=Capybara.server_host)
       @app = app
       @middleware = Middleware.new(@app)
       @server_thread = nil # supress warnings
-      @port = port
+      @host, @port = host, port
       @port ||= Capybara::Server.ports[@app.object_id]
       @port ||= find_available_port
     end
@@ -48,10 +48,6 @@ module Capybara
 
     def error
       @middleware.error
-    end
-
-    def host
-      Capybara.server_host || "127.0.0.1"
     end
 
     def responsive?

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -18,13 +18,21 @@ describe Capybara::Server do
   end
 
   it "should bind to the specified host" do
-    Capybara.server_host = '0.0.0.0'
+    begin
+      app = proc { |env| [200, {}, ['Hello Server!']] }
 
-    app = proc { |env| [200, {}, ["Hello Server!"]]}
-    server = Capybara::Server.new(app).boot
-    server.host.should == '0.0.0.0'
+      Capybara.server_host = '127.0.0.1'
+      server = Capybara::Server.new(app).boot
+      res = Net::HTTP.get(URI("http://127.0.0.1:#{server.port}"))
+      expect(res).to eq('Hello Server!')
 
-    Capybara.server_host = nil
+      Capybara.server_host = '0.0.0.0'
+      server = Capybara::Server.new(app).boot
+      res = Net::HTTP.get(URI("http://127.0.0.1:#{server.port}"))
+      expect(res).to eq('Hello Server!')
+    ensure
+      Capybara.server_host = nil
+    end
   end
 
   it "should use specified port" do


### PR DESCRIPTION
Setting `server_host` was added by 2dca77060ab33fe35ce3996f9721657a8d604ca3 but it doesn't work properly.
Webrick was still binding host by default it's `0.0.0.0`, `host` in `server.rb` related just to request `Net::HTTP.start`.
So the test I commented doesn't test that Webrick binded proper host, actually I have no clue how to test that... and just commented that one to pay you attention to it.
