### PR TITLE
Results can now be sampled.

### DIFF
--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -29,7 +29,7 @@ module Capybara
       @query = query
     end
 
-    def_delegators :@result, :each, :[], :at, :size, :count, :length, :first, :last, :empty?, :inspect
+    def_delegators :@result, :each, :[], :at, :size, :count, :length, :first, :last, :empty?, :inspect, :sample
 
     def matches_count?
       Capybara::Helpers.matches_count?(@result.size, @query.options)

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -48,4 +48,8 @@ describe Capybara::Result do
       memo += element.text[0]
     end.should == 'ABGD'
   end
+
+  it 'can be sampled' do
+    result.should include(result.sample)
+  end
 end


### PR DESCRIPTION
An instance of Result can now call #sample. This is delegated to Array#sample.
This allows a random result to be chosen.
This is useful if we want to check one of the results but with no particular preference as to which result.
