### PR TITLE
Fix failure message of have_text when text of node changes rapidly

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -462,12 +462,16 @@ module Capybara
         self.eql?(other) or (other.respond_to?(:base) and base == other.base)
       end
 
+      # @api private
+      attr_reader :actual_text
+
     private
 
       def text_found?(*args)
         type = args.shift if args.first.is_a?(Symbol) or args.first.nil?
         content, options = args
-        count = Capybara::Helpers.normalize_whitespace(text(type)).scan(Capybara::Helpers.to_regexp(content)).count
+        @actual_text = text(type)
+        count = @actual_text.scan(Capybara::Helpers.to_regexp(content)).size
 
         Capybara::Helpers.matches_count?(count, options || {})
       end

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -27,7 +27,7 @@ module Capybara
       # @return [String]    The text of the element
       #
       def text(type=nil)
-        native.text
+        Capybara::Helpers.normalize_whitespace(native.text)
       end
 
       ##

--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -53,7 +53,7 @@ module Capybara
 
       def failure_message_for_should
         message = Capybara::Helpers.failure_message(description, options)
-        message << " in #{format(@actual.text(type))}"
+        message << " in #{format(@actual.actual_text)}"
         message
       end
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -25,7 +25,7 @@ module Capybara
   #
   class Session
     NODE_METHODS = [
-      :all, :first, :attach_file, :text, :check, :choose,
+      :all, :first, :attach_file, :text, :actual_text, :check, :choose,
       :click_link_or_button, :click_button, :click_link, :field_labeled,
       :fill_in, :find, :find_button, :find_by_id, :find_field, :find_link,
       :has_content?, :has_text?, :has_css?, :has_no_content?, :has_no_text?,
@@ -44,7 +44,7 @@ module Capybara
       :reset_session!, :response_headers, :status_code,
       :title, :has_title?, :has_no_title?, :current_scope
     ]
-    DSL_METHODS = NODE_METHODS + SESSION_METHODS
+    DSL_METHODS = NODE_METHODS + SESSION_METHODS - [:actual_text]
 
     attr_reader :mode, :app, :server
     attr_accessor :synchronized


### PR DESCRIPTION
Attempt to fix #1179 
`normalize_whitespace` inside `text_found?` is removed is it seems to be already normalized in `all_text` and `visible_text`.
