### PR TITLE
In README.md, change 'Capybara.app = MyRackApp' to 'Capybara.app = MyRac...

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ require 'capybara/rails'
 If the application that you are testing is a Rack app, but not Rails, set Capybara.app to your Rack app:
 
 ```ruby
-Capybara.app = MyRackApp
+Capybara.app = MyRackApp.new
 ```
 
 If you need to test JavaScript, or if your app interacts with (or is located at)


### PR DESCRIPTION
I was en undefined method error for "call" on MyApp:Class, then I realized the documentation was incorrect.  I added the .new and the problem was solved!
