### PR TITLE
Github Issue:1178 -- throw warning with trying to set readonly attribute

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -13,6 +13,7 @@ module Capybara
   class UnselectNotAllowed < CapybaraError; end
   class NotSupportedByDriverError < CapybaraError; end
   class InfiniteRedirectError < CapybaraError; end
+  class ReadOnlyElementError < CapybaraError; end
 
   class << self
     attr_accessor :asset_host, :app_host, :run_server, :default_host, :always_include_port

--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -27,10 +27,10 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     elsif input_field?
       set_input(value)
     elsif textarea?
-      if self[:readonly]
-        Kernel.warn('Attempt to set readonly field')
-      else
+      unless self[:readonly]
         native.content = value.to_s
+      else
+        raise Capybara::ReadOnlyElementError.new "Attempt to set readonly element with value: #{value}" 
       end
     end
   end
@@ -169,7 +169,7 @@ private
       end
       native.remove
     elsif self[:readonly]
-      Kernel.warn('Attempt to set readonly field')
+      raise Capybara::ReadOnlyElementError.new "Attempt to set readonly element with value: #{value}"
     else
       native['value'] = value.to_s
     end

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -45,7 +45,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
           driver.browser.execute_script "arguments[0].value = ''", native
           native.send_keys(value.to_s)
         else
-          #TODO
+          raise Capybara::ReadOnlyElementError.new "Attempt to set readonly #{tag_name} with value: #{value}"
         end
       end
     elsif native.attribute('isContentEditable')

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -94,13 +94,17 @@ Capybara::SpecHelper.spec "node" do
 
     it "should not set if the text field is readonly" do
       expect(@session.first('//input[@readonly]').value).to eq('should not change')
-      @session.first('//input[@readonly]').set('changed')
+      expect do
+        @session.first('//input[@readonly]').set('changed')
+      end.to raise_error(Capybara::ReadOnlyElementError)
       expect(@session.first('//input[@readonly]').value).to eq('should not change')
     end
 
     it "should not set if the textarea is readonly" do
       expect(@session.first('//textarea[@readonly]').value).to eq('textarea should not change')
-      @session.first('//textarea[@readonly]').set('changed')
+      expect do
+        @session.first('//textarea[@readonly]').set('changed')
+      end.to raise_error(Capybara::ReadOnlyElementError)
       expect(@session.first('//textarea[@readonly]').value).to eq('textarea should not change')
     end
 


### PR DESCRIPTION
Inspired from this issue: https://github.com/jnicklas/capybara/issues/1178

This is my first PR to an open source project, so please correct me if I didn't follow some protocol, I'd like to contribute more in the future.

I decided to throw a warning instead of throwing an error (As the issue requested) for backwards compatibility

I did not create any new tests, but modified the 2 tests I could find that cared about read only fields. 
