### PR TITLE
Changes required to get rid of deprecation warnings with rspec 2.99/3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,18 @@ gemfile:
   - Gemfile
   - gemfiles/Gemfile.base-versions
 matrix:
+  include:
+    - gemfile: gemfiles/Gemfile.beta-versions
+      rvm: 2.1.1
   exclude:
     # Nokogiri 1.3.3 is not compatible with Rubinius or JRuby
     - gemfile: gemfiles/Gemfile.base-versions
       rvm: rbx
     - gemfile: gemfiles/Gemfile.base-versions
       rvm: jruby-19mode
+  allow_failures:
+    - gemfile: gemfiles/Gemfile.beta-versions
+      rvm: 2.1.1
 before_install:
   - CHROMEDRIVER_VERSION=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
   - CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip"

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ You can get the [current path](http://rubydoc.info/github/jnicklas/capybara/mast
 of the browsing session for test assertions:
 
 ```ruby
-current_path.should == post_comments_path(post)
+expect(current_path).to eq(post_comments_path(post))
 ```
 
 ### Clicking links and buttons
@@ -400,12 +400,12 @@ has_selector?`. Read the section on asynchronous JavaScript for an explanation.
 You can use these with RSpec's magic matchers:
 
 ```ruby
-page.should have_selector('table tr')
-page.should have_selector(:xpath, '//table/tr')
+expect(page).to have_selector('table tr')
+expect(page).to have_selector(:xpath, '//table/tr')
 
-page.should have_xpath('//table/tr')
-page.should have_css('table tr.foo')
-page.should have_content('foo')
+expect(page).to have_xpath('//table/tr')
+expect(page).to have_css('table tr.foo')
+expect(page).to have_content('foo')
 ```
 
 ### Finding
@@ -432,7 +432,7 @@ to specific parts of the page:
 
 ```ruby
 find('#navigation').click_link('Home')
-find('#navigation').should have_button('Sign out')
+expect(find('#navigation')).to have_button('Sign out')
 ```
 
 ### Scoping
@@ -595,7 +595,7 @@ When issuing instructions to the DSL such as:
 ```ruby
 click_link('foo')
 click_link('bar')
-page.should have_content('baz')
+expect(page).to have_content('baz')
 ```
 
 If clicking on the *foo* link triggers an asynchronous process, such as
@@ -627,15 +627,15 @@ Capybara's Rspec matchers, however, are smart enough to handle either form.
 The two following statements are functionally equivalent:
 
 ```ruby
-page.should_not have_xpath('a')
-page.should have_no_xpath('a')
+expect(page).not_to have_xpath('a')
+expect(page).to have_no_xpath('a')
 ```
 
 Capybara's waiting behaviour is quite advanced, and can deal with situations
 such as the following line of code:
 
 ```ruby
-find('#sidebar').find('h1').should have_content('Something')
+expect(find('#sidebar').find('h1')).to have_content('Something')
 ```
 
 Even if JavaScript causes `#sidebar` to disappear off the page, Capybara

--- a/features/step_definitions/capybara_steps.rb
+++ b/features/step_definitions/capybara_steps.rb
@@ -3,22 +3,22 @@ When /^I visit the (?:root|home) page$/ do
 end
 
 Then /^I should see "([^"]*)"$/ do |text|
-  page.should have_content(text)
+  expect(page).to have_content(text)
 end
 
 Then /^Capybara should use the "([^"]*)" driver$/ do |driver|
-  Capybara.current_driver.should == driver.to_sym
+  expect(Capybara.current_driver).to eq(driver.to_sym)
 end
 
 When /^I use a matcher that fails$/ do
   begin
-    page.should have_css('h1#doesnotexist')
+    expect(page).to have_css('h1#doesnotexist')
   rescue StandardError => e
     @error_message = e.message
   end
 end
 
 Then /^the failing exception should be nice$/ do
-  @error_message.should =~ %r(expected to find css \"h1#doesnotexist\")
+  expect(@error_message).to match %r(expected to find css \"h1#doesnotexist\")
 end
 

--- a/gemfiles/Gemfile.base-versions
+++ b/gemfiles/Gemfile.base-versions
@@ -9,6 +9,7 @@ gem 'rack', '= 1.3.0' # cannot go lower because referer tests need aa7ce77cd0
 gem 'rack-test', '= 0.5.4'
 gem 'nokogiri', '= 1.3.3'
 gem 'rspec', '= 2.2.0'
+gem 'fuubar', '>= 0.0.1'
 gem 'cucumber', '= 0.10.5'
 # We cannot test against older versions of selenium-webdriver without
 # installing older compatible Firefox versions.

--- a/gemfiles/Gemfile.beta-versions
+++ b/gemfiles/Gemfile.beta-versions
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem 'bundler', '~> 1.0'
+gemspec :path => '..'
+
+gem 'xpath', :git => 'git://github.com/jnicklas/xpath.git'
+
+gem 'rspec', '>= 3.0.0.beta2'
+gem 'fuubar', '>= 2.0.0.beta1'

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -86,7 +86,7 @@ module Capybara
     #     find(:row, 3)
     #     page.find('table#myTable').find(:row, 3).text
     #     page.find('table#myTable').has_selector?(:row, 3)
-    #     within(:row, 3) { page.should have_content('$100.000') }
+    #     within(:row, 3) { expect(page).to have_content('$100.000') }
     #
     # Here is another example:
     #

--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -29,3 +29,4 @@ RSpec.configure do |config|
     end
   end
 end
+

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -19,7 +19,7 @@ module Capybara
   #
   #     session.fill_in('q', :with => 'Capybara')
   #     session.click_button('Search')
-  #     session.should have_content('Capybara')
+  #     expect(session).to have_content('Capybara')
   #
   # When using capybara/dsl, the Session is initialized automatically for you.
   #

--- a/lib/capybara/spec/session/all_spec.rb
+++ b/lib/capybara/spec/session/all_spec.rb
@@ -4,20 +4,20 @@ Capybara::SpecHelper.spec "#all" do
   end
 
   it "should find all elements using the given locator" do
-    @session.all('//p').should have(3).elements
-    @session.all('//h1').first.text.should == 'This is a test'
-    @session.all("//input[@id='test_field']").first[:value].should == 'monkey'
+    expect(@session.all('//p').size).to eq(3)
+    expect(@session.all('//h1').first.text).to eq('This is a test')
+    expect(@session.all("//input[@id='test_field']").first[:value]).to eq('monkey')
   end
 
   it "should return an empty array when nothing was found" do
-    @session.all('//div[@id="nosuchthing"]').should be_empty
+    expect(@session.all('//div[@id="nosuchthing"]')).to be_empty
   end
 
   it "should accept an XPath instance" do
     @session.visit('/form')
     @xpath = XPath::HTML.fillable_field('Name')
     @result = @session.all(@xpath).map { |r| r.value }
-    @result.should include('Smith', 'John', 'John Smith')
+    expect(@result).to include('Smith', 'John', 'John Smith')
   end
 
   it "should raise an error when given invalid options" do
@@ -26,44 +26,44 @@ Capybara::SpecHelper.spec "#all" do
 
   context "with css selectors" do
     it "should find all elements using the given selector" do
-      @session.all(:css, 'h1').first.text.should == 'This is a test'
-      @session.all(:css, "input[id='test_field']").first[:value].should == 'monkey'
+      expect(@session.all(:css, 'h1').first.text).to eq('This is a test')
+      expect(@session.all(:css, "input[id='test_field']").first[:value]).to eq('monkey')
     end
 
     it "should find all elements when given a list of selectors" do
-      @session.all(:css, 'h1, p').should have(4).elements
+      expect(@session.all(:css, 'h1, p').size).to eq(4)
     end
   end
 
   context "with xpath selectors" do
     it "should find the first element using the given locator" do
-      @session.all(:xpath, '//h1').first.text.should == 'This is a test'
-      @session.all(:xpath, "//input[@id='test_field']").first[:value].should == 'monkey'
+      expect(@session.all(:xpath, '//h1').first.text).to eq('This is a test')
+      expect(@session.all(:xpath, "//input[@id='test_field']").first[:value]).to eq('monkey')
     end
   end
 
   context "with css as default selector" do
     before { Capybara.default_selector = :css }
     it "should find the first element using the given locator" do
-      @session.all('h1').first.text.should == 'This is a test'
-      @session.all("input[id='test_field']").first[:value].should == 'monkey'
+      expect(@session.all('h1').first.text).to eq('This is a test')
+      expect(@session.all("input[id='test_field']").first[:value]).to eq('monkey')
     end
   end
 
   context "with visible filter" do
     it "should only find visible nodes when true" do
-      @session.all(:css, "a.simple", :visible => true).should have(1).elements
+      expect(@session.all(:css, "a.simple", :visible => true).size).to eq(1)
     end
 
     it "should find nodes regardless of whether they are invisible when false" do
-      @session.all(:css, "a.simple", :visible => false).should have(2).elements
+      expect(@session.all(:css, "a.simple", :visible => false).size).to eq(2)
     end
 
     it "should default to Capybara.ignore_hidden_elements" do
       Capybara.ignore_hidden_elements = true
-      @session.all(:css, "a.simple").should have(1).elements
+      expect(@session.all(:css, "a.simple").size).to eq(1)
       Capybara.ignore_hidden_elements = false
-      @session.all(:css, "a.simple").should have(2).elements
+      expect(@session.all(:css, "a.simple").size).to eq(2)
     end
   end
 
@@ -145,7 +145,7 @@ Capybara::SpecHelper.spec "#all" do
 
     it "should find any element using the given locator" do
       @session.within(:xpath, "//div[@id='for_bar']") do
-        @session.all('.//li').should have(2).elements
+        expect(@session.all('.//li').size).to eq(2)
       end
     end
   end

--- a/lib/capybara/spec/session/assert_selector.rb
+++ b/lib/capybara/spec/session/assert_selector.rb
@@ -72,7 +72,7 @@ end
 
 Capybara::SpecHelper.spec '#refute_selector' do
   it "should be an alias of #assert_no_selector" do
-    Capybara::Node::Matchers.instance_method(:refute_selector).should == Capybara::Node::Matchers.instance_method(:assert_no_selector)
+    expect(Capybara::Node::Matchers.instance_method(:refute_selector)).to eq Capybara::Node::Matchers.instance_method(:assert_no_selector)
   end
 end
 

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -10,19 +10,19 @@ Capybara::SpecHelper.spec "#attach_file" do
     it "should set a file path by id" do
       @session.attach_file "form_image", __FILE__
       @session.click_button('awesome')
-      extract_results(@session)['image'].should == File.basename(__FILE__)
+      expect(extract_results(@session)['image']).to eq(File.basename(__FILE__))
     end
 
     it "should set a file path by label" do
       @session.attach_file "Image", __FILE__
       @session.click_button('awesome')
-      extract_results(@session)['image'].should == File.basename(__FILE__)
+      expect(extract_results(@session)['image']).to eq(File.basename(__FILE__))
     end
 
     it "casts to string" do
       @session.attach_file :"form_image", __FILE__
       @session.click_button('awesome')
-      extract_results(@session)['image'].should == File.basename(__FILE__)
+      expect(extract_results(@session)['image']).to eq(File.basename(__FILE__))
     end
   end
 
@@ -30,51 +30,51 @@ Capybara::SpecHelper.spec "#attach_file" do
     it "should set a file path by id" do
       @session.attach_file "form_document", @test_file_path
       @session.click_button('Upload Single')
-      @session.should have_content(File.read(@test_file_path))
+      expect(@session).to have_content(File.read(@test_file_path))
     end
 
     it "should set a file path by label" do
       @session.attach_file "Single Document", @test_file_path
       @session.click_button('Upload Single')
-      @session.should have_content(File.read(@test_file_path))
+      expect(@session).to have_content(File.read(@test_file_path))
     end
 
     it "should not break if no file is submitted" do
       @session.click_button('Upload Single')
-      @session.should have_content('No file uploaded')
+      expect(@session).to have_content('No file uploaded')
     end
 
     it "should send content type text/plain when uploading a text file" do
       @session.attach_file "Single Document", @test_file_path
       @session.click_button 'Upload Single'
-      @session.should have_content('text/plain')
+      expect(@session).to have_content('text/plain')
     end
 
     it "should send content type image/jpeg when uploading an image" do
       @session.attach_file "Single Document", @test_jpg_file_path
       @session.click_button 'Upload Single'
-      @session.should have_content('image/jpeg')
+      expect(@session).to have_content('image/jpeg')
     end
 
     it "should not break when using HTML5 multiple file input" do
       @session.attach_file "Multiple Documents", @test_file_path
       @session.click_button('Upload Multiple')
-      @session.body.should include("1 | ")#number of files
-      @session.should have_content(File.read(@test_file_path))
+      expect(@session.body).to include("1 | ")#number of files
+      expect(@session).to have_content(File.read(@test_file_path))
     end
 
     it  "should not break when using HTML5 multiple file input uploading multiple files" do
       pending "Selenium is buggy on this, see http://code.google.com/p/selenium/issues/detail?id=2239" if @session.respond_to?(:mode) && @session.mode.to_s =~ /^selenium/
       @session.attach_file "Multiple Documents", [@test_file_path, @another_test_file_path]
       @session.click_button('Upload Multiple')
-      @session.body.should include("2 | ")#number of files
-      @session.body.should include(File.read(@test_file_path))
-      @session.body.should include(File.read(@another_test_file_path))
+      expect(@session.body).to include("2 | ")#number of files
+      expect(@session.body).to include(File.read(@test_file_path))
+      expect(@session.body).to include(File.read(@another_test_file_path))
     end
 
     it "should not send anything when attaching no files to a multiple upload field" do
       @session.click_button('Upload Empty Multiple')
-      @session.body.should include("Successfully ignored empty file field")
+      expect(@session.body).to include("Successfully ignored empty file field")
     end
   end
 
@@ -97,7 +97,7 @@ Capybara::SpecHelper.spec "#attach_file" do
     it "should set a file path by partial label when false" do
       @session.attach_file "Imag", __FILE__, :exact => false
       @session.click_button('awesome')
-      extract_results(@session)['image'].should == File.basename(__FILE__)
+      expect(extract_results(@session)['image']).to eq(File.basename(__FILE__))
     end
 
     it "not allow partial matches when true" do

--- a/lib/capybara/spec/session/body_spec.rb
+++ b/lib/capybara/spec/session/body_spec.rb
@@ -1,20 +1,20 @@
 Capybara::SpecHelper.spec '#body' do
   it "should return the unmodified page body" do
     @session.visit('/')
-    @session.should have_content('Hello world!') # wait for content to appear if visit is async
-    @session.body.should include('Hello world!')
+    expect(@session).to have_content('Hello world!') # wait for content to appear if visit is async
+    expect(@session.body).to include('Hello world!')
   end
 
   if "".respond_to?(:encoding)
     context "encoding of response between ascii and utf8" do
       it "should be valid with html entities" do
         @session.visit('/with_html_entities')
-        lambda { @session.body.encode!("UTF-8") }.should_not raise_error
+        expect { @session.body.encode!("UTF-8") }.not_to raise_error
       end
 
       it "should be valid without html entities" do
         @session.visit('/with_html')
-        lambda { @session.body.encode!("UTF-8") }.should_not raise_error
+        expect { @session.body.encode!("UTF-8") }.not_to raise_error
       end
     end
   end

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -6,64 +6,64 @@ Capybara::SpecHelper.spec "#check" do
   describe "'checked' attribute" do
     it "should be true if checked" do
       @session.check("Terms of Use")
-      @session.find(:xpath, "//input[@id='form_terms_of_use']")['checked'].should be_true
+      expect(@session.find(:xpath, "//input[@id='form_terms_of_use']")['checked']).to be_truthy
     end
 
     it "should be false if unchecked" do
-      @session.find(:xpath, "//input[@id='form_terms_of_use']")['checked'].should be_false
+      expect(@session.find(:xpath, "//input[@id='form_terms_of_use']")['checked']).to be_falsey
     end
   end
 
   it "should trigger associated events", :requires => [:js] do
     @session.visit('/with_js')
     @session.check('checkbox_with_event')
-    @session.should have_css('#checkbox_event_triggered');
+    expect(@session).to have_css('#checkbox_event_triggered');
   end
 
   describe "checking" do
     it "should not change an already checked checkbox" do
-      @session.find(:xpath, "//input[@id='form_pets_dog']")['checked'].should be_true
+      expect(@session.find(:xpath, "//input[@id='form_pets_dog']")['checked']).to be_truthy
       @session.check('form_pets_dog')
-      @session.find(:xpath, "//input[@id='form_pets_dog']")['checked'].should be_true
+      expect(@session.find(:xpath, "//input[@id='form_pets_dog']")['checked']).to be_truthy
     end
 
     it "should check an unchecked checkbox" do
-      @session.find(:xpath, "//input[@id='form_pets_cat']")['checked'].should be_false
+      expect(@session.find(:xpath, "//input[@id='form_pets_cat']")['checked']).to be_falsey
       @session.check('form_pets_cat')
-      @session.find(:xpath, "//input[@id='form_pets_cat']")['checked'].should be_true
+      expect(@session.find(:xpath, "//input[@id='form_pets_cat']")['checked']).to be_truthy
     end
   end
 
   describe "unchecking" do
     it "should not change an already unchecked checkbox" do
-      @session.find(:xpath, "//input[@id='form_pets_cat']")['checked'].should be_false
+      expect(@session.find(:xpath, "//input[@id='form_pets_cat']")['checked']).to be_falsey
       @session.uncheck('form_pets_cat')
-      @session.find(:xpath, "//input[@id='form_pets_cat']")['checked'].should be_false
+      expect(@session.find(:xpath, "//input[@id='form_pets_cat']")['checked']).to be_falsey
     end
 
     it "should uncheck a checked checkbox" do
-      @session.find(:xpath, "//input[@id='form_pets_dog']")['checked'].should be_true
+      expect(@session.find(:xpath, "//input[@id='form_pets_dog']")['checked']).to be_truthy
       @session.uncheck('form_pets_dog')
-      @session.find(:xpath, "//input[@id='form_pets_dog']")['checked'].should be_false
+      expect(@session.find(:xpath, "//input[@id='form_pets_dog']")['checked']).to be_falsey
     end
   end
 
   it "should check a checkbox by id" do
     @session.check("form_pets_cat")
     @session.click_button('awesome')
-    extract_results(@session)['pets'].should include('dog', 'cat', 'hamster')
+    expect(extract_results(@session)['pets']).to include('dog', 'cat', 'hamster')
   end
 
   it "should check a checkbox by label" do
     @session.check("Cat")
     @session.click_button('awesome')
-    extract_results(@session)['pets'].should include('dog', 'cat', 'hamster')
+    expect(extract_results(@session)['pets']).to include('dog', 'cat', 'hamster')
   end
 
   it "casts to string" do
     @session.check(:"form_pets_cat")
     @session.click_button('awesome')
-    extract_results(@session)['pets'].should include('dog', 'cat', 'hamster')
+    expect(extract_results(@session)['pets']).to include('dog', 'cat', 'hamster')
   end
 
   context "with a locator that doesn't exist" do
@@ -87,7 +87,7 @@ Capybara::SpecHelper.spec "#check" do
     it "should accept partial matches when false" do
       @session.check('Ham', :exact => false)
       @session.click_button('awesome')
-      extract_results(@session)['pets'].should include('hamster')
+      expect(extract_results(@session)['pets']).to include('hamster')
     end
 
     it "should not accept partial matches when true" do
@@ -101,7 +101,7 @@ Capybara::SpecHelper.spec "#check" do
     it "can check boxes by their value" do
       @session.check('form[pets][]', :option => "cat")
       @session.click_button('awesome')
-      extract_results(@session)['pets'].should include('cat')
+      expect(extract_results(@session)['pets']).to include('cat')
     end
 
     it "should raise an error if option not found" do

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -6,19 +6,19 @@ Capybara::SpecHelper.spec "#choose" do
   it "should choose a radio button by id" do
     @session.choose("gender_male")
     @session.click_button('awesome')
-    extract_results(@session)['gender'].should == 'male'
+    expect(extract_results(@session)['gender']).to eq('male')
   end
 
   it "should choose a radio button by label" do
     @session.choose("Both")
     @session.click_button('awesome')
-    extract_results(@session)['gender'].should == 'both'
+    expect(extract_results(@session)['gender']).to eq('both')
   end
 
   it "casts to string" do
     @session.choose("Both")
     @session.click_button(:'awesome')
-    extract_results(@session)['gender'].should == 'both'
+    expect(extract_results(@session)['gender']).to eq('both')
   end
 
   context "with a locator that doesn't exist" do
@@ -42,7 +42,7 @@ Capybara::SpecHelper.spec "#choose" do
     it "should accept partial matches when false" do
       @session.choose("Mal", :exact => false)
       @session.click_button('awesome')
-      extract_results(@session)['gender'].should == 'male'
+      expect(extract_results(@session)['gender']).to eq('male')
     end
 
     it "should not accept partial matches when true" do
@@ -56,7 +56,7 @@ Capybara::SpecHelper.spec "#choose" do
     it "can check radio buttons by their value" do
       @session.choose('form[gender]', :option => "male")
       @session.click_button('awesome')
-      extract_results(@session)['gender'].should == "male"
+      expect(extract_results(@session)['gender']).to eq("male")
     end
 
     it "should raise an error if option not found" do

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -11,31 +11,31 @@ Capybara::SpecHelper.spec '#click_button' do
 
   it "casts to string" do
     @session.click_button(:'Relative Action')
-    @session.current_path.should == '/relative'
-    extract_results(@session)['relative'].should == 'Relative Action'
+    expect(@session.current_path).to eq('/relative')
+    expect(extract_results(@session)['relative']).to eq('Relative Action')
   end
 
   context "with multiple values with the same name" do
     it "should use the latest given value" do
       @session.check('Terms of Use')
       @session.click_button('awesome')
-      extract_results(@session)['terms_of_use'].should == '1'
+      expect(extract_results(@session)['terms_of_use']).to eq('1')
     end
   end
 
   context "with a form that has a relative url as an action" do
     it "should post to the correct url" do
       @session.click_button('Relative Action')
-      @session.current_path.should == '/relative'
-      extract_results(@session)['relative'].should == 'Relative Action'
+      expect(@session.current_path).to eq('/relative')
+      expect(extract_results(@session)['relative']).to eq('Relative Action')
     end
   end
 
   context "with a form that has no action specified" do
     it "should post to the correct url" do
       @session.click_button('No Action')
-      @session.current_path.should == '/form'
-      extract_results(@session)['no_action'].should == 'No Action'
+      expect(@session.current_path).to eq('/form')
+      expect(extract_results(@session)['no_action']).to eq('No Action')
     end
   end
 
@@ -47,23 +47,23 @@ Capybara::SpecHelper.spec '#click_button' do
       end
 
       it "should serialise and submit search fields" do
-        @results['html5_search'].should == 'what are you looking for'
+        expect(@results['html5_search']).to eq('what are you looking for')
       end
 
       it "should serialise and submit email fields" do
-        @results['html5_email'].should == 'person@email.com'
+        expect(@results['html5_email']).to eq('person@email.com')
       end
 
       it "should serialise and submit url fields" do
-        @results['html5_url'].should == 'http://www.example.com'
+        expect(@results['html5_url']).to eq('http://www.example.com')
       end
 
       it "should serialise and submit tel fields" do
-        @results['html5_tel'].should == '911'
+        expect(@results['html5_tel']).to eq('911')
       end
 
       it "should serialise and submit color fields" do
-        @results['html5_color'].upcase.should == '#FFFFFF'
+        expect(@results['html5_color'].upcase).to eq('#FFFFFF')
       end
     end
 
@@ -74,78 +74,78 @@ Capybara::SpecHelper.spec '#click_button' do
       end
 
       it "should serialize and submit text fields" do
-        @results['first_name'].should == 'John'
+        expect(@results['first_name']).to eq('John')
       end
 
       it "should escape fields when submitting" do
-        @results['phone'].should == '+1 555 7021'
+        expect(@results['phone']).to eq('+1 555 7021')
       end
 
       it "should serialize and submit password fields" do
-        @results['password'].should == 'seeekrit'
+        expect(@results['password']).to eq('seeekrit')
       end
 
       it "should serialize and submit hidden fields" do
-        @results['token'].should == '12345'
+        expect(@results['token']).to eq('12345')
       end
 
       it "should not serialize fields from other forms" do
-        @results['middle_name'].should be_nil
+        expect(@results['middle_name']).to be_nil
       end
 
       it "should submit the button that was clicked, but not other buttons" do
-        @results['awesome'].should == 'awesome'
-        @results['crappy'].should be_nil
+        expect(@results['awesome']).to eq('awesome')
+        expect(@results['crappy']).to be_nil
       end
 
       it "should serialize radio buttons" do
-        @results['gender'].should == 'female'
+        expect(@results['gender']).to eq('female')
       end
 
       it "should default radio value to 'on' if none specified" do
-        @results['valueless_radio'].should == 'on'
+        expect(@results['valueless_radio']).to eq('on')
       end
 
       it "should serialize check boxes" do
-        @results['pets'].should include('dog', 'hamster')
-        @results['pets'].should_not include('cat')
+        expect(@results['pets']).to include('dog', 'hamster')
+        expect(@results['pets']).not_to include('cat')
       end
       
       it "should default checkbox value to 'on' if none specififed" do
-        @results['valueless_checkbox'].should == 'on'
+        expect(@results['valueless_checkbox']).to eq('on')
       end
 
       it "should serialize text areas" do
-        @results['description'].should == 'Descriptive text goes here'
+        expect(@results['description']).to eq('Descriptive text goes here')
       end
 
       it "should serialize select tag with values" do
-        @results['locale'].should == 'en'
+        expect(@results['locale']).to eq('en')
       end
 
       it "should serialize select tag without values" do
-        @results['region'].should == 'Norway'
+        expect(@results['region']).to eq('Norway')
       end
 
       it "should serialize first option for select tag with no selection" do
-        @results['city'].should == 'London'
+        expect(@results['city']).to eq('London')
       end
 
       it "should not serialize a select tag without options" do
-        @results['tendency'].should be_nil
+        expect(@results['tendency']).to be_nil
       end
       
       it "should convert lf to cr/lf in submitted textareas" do
-        @results['newline'].should == "\r\nNew line after and before textarea tag\r\n"
+        expect(@results['newline']).to eq("\r\nNew line after and before textarea tag\r\n")
       end
       
       it "should not submit disabled fields" do
-        @results['disabled_text_field'].should be_nil
-        @results['disabled_textarea'].should be_nil
-        @results['disabled_checkbox'].should be_nil
-        @results['disabled_radio'].should be_nil
-        @results['disabled_select'].should be_nil
-        @results['disabled_file'].should be_nil
+        expect(@results['disabled_text_field']).to be_nil
+        expect(@results['disabled_textarea']).to be_nil
+        expect(@results['disabled_checkbox']).to be_nil
+        expect(@results['disabled_radio']).to be_nil
+        expect(@results['disabled_select']).to be_nil
+        expect(@results['disabled_file']).to be_nil
       end
     end
   end
@@ -153,24 +153,24 @@ Capybara::SpecHelper.spec '#click_button' do
   context "with id given on a submit button" do
     it "should submit the associated form" do
       @session.click_button('awe123')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('Go')
-      @session.should have_content('You landed')
+      expect(@session).to have_content('You landed')
     end
   end
 
   context "with title given on a submit button" do
     it "should submit the associated form" do
       @session.click_button('What an Awesome Button')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('What an Awesome')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
 
@@ -181,19 +181,19 @@ Capybara::SpecHelper.spec '#click_button' do
     end
 
     it "should serialize and submit text fields" do
-      @results['outside_input'].should == 'outside_input'
+      expect(@results['outside_input']).to eq('outside_input')
     end
 
     it "should serialize text areas" do
-      @results['outside_textarea'].should == 'Some text here'
+      expect(@results['outside_textarea']).to eq('Some text here')
     end
 
     it "should serialize select tags" do
-      @results['outside_select'].should == 'Ruby'
+      expect(@results['outside_select']).to eq('Ruby')
     end
 
     it "should not serliaze fields associated with a different form" do
-      @results['for_form2'].should be_nil
+      expect(@results['for_form2']).to be_nil
     end
   end
 
@@ -205,12 +205,12 @@ Capybara::SpecHelper.spec '#click_button' do
     end
 
     it "should submit the associated form" do
-      @results['which_form'].should == 'form2'
+      expect(@results['which_form']).to eq('form2')
     end
 
     it "should submit the button that was clicked, but not other buttons" do
-      @results['outside_button'].should == 'outside_button'
-      @results['unused'].should be_nil
+      expect(@results['outside_button']).to eq('outside_button')
+      expect(@results['unused']).to be_nil
     end
   end
 
@@ -221,37 +221,37 @@ Capybara::SpecHelper.spec '#click_button' do
     end
 
     it "should submit the associated form" do
-      @results['which_form'].should == 'form1'
+      expect(@results['which_form']).to eq('form1')
     end
 
     it "should submit the button that was clicked, but not other buttons" do
-      @results['outside_submit'].should == 'outside_submit'
-      @results['submit_form1'].should be_nil
+      expect(@results['outside_submit']).to eq('outside_submit')
+      expect(@results['submit_form1']).to be_nil
     end
   end
 
   context "with submit button for form1 located within form2" do
     it "should submit the form associated with the button" do
       @session.click_button('other_form_button')
-      extract_results(@session)['which_form'].should == "form1"
+      expect(extract_results(@session)['which_form']).to eq("form1")
     end
   end
 
   context "with submit button not associated with any form" do
     it "should not error when clicked" do
-      lambda { @session.click_button('no_form_button') }.should_not raise_error
+      expect { @session.click_button('no_form_button') }.not_to raise_error
     end
   end
 
   context "with alt given on an image button" do
     it "should submit the associated form" do
       @session.click_button('oh hai thar')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('hai')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
   
@@ -259,82 +259,82 @@ Capybara::SpecHelper.spec '#click_button' do
   context "with value given on an image button" do
     it "should submit the associated form" do
       @session.click_button('okay')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('kay')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
 
   context "with id given on an image button" do
     it "should submit the associated form" do
       @session.click_button('okay556')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
 
   context "with title given on an image button" do
     it "should submit the associated form" do
       @session.click_button('Okay 556 Image')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('Okay 556')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
 
   context "with text given on a button defined by <button> tag" do
     it "should submit the associated form" do
       @session.click_button('Click me')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('Click')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
 
  context "with id given on a button defined by <button> tag" do
     it "should submit the associated form" do
       @session.click_button('click_me_123')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should serialize and send GET forms" do
       @session.visit('/form')
       @session.click_button('med')
       @results = extract_results(@session)
-      @results['middle_name'].should == 'Darren'
-      @results['foo'].should be_nil
+      expect(@results['middle_name']).to eq('Darren')
+      expect(@results['foo']).to be_nil
     end
   end
 
  context "with value given on a button defined by <button> tag" do
     it "should submit the associated form" do
       @session.click_button('click_me')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('ck_me')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
 
   context "with title given on a button defined by <button> tag" do
     it "should submit the associated form" do
       @session.click_button('Click Title button')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should work with partial matches" do
       @session.click_button('Click Title')
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
   end
   context "with a locator that doesn't exist" do
@@ -349,48 +349,48 @@ Capybara::SpecHelper.spec '#click_button' do
   context "with formaction attribute on button" do
     it "should submit to the formaction attribute" do
       @session.click_button('Formaction button')
-      @session.current_path.should == '/form'
+      expect(@session.current_path).to eq '/form'
       @results = extract_results(@session)
-      @results['which_form'].should == 'formaction form'
+      expect(@results['which_form']).to eq 'formaction form'
     end
   end
 
   it "should serialize and send valueless buttons that were clicked" do
     @session.click_button('No Value!')
     @results = extract_results(@session)
-    @results['no_value'].should_not be_nil
+    expect(@results['no_value']).not_to be_nil
   end
 
   it "should not send image buttons that were not clicked" do
     @session.click_button('Click me!')
     @results = extract_results(@session)
-    @results['okay'].should be_nil
+    expect(@results['okay']).to be_nil
   end
 
   it "should serialize and send GET forms" do
     @session.visit('/form')
     @session.click_button('med')
     @results = extract_results(@session)
-    @results['middle_name'].should == 'Darren'
-    @results['foo'].should be_nil
+    expect(@results['middle_name']).to eq('Darren')
+    expect(@results['foo']).to be_nil
   end
 
   it "should follow redirects" do
     @session.click_button('Go FAR')
-    @session.current_url.should match(%r{/landed$})
-    @session.should have_content('You landed')
+    expect(@session.current_url).to match(%r{/landed$})
+    expect(@session).to have_content('You landed')
   end
 
   it "should post pack to the same URL when no action given" do
     @session.visit('/postback')
     @session.click_button('With no action')
-    @session.should have_content('Postback')
+    expect(@session).to have_content('Postback')
   end
 
   it "should post pack to the same URL when blank action given" do
     @session.visit('/postback')
     @session.click_button('With blank action')
-    @session.should have_content('Postback')
+    expect(@session).to have_content('Postback')
   end
 
   it "ignores disabled buttons" do
@@ -413,21 +413,21 @@ Capybara::SpecHelper.spec '#click_button' do
     @session.click_button "awesome"
 
     addresses=extract_results(@session)["addresses"]
-    addresses.should have(2).addresses
+    expect(addresses.size).to eq(2)
 
-    addresses[0]["street"].should   == 'CDG'
-    addresses[0]["city"].should     == 'Paris'
-    addresses[0]["country"].should  == 'France'
+    expect(addresses[0]["street"]).to eq('CDG')
+    expect(addresses[0]["city"]).to eq('Paris')
+    expect(addresses[0]["country"]).to eq('France')
 
-    addresses[1]["street"].should   == 'PGS'
-    addresses[1]["city"].should     == 'Mikolaiv'
-    addresses[1]["country"].should  == 'Ukraine'
+    expect(addresses[1]["street"]).to eq('PGS')
+    expect(addresses[1]["city"]).to eq('Mikolaiv')
+    expect(addresses[1]["country"]).to eq('Ukraine')
   end
 
   context "with :exact option" do
     it "should accept partial matches when false" do
       @session.click_button('What an Awesome', :exact => false)
-      extract_results(@session)['first_name'].should == 'John'
+      expect(extract_results(@session)['first_name']).to eq('John')
     end
 
     it "should not accept partial matches when true" do

--- a/lib/capybara/spec/session/click_link_or_button_spec.rb
+++ b/lib/capybara/spec/session/click_link_or_button_spec.rb
@@ -2,25 +2,25 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
   it "should click on a link" do
     @session.visit('/with_html')
     @session.click_link_or_button('labore')
-    @session.should have_content('Bar')
+    expect(@session).to have_content('Bar')
   end
 
   it "should click on a button" do
     @session.visit('/form')
     @session.click_link_or_button('awe123')
-    extract_results(@session)['first_name'].should == 'John'
+    expect(extract_results(@session)['first_name']).to eq('John')
   end
 
   it "should click on a button with no type attribute" do
     @session.visit('/form')
     @session.click_link_or_button('no_type')
-    extract_results(@session)['first_name'].should == 'John'
+    expect(extract_results(@session)['first_name']).to eq('John')
   end
 
   it "should be aliased as click_on" do
     @session.visit('/form')
     @session.click_on('awe123')
-    extract_results(@session)['first_name'].should == 'John'
+    expect(extract_results(@session)['first_name']).to eq('John')
   end
 
   it "should wait for asynchronous load", :requires => [:js] do
@@ -32,7 +32,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
   it "casts to string" do
     @session.visit('/form')
     @session.click_link_or_button(:'awe123')
-    extract_results(@session)['first_name'].should == 'John'
+    expect(extract_results(@session)['first_name']).to eq('John')
   end
 
   context "with :exact option" do
@@ -40,13 +40,13 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
       it "clicks on approximately matching link" do
         @session.visit('/with_html')
         @session.click_link_or_button('abore', :exact => false)
-        @session.should have_content('Bar')
+        expect(@session).to have_content('Bar')
       end
 
       it "clicks on approximately matching button" do
         @session.visit('/form')
         @session.click_link_or_button('awe')
-        extract_results(@session)['first_name'].should == 'John'
+        expect(extract_results(@session)['first_name']).to eq('John')
       end
     end
 
@@ -98,7 +98,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
     it "happily clicks on links which incorrectly have the disabled attribute" do
       @session.visit('/with_html')
       @session.click_link_or_button('Disabled link')
-      @session.should have_content("Bar")
+      expect(@session).to have_content("Bar")
     end
 
     it "does nothing when button is disabled" do

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -11,7 +11,7 @@ Capybara::SpecHelper.spec '#click_link' do
 
   it "casts to string" do
     @session.click_link(:'foo')
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
   end
 
   it "raises any errors caught inside the server", :requires => [:server] do
@@ -24,43 +24,43 @@ Capybara::SpecHelper.spec '#click_link' do
   context "with id given" do
     it "should take user to the linked page" do
       @session.click_link('foo')
-      @session.should have_content('Another World')
+      expect(@session).to have_content('Another World')
     end
   end
 
   context "with text given" do
     it "should take user to the linked page" do
       @session.click_link('labore')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
 
     it "should accept partial matches" do
       @session.click_link('abo')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
   context "with title given" do
     it "should take user to the linked page" do
       @session.click_link('awesome title')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
 
     it "should accept partial matches" do
       @session.click_link('some titl')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
   context "with alternative text given to a contained image" do
     it "should take user to the linked page" do
       @session.click_link('awesome image')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
 
     it "should accept partial matches" do
       @session.click_link('some imag')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
@@ -76,7 +76,7 @@ Capybara::SpecHelper.spec '#click_link' do
   context "with :href option given" do
     it "should find links with valid href" do
       @session.click_link('labore', :href => '/with_simple_html')
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
 
     it "should raise error if link wasn't found" do
@@ -87,46 +87,46 @@ Capybara::SpecHelper.spec '#click_link' do
   it "should follow relative links" do
     @session.visit('/')
     @session.click_link('Relative')
-    @session.should have_content('This is a test')
+    expect(@session).to have_content('This is a test')
   end
 
   it "should follow protocol relative links" do
     @session.click_link('Protocol')
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
   end
 
   it "should follow redirects" do
     @session.click_link('Redirect')
-    @session.should have_content('You landed')
+    expect(@session).to have_content('You landed')
   end
 
   it "should follow redirects" do
     @session.click_link('BackToMyself')
-    @session.should have_content('This is a test')
+    expect(@session).to have_content('This is a test')
   end
 
   it "should add query string to current URL with naked query string" do
     @session.click_link('Naked Query String')
-    @session.should have_content('Query String sent')
+    expect(@session).to have_content('Query String sent')
   end
 
   it "should do nothing on anchor links" do
     @session.fill_in("test_field", :with => 'blah')
     @session.click_link('Normal Anchor')
-    @session.find_field("test_field").value.should == 'blah'
+    expect(@session.find_field("test_field").value).to eq('blah')
     @session.click_link('Blank Anchor')
-    @session.find_field("test_field").value.should == 'blah'
+    expect(@session.find_field("test_field").value).to eq('blah')
   end
 
   it "should do nothing on URL+anchor links for the same page" do
     @session.fill_in("test_field", :with => 'blah')
     @session.click_link('Anchor on same page')
-    @session.find_field("test_field").value.should == 'blah'
+    expect(@session.find_field("test_field").value).to eq('blah')
   end
 
   it "should follow link on URL+anchor links for a different page" do
     @session.click_link('Anchor on different page')
-    @session.should have_content('Bar')
+    expect(@session).to have_content('Bar')
   end
 
   it "raise an error with links with no href" do
@@ -138,7 +138,7 @@ Capybara::SpecHelper.spec '#click_link' do
   context "with :exact option" do
     it "should accept partial matches when false" do
       @session.click_link('abo', :exact => false)
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
 
     it "should not accept partial matches when true" do

--- a/lib/capybara/spec/session/current_scope_spec.rb
+++ b/lib/capybara/spec/session/current_scope_spec.rb
@@ -5,14 +5,14 @@ Capybara::SpecHelper.spec '#current_scope' do
   
   context "when not in a #within block" do
     it "should return the document" do
-      @session.current_scope.should be_kind_of Capybara::Node::Document
+      expect(@session.current_scope).to be_kind_of Capybara::Node::Document
     end
   end
   
   context "when in a #within block" do
     it "should return the element in scope" do
       @session.within(:css, "#simple_first_name") do
-        @session.current_scope[:name].should eq 'first_name'
+        expect(@session.current_scope[:name]).to eq 'first_name'
       end
     end
   end
@@ -21,7 +21,7 @@ Capybara::SpecHelper.spec '#current_scope' do
     it "should return the element in scope" do
       @session.within("//div[@id='for_bar']") do
         @session.within(".//input[@value='Peter']") do
-          @session.current_scope[:name].should eq 'form[first_name]'
+          expect(@session.current_scope[:name]).to eq 'form[first_name]'
         end
       end
     end

--- a/lib/capybara/spec/session/current_url_spec.rb
+++ b/lib/capybara/spec/session/current_url_spec.rb
@@ -2,8 +2,8 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
   before :all do
     @servers = 2.times.map { Capybara::Server.new(TestApp.clone).boot }
     # sanity check
-    @servers[0].port.should_not == @servers[1].port
-    @servers.map { |s| s.port }.should_not include 80
+    expect(@servers[0].port).not_to eq(@servers[1].port)
+    expect(@servers.map { |s| s.port }).not_to include 80
   end
 
   def bases
@@ -13,12 +13,12 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
   def should_be_on server_index, path="/host", scheme="http"
     # Check that we are on /host on the given server
     s = @servers[server_index]
-    @session.current_url.chomp('?').should == "#{scheme}://#{s.host}:#{s.port}#{path}"
-    @session.current_host.should == "#{scheme}://#{s.host}" # no port
-    @session.current_path.should == path
+    expect(@session.current_url.chomp('?')).to eq("#{scheme}://#{s.host}:#{s.port}#{path}")
+    expect(@session.current_host).to eq("#{scheme}://#{s.host}") # no port
+    expect(@session.current_path).to eq(path)
     if path == '/host'
       # Server should agree with us
-      @session.should have_content("Current host is #{scheme}://#{s.host}:#{s.port}")
+      expect(@session).to have_content("Current host is #{scheme}://#{s.host}:#{s.port}")
     end
   end
 
@@ -82,12 +82,12 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
   it "is affected by pushState", :requires => [:js] do
     @session.visit("/with_js")
     @session.execute_script("window.history.pushState({}, '', '/pushed')")
-    @session.current_path.should == "/pushed"
+    expect(@session.current_path).to eq("/pushed")
   end
 
   it "is affected by replaceState", :requires => [:js] do
     @session.visit("/with_js")
     @session.execute_script("window.history.replaceState({}, '', '/replaced')")
-    @session.current_path.should == "/replaced"
+    expect(@session.current_path).to eq("/replaced")
   end
 end

--- a/lib/capybara/spec/session/evaluate_script_spec.rb
+++ b/lib/capybara/spec/session/evaluate_script_spec.rb
@@ -1,6 +1,6 @@
 Capybara::SpecHelper.spec "#evaluate_script", :requires => [:js] do
   it "should evaluate the given script and return whatever it produces" do
     @session.visit('/with_js')
-    @session.evaluate_script("1+3").should == 4
+    expect(@session.evaluate_script("1+3")).to eq(4)
   end
 end

--- a/lib/capybara/spec/session/execute_script_spec.rb
+++ b/lib/capybara/spec/session/execute_script_spec.rb
@@ -1,7 +1,7 @@
 Capybara::SpecHelper.spec "#execute_script", :requires => [:js] do
   it "should execute the given script and return nothing" do
     @session.visit('/with_js')
-    @session.execute_script("$('#change').text('Funky Doodle')").should be_nil
-    @session.should have_css('#change', :text => 'Funky Doodle')
+    expect(@session.execute_script("$('#change').text('Funky Doodle')")).to be_nil
+    expect(@session).to have_css('#change', :text => 'Funky Doodle')
   end
 end

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -6,101 +6,101 @@ Capybara::SpecHelper.spec "#fill_in" do
   it "should fill in a text field by id" do
     @session.fill_in('form_first_name', :with => 'Harry')
     @session.click_button('awesome')
-    extract_results(@session)['first_name'].should == 'Harry'
+    expect(extract_results(@session)['first_name']).to eq('Harry')
   end
 
   it "should fill in a text field by name" do
     @session.fill_in('form[last_name]', :with => 'Green')
     @session.click_button('awesome')
-    extract_results(@session)['last_name'].should == 'Green'
+    expect(extract_results(@session)['last_name']).to eq('Green')
   end
 
   it "should fill in a text field by label without for" do
     @session.fill_in('First Name', :with => 'Harry')
     @session.click_button('awesome')
-    extract_results(@session)['first_name'].should == 'Harry'
+    expect(extract_results(@session)['first_name']).to eq('Harry')
   end
 
   it "should fill in a url field by label without for" do
     @session.fill_in('Html5 Url', :with => 'http://www.avenueq.com')
     @session.click_button('html5_submit')
-    extract_results(@session)['html5_url'].should == 'http://www.avenueq.com'
+    expect(extract_results(@session)['html5_url']).to eq('http://www.avenueq.com')
   end
 
   it "should fill in a textarea by id" do
     @session.fill_in('form_description', :with => 'Texty text')
     @session.click_button('awesome')
-    extract_results(@session)['description'].should == 'Texty text'
+    expect(extract_results(@session)['description']).to eq('Texty text')
   end
 
   it "should fill in a textarea by label" do
     @session.fill_in('Description', :with => 'Texty text')
     @session.click_button('awesome')
-    extract_results(@session)['description'].should == 'Texty text'
+    expect(extract_results(@session)['description']).to eq('Texty text')
   end
 
   it "should fill in a textarea by name" do
     @session.fill_in('form[description]', :with => 'Texty text')
     @session.click_button('awesome')
-    extract_results(@session)['description'].should == 'Texty text'
+    expect(extract_results(@session)['description']).to eq('Texty text')
   end
 
   it "should fill in a password field by id" do
     @session.fill_in('form_password', :with => 'supasikrit')
     @session.click_button('awesome')
-    extract_results(@session)['password'].should == 'supasikrit'
+    expect(extract_results(@session)['password']).to eq('supasikrit')
   end
 
   it "should handle HTML in a textarea" do
     @session.fill_in('form_description', :with => 'is <strong>very</strong> secret!')
     @session.click_button('awesome')
-    extract_results(@session)['description'].should == 'is <strong>very</strong> secret!'
+    expect(extract_results(@session)['description']).to eq('is <strong>very</strong> secret!')
   end
 
   it "should handle newlines in a textarea" do
     @session.fill_in('form_description', :with => "\nSome text\n")
     @session.click_button('awesome')
-    extract_results(@session)['description'].should == "\r\nSome text\r\n"
+    expect(extract_results(@session)['description']).to eq("\r\nSome text\r\n")
   end
 
   it "should fill in a field with a custom type" do
     @session.fill_in('Schmooo', :with => 'Schmooo is the game')
     @session.click_button('awesome')
-    extract_results(@session)['schmooo'].should == 'Schmooo is the game'
+    expect(extract_results(@session)['schmooo']).to eq('Schmooo is the game')
   end
 
   it "should fill in a field without a type" do
     @session.fill_in('Phone', :with => '+1 555 7022')
     @session.click_button('awesome')
-    extract_results(@session)['phone'].should == '+1 555 7022'
+    expect(extract_results(@session)['phone']).to eq('+1 555 7022')
   end
 
   it "should fill in a text field respecting its maxlength attribute" do
     @session.fill_in('Zipcode', :with => '52071350')
     @session.click_button('awesome')
-    extract_results(@session)['zipcode'].should == '52071'
+    expect(extract_results(@session)['zipcode']).to eq('52071')
   end
 
   it "should fill in a password field by name" do
     @session.fill_in('form[password]', :with => 'supasikrit')
     @session.click_button('awesome')
-    extract_results(@session)['password'].should == 'supasikrit'
+    expect(extract_results(@session)['password']).to eq('supasikrit')
   end
 
   it "should fill in a password field by label" do
     @session.fill_in('Password', :with => 'supasikrit')
     @session.click_button('awesome')
-    extract_results(@session)['password'].should == 'supasikrit'
+    expect(extract_results(@session)['password']).to eq('supasikrit')
   end
 
   it "should fill in a password field by name" do
     @session.fill_in('form[password]', :with => 'supasikrit')
     @session.click_button('awesome')
-    extract_results(@session)['password'].should == 'supasikrit'
+    expect(extract_results(@session)['password']).to eq('supasikrit')
   end
 
   it "should throw an exception if a hash containing 'with' is not provided" do
-    lambda{@session.fill_in 'Name', 'ignu'}.should raise_error
+    expect {@session.fill_in 'Name', 'ignu'}.to raise_error
   end
 
   it "should wait for asynchronous load", :requires => [:js] do
@@ -112,13 +112,13 @@ Capybara::SpecHelper.spec "#fill_in" do
   it "casts to string" do
     @session.fill_in(:'form_first_name', :with => :'Harry')
     @session.click_button('awesome')
-    extract_results(@session)['first_name'].should == 'Harry'
+    expect(extract_results(@session)['first_name']).to eq('Harry')
   end
 
   it "casts to string if field has maxlength" do
     @session.fill_in(:'form_zipcode', :with => 1234567)
     @session.click_button('awesome')
-    extract_results(@session)['zipcode'].should == '12345'
+    expect(extract_results(@session)['zipcode']).to eq('12345')
   end
 
   context 'on a pre-populated textfield with a reformatting onchange', :requires => [:js] do
@@ -127,7 +127,7 @@ Capybara::SpecHelper.spec "#fill_in" do
       @session.fill_in('with_change_event', :with => 'some value')
       # click outside the field to trigger the change event
       @session.find(:css, 'body').click
-      @session.find(:css, '.change_event_triggered', :match => :one).should have_text 'some value'
+      expect(@session.find(:css, '.change_event_triggered', :match => :one)).to have_text 'some value'
     end
 
     it 'should trigger change when clearing field' do
@@ -135,7 +135,7 @@ Capybara::SpecHelper.spec "#fill_in" do
       @session.fill_in('with_change_event', :with => '')
       # click outside the field to trigger the change event
       @session.find(:css, 'body').click
-      @session.should have_selector(:css, '.change_event_triggered', :match => :one)
+      expect(@session).to have_selector(:css, '.change_event_triggered', :match => :one)
     end
   end
 
@@ -171,7 +171,7 @@ Capybara::SpecHelper.spec "#fill_in" do
     it "should accept partial matches when false" do
       @session.fill_in("Explanation", :with => "Dude", :exact => false)
       @session.click_button("awesome")
-      extract_results(@session)["name_explanation"].should == "Dude"
+      expect(extract_results(@session)["name_explanation"]).to eq("Dude")
     end
 
     it "should not accept partial matches when true" do

--- a/lib/capybara/spec/session/find_button_spec.rb
+++ b/lib/capybara/spec/session/find_button_spec.rb
@@ -4,12 +4,12 @@ Capybara::SpecHelper.spec '#find_button' do
   end
 
   it "should find any button" do
-    @session.find_button('med')[:id].should == "mediocre"
-    @session.find_button('crap321').value.should == "crappy"
+    expect(@session.find_button('med')[:id]).to eq("mediocre")
+    expect(@session.find_button('crap321').value).to eq("crappy")
   end
 
   it "casts to string" do
-    @session.find_button(:'med')[:id].should == "mediocre"
+    expect(@session.find_button(:'med')[:id]).to eq("mediocre")
   end
 
   it "should raise error if the button doesn't exist" do
@@ -20,7 +20,7 @@ Capybara::SpecHelper.spec '#find_button' do
 
   context "with :exact option" do
     it "should accept partial matches when false" do
-      @session.find_button('What an Awesome', :exact => false)[:value].should == "awesome"
+      expect(@session.find_button('What an Awesome', :exact => false)[:value]).to eq("awesome")
     end
 
     it "should not accept partial matches when true" do

--- a/lib/capybara/spec/session/find_by_id_spec.rb
+++ b/lib/capybara/spec/session/find_by_id_spec.rb
@@ -4,11 +4,11 @@ Capybara::SpecHelper.spec '#find_by_id' do
   end
 
   it "should find any element by id" do
-    @session.find_by_id('red').tag_name.should == 'a'
+    expect(@session.find_by_id('red').tag_name).to eq('a')
   end
 
   it "casts to string" do
-    @session.find_by_id(:'red').tag_name.should == 'a'
+    expect(@session.find_by_id(:'red').tag_name).to eq('a')
   end
 
   it "should raise error if no element with id is found" do
@@ -19,7 +19,7 @@ Capybara::SpecHelper.spec '#find_by_id' do
 
   context "with :visible option" do
     it "finds invisible elements when `false`" do
-      @session.find_by_id("hidden_via_ancestor", :visible => false).text(:all).should =~ /with hidden ancestor/
+      expect(@session.find_by_id("hidden_via_ancestor", :visible => false).text(:all)).to match(/with hidden ancestor/)
     end
 
     it "finds invisible elements when `false`" do

--- a/lib/capybara/spec/session/find_field_spec.rb
+++ b/lib/capybara/spec/session/find_field_spec.rb
@@ -4,13 +4,13 @@ Capybara::SpecHelper.spec '#find_field' do
   end
 
   it "should find any field" do
-    @session.find_field('Dog').value.should == 'dog'
-    @session.find_field('form_description').text.should == 'Descriptive text goes here'
-    @session.find_field('Region')[:name].should == 'form[region]'
+    expect(@session.find_field('Dog').value).to eq('dog')
+    expect(@session.find_field('form_description').text).to eq('Descriptive text goes here')
+    expect(@session.find_field('Region')[:name]).to eq('form[region]')
   end
 
   it "casts to string" do
-    @session.find_field(:'Dog').value.should == 'dog'
+    expect(@session.find_field(:'Dog').value).to eq('dog')
   end
 
   it "should raise error if the field doesn't exist" do
@@ -20,7 +20,7 @@ Capybara::SpecHelper.spec '#find_field' do
   end
 
   it "should be aliased as 'field_labeled' for webrat compatibility" do
-    @session.field_labeled('Dog').value.should == 'dog'
+    expect(@session.field_labeled('Dog').value).to eq('dog')
     expect do
       @session.field_labeled('Does not exist')
     end.to raise_error(Capybara::ElementNotFound)
@@ -28,7 +28,7 @@ Capybara::SpecHelper.spec '#find_field' do
 
   context "with :exact option" do
     it "should accept partial matches when false" do
-      @session.find_field("Explanation", :exact => false)[:name].should == "form[name_explanation]"
+      expect(@session.find_field("Explanation", :exact => false)[:name]).to eq("form[name_explanation]")
     end
 
     it "should not accept partial matches when true" do
@@ -40,7 +40,7 @@ Capybara::SpecHelper.spec '#find_field' do
 
   context "with :disabled option" do
     it "should find disabled fields when true" do
-      @session.find_field("Disabled Checkbox", :disabled => true)[:name].should == "form[disabled_checkbox]"
+      expect(@session.find_field("Disabled Checkbox", :disabled => true)[:name]).to eq("form[disabled_checkbox]")
     end
 
     it "should not find disabled fields when false" do

--- a/lib/capybara/spec/session/find_link_spec.rb
+++ b/lib/capybara/spec/session/find_link_spec.rb
@@ -4,12 +4,12 @@ Capybara::SpecHelper.spec '#find_link' do
   end
 
   it "should find any field" do
-    @session.find_link('foo').text.should == "ullamco"
-    @session.find_link('labore')[:href].should =~ %r(/with_simple_html$)
+    expect(@session.find_link('foo').text).to eq("ullamco")
+    expect(@session.find_link('labore')[:href]).to match %r(/with_simple_html$)
   end
 
   it "casts to string" do
-    @session.find_link(:'foo').text.should == "ullamco"
+    expect(@session.find_link(:'foo').text).to eq("ullamco")
   end
 
   it "should raise error if the field doesn't exist" do
@@ -20,7 +20,7 @@ Capybara::SpecHelper.spec '#find_link' do
 
   context "with :exact option" do
     it "should accept partial matches when false" do
-      @session.find_link('abo', :exact => false).text.should == "labore"
+      expect(@session.find_link('abo', :exact => false).text).to eq("labore")
     end
 
     it "should not accept partial matches when true" do

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -8,13 +8,13 @@ Capybara::SpecHelper.spec '#find' do
   end
 
   it "should find the first element using the given locator" do
-    @session.find('//h1').text.should == 'This is a test'
-    @session.find("//input[@id='test_field']")[:value].should == 'monkey'
+    expect(@session.find('//h1').text).to eq('This is a test')
+    expect(@session.find("//input[@id='test_field']")[:value]).to eq('monkey')
   end
 
   it "should find the first element using the given locator and options" do
-    @session.find('//a', :text => 'Redirect')[:id].should == 'red'
-    @session.find(:css, 'a', :text => 'A link came first')[:title].should == 'twas a fine link'
+    expect(@session.find('//a', :text => 'Redirect')[:id]).to eq('red')
+    expect(@session.find(:css, 'a', :text => 'A link came first')[:title]).to eq('twas a fine link')
   end
 
   it "should raise an error if there are multiple matches" do
@@ -24,12 +24,12 @@ Capybara::SpecHelper.spec '#find' do
   it "should wait for asynchronous load", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.find(:css, "a#has-been-clicked").text.should include('Has been clicked')
+    expect(@session.find(:css, "a#has-been-clicked").text).to include('Has been clicked')
   end
 
   context "with :text option" do
     it "casts text's argument to string" do
-      @session.find(:css, '.number', text: 42).should have_content("42")
+      expect(@session.find(:css, '.number', text: 42)).to have_content("42")
     end
   end
 
@@ -53,7 +53,7 @@ Capybara::SpecHelper.spec '#find' do
     it "should find element if it appears before given wait duration" do
       @session.visit('/with_js')
       @session.click_link('Click me')
-      @session.find(:css, "a#has-been-clicked", :wait => 0.9).text.should include('Has been clicked')
+      expect(@session.find(:css, "a#has-been-clicked", :wait => 0.9).text).to include('Has been clicked')
     end
   end
 
@@ -61,26 +61,26 @@ Capybara::SpecHelper.spec '#find' do
     it "raises an error suggesting that Capybara is stuck in time" do
       @session.visit('/with_js')
       now = Time.now
-      Time.stub(:now).and_return(now)
+      allow(Time).to receive(:now).and_return(now)
       expect { @session.find('//isnotthere') }.to raise_error(Capybara::FrozenInTime)
     end
   end
 
   context "with css selectors" do
     it "should find the first element using the given locator" do
-      @session.find(:css, 'h1').text.should == 'This is a test'
-      @session.find(:css, "input[id='test_field']")[:value].should == 'monkey'
+      expect(@session.find(:css, 'h1').text).to eq('This is a test')
+      expect(@session.find(:css, "input[id='test_field']")[:value]).to eq('monkey')
     end
 
     it "should support pseudo selectors" do
-      @session.find(:css, 'input:disabled').value.should == 'This is disabled'
+      expect(@session.find(:css, 'input:disabled').value).to eq('This is disabled')
     end
   end
 
   context "with xpath selectors" do
     it "should find the first element using the given locator" do
-      @session.find(:xpath, '//h1').text.should == 'This is a test'
-      @session.find(:xpath, "//input[@id='test_field']")[:value].should == 'monkey'
+      expect(@session.find(:xpath, '//h1').text).to eq('This is a test')
+      expect(@session.find(:xpath, "//input[@id='test_field']")[:value]).to eq('monkey')
     end
   end
 
@@ -89,8 +89,8 @@ Capybara::SpecHelper.spec '#find' do
       Capybara.add_selector(:beatle) do
         xpath { |name| ".//*[@id='#{name}']" }
       end
-      @session.find(:beatle, 'john').text.should == 'John'
-      @session.find(:beatle, 'paul').text.should == 'Paul'
+      expect(@session.find(:beatle, 'john').text).to eq('John')
+      expect(@session.find(:beatle, 'paul').text).to eq('Paul')
     end
   end
 
@@ -100,10 +100,10 @@ Capybara::SpecHelper.spec '#find' do
         xpath { |num| ".//*[contains(@class, 'beatle')][#{num}]" }
         match { |value| value.is_a?(Fixnum) }
       end
-      @session.find(:beatle, '2').text.should == 'Paul'
-      @session.find(1).text.should == 'John'
-      @session.find(2).text.should == 'Paul'
-      @session.find('//h1').text.should == 'This is a test'
+      expect(@session.find(:beatle, '2').text).to eq('Paul')
+      expect(@session.find(1).text).to eq('John')
+      expect(@session.find(2).text).to eq('Paul')
+      expect(@session.find('//h1').text).to eq('This is a test')
     end
   end
 
@@ -116,13 +116,13 @@ Capybara::SpecHelper.spec '#find' do
     end
 
     it "should find elements that match the filter" do
-      @session.find(:beatle, 'Paul', :type => 'drummer').text.should == 'Paul'
-      @session.find(:beatle, 'Ringo', :type => 'drummer').text.should == 'Ringo'
+      expect(@session.find(:beatle, 'Paul', :type => 'drummer').text).to eq('Paul')
+      expect(@session.find(:beatle, 'Ringo', :type => 'drummer').text).to eq('Ringo')
     end
 
     it "ignores filter when it is not given" do
-      @session.find(:beatle, 'Paul').text.should == 'Paul'
-      @session.find(:beatle, 'John').text.should == 'John'
+      expect(@session.find(:beatle, 'Paul').text).to eq('Paul')
+      expect(@session.find(:beatle, 'John').text).to eq('John')
     end
 
     it "should not find elements that don't match the filter" do
@@ -140,12 +140,12 @@ Capybara::SpecHelper.spec '#find' do
     end
 
     it "should find elements that match the filter" do
-      @session.find(:beatle, 'Paul', :type => 'drummer').text.should == 'Paul'
-      @session.find(:beatle, 'Ringo', :type => 'drummer').text.should == 'Ringo'
+      expect(@session.find(:beatle, 'Paul', :type => 'drummer').text).to eq('Paul')
+      expect(@session.find(:beatle, 'Ringo', :type => 'drummer').text).to eq('Ringo')
     end
 
     it "should use default value when filter is not given" do
-      @session.find(:beatle, 'Paul').text.should == 'Paul'
+      expect(@session.find(:beatle, 'Paul').text).to eq('Paul')
       expect { @session.find(:beatle, 'John') }.to raise_error(Capybara::ElementNotFound)
     end
 
@@ -158,8 +158,8 @@ Capybara::SpecHelper.spec '#find' do
   context "with css as default selector" do
     before { Capybara.default_selector = :css }
     it "should find the first element using the given locator" do
-      @session.find('h1').text.should == 'This is a test'
-      @session.find("input[id='test_field']")[:value].should == 'monkey'
+      expect(@session.find('h1').text).to eq('This is a test')
+      expect(@session.find("input[id='test_field']")[:value]).to eq('monkey')
     end
     after { Capybara.default_selector = :xpath }
   end
@@ -173,20 +173,20 @@ Capybara::SpecHelper.spec '#find' do
   it "should accept an XPath instance" do
     @session.visit('/form')
     @xpath = XPath::HTML.fillable_field('First Name')
-    @session.find(@xpath).value.should == 'John'
+    expect(@session.find(@xpath).value).to eq('John')
   end
 
   context "with :exact option" do
     it "matches exactly when true" do
-      @session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("test_field")], :exact => true).value.should == "monkey"
+      expect(@session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("test_field")], :exact => true).value).to eq("monkey")
       expect do
         @session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("est_fiel")], :exact => true)
       end.to raise_error(Capybara::ElementNotFound)
     end
 
     it "matches loosely when false" do
-      @session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("test_field")], :exact => false).value.should == "monkey"
-      @session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("est_fiel")], :exact => false).value.should == "monkey"
+      expect(@session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("test_field")], :exact => false).value).to eq("monkey")
+      expect(@session.find(:xpath, XPath.descendant(:input)[XPath.attr(:id).is("est_fiel")], :exact => false).value).to eq("monkey")
     end
 
     it "defaults to `Capybara.exact`" do
@@ -212,7 +212,7 @@ Capybara::SpecHelper.spec '#find' do
         end.to raise_error(Capybara::Ambiguous)
       end
       it "returns the element if there is only one" do
-        @session.find(:css, ".singular", :match => :one).text.should == "singular"
+        expect(@session.find(:css, ".singular", :match => :one).text).to eq("singular")
       end
       it "raises an error if there is no match" do
         expect do
@@ -223,7 +223,7 @@ Capybara::SpecHelper.spec '#find' do
 
     context "when set to `first`" do
       it "returns the first matched element" do
-        @session.find(:css, ".multiple", :match => :first).text.should == "multiple one"
+        expect(@session.find(:css, ".multiple", :match => :first).text).to eq("multiple one")
       end
       it "raises an error if there is no match" do
         expect do
@@ -241,7 +241,7 @@ Capybara::SpecHelper.spec '#find' do
         end
         it "finds a single exact match when there also are inexact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singular")], :match => :smart, :exact => false)
-          result.text.should == "almost singular"
+          expect(result.text).to eq("almost singular")
         end
         it "raises an error when there are multiple inexact matches" do
           expect do
@@ -250,7 +250,7 @@ Capybara::SpecHelper.spec '#find' do
         end
         it "finds a single inexact match" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singular but")], :match => :smart, :exact => false)
-          result.text.should == "almost singular but not quite"
+          expect(result.text).to eq("almost singular but not quite")
         end
         it "raises an error if there is no match" do
           expect do
@@ -267,7 +267,7 @@ Capybara::SpecHelper.spec '#find' do
         end
         it "finds a single exact match when there also are inexact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singular")], :match => :smart, :exact => true)
-          result.text.should == "almost singular"
+          expect(result.text).to eq("almost singular")
         end
         it "raises an error when there are multiple inexact matches" do
           expect do
@@ -291,19 +291,19 @@ Capybara::SpecHelper.spec '#find' do
       context "and `exact` set to `false`" do
         it "picks the first one when there are multiple exact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("multiple")], :match => :prefer_exact, :exact => false)
-          result.text.should == "multiple one"
+          expect(result.text).to eq("multiple one")
         end
         it "finds a single exact match when there also are inexact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singular")], :match => :prefer_exact, :exact => false)
-          result.text.should == "almost singular"
+          expect(result.text).to eq("almost singular")
         end
         it "picks the first one when there are multiple inexact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singul")], :match => :prefer_exact, :exact => false)
-          result.text.should == "almost singular but not quite"
+          expect(result.text).to eq("almost singular but not quite")
         end
         it "finds a single inexact match" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singular but")], :match => :prefer_exact, :exact => false)
-          result.text.should == "almost singular but not quite"
+          expect(result.text).to eq("almost singular but not quite")
         end
         it "raises an error if there is no match" do
           expect do
@@ -315,11 +315,11 @@ Capybara::SpecHelper.spec '#find' do
       context "with `exact` set to `true`" do
         it "picks the first one when there are multiple exact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("multiple")], :match => :prefer_exact, :exact => true)
-          result.text.should == "multiple one"
+          expect(result.text).to eq("multiple one")
         end
         it "finds a single exact match when there also are inexact matches" do
           result = @session.find(:xpath, XPath.descendant[XPath.attr(:class).is("almost_singular")], :match => :prefer_exact, :exact => true)
-          result.text.should == "almost singular"
+          expect(result.text).to eq("almost singular")
         end
         it "raises an error if there are multiple inexact matches" do
           expect do
@@ -345,7 +345,7 @@ Capybara::SpecHelper.spec '#find' do
         @session.find(:css, ".multiple")
       end.to raise_error(Capybara::Ambiguous)
       Capybara.match = :first
-      @session.find(:css, ".multiple").text.should == "multiple one"
+      expect(@session.find(:css, ".multiple").text).to eq("multiple one")
     end
 
     it "raises an error when unknown option given" do
@@ -362,13 +362,13 @@ Capybara::SpecHelper.spec '#find' do
 
     it "should find the an element using the given locator" do
       @session.within(:xpath, "//div[@id='for_bar']") do
-        @session.find('.//li[1]').text.should =~ /With Simple HTML/
+        expect(@session.find('.//li[1]').text).to match(/With Simple HTML/)
       end
     end
 
     it "should support pseudo selectors" do
       @session.within(:xpath, "//div[@id='for_bar']") do
-        @session.find(:css, 'input:disabled').value.should == 'James'
+        expect(@session.find(:css, 'input:disabled').value).to eq('James')
       end
     end
   end

--- a/lib/capybara/spec/session/first_spec.rb
+++ b/lib/capybara/spec/session/first_spec.rb
@@ -4,73 +4,73 @@ Capybara::SpecHelper.spec '#first' do
   end
 
   it "should find the first element using the given locator" do
-    @session.first('//h1').text.should == 'This is a test'
-    @session.first("//input[@id='test_field']")[:value].should == 'monkey'
+    expect(@session.first('//h1').text).to eq('This is a test')
+    expect(@session.first("//input[@id='test_field']")[:value]).to eq('monkey')
   end
 
   it "should return nil when nothing was found" do
-    @session.first('//div[@id="nosuchthing"]').should be_nil
+    expect(@session.first('//div[@id="nosuchthing"]')).to be_nil
   end
 
   it "should accept an XPath instance" do
     @session.visit('/form')
     @xpath = XPath::HTML.fillable_field('First Name')
-    @session.first(@xpath).value.should == 'John'
+    expect(@session.first(@xpath).value).to eq('John')
   end
 
   context "with css selectors" do
     it "should find the first element using the given selector" do
-      @session.first(:css, 'h1').text.should == 'This is a test'
-      @session.first(:css, "input[id='test_field']")[:value].should == 'monkey'
+      expect(@session.first(:css, 'h1').text).to eq('This is a test')
+      expect(@session.first(:css, "input[id='test_field']")[:value]).to eq('monkey')
     end
   end
 
   context "with xpath selectors" do
     it "should find the first element using the given locator" do
-      @session.first(:xpath, '//h1').text.should == 'This is a test'
-      @session.first(:xpath, "//input[@id='test_field']")[:value].should == 'monkey'
+      expect(@session.first(:xpath, '//h1').text).to eq('This is a test')
+      expect(@session.first(:xpath, "//input[@id='test_field']")[:value]).to eq('monkey')
     end
   end
 
   context "with css as default selector" do
     before { Capybara.default_selector = :css }
     it "should find the first element using the given locator" do
-      @session.first('h1').text.should == 'This is a test'
-      @session.first("input[id='test_field']")[:value].should == 'monkey'
+      expect(@session.first('h1').text).to eq('This is a test')
+      expect(@session.first("input[id='test_field']")[:value]).to eq('monkey')
     end
   end
 
   context "with visible filter" do
     it "should only find visible nodes when true" do
-      @session.first(:css, "a#invisible", :visible => true).should be_nil
+      expect(@session.first(:css, "a#invisible", :visible => true)).to be_nil
     end
 
     it "should find nodes regardless of whether they are invisible when false" do
-      @session.first(:css, "a#invisible", :visible => false).should_not be_nil
-      @session.first(:css, "a#visible", :visible => false).should_not be_nil
+      expect(@session.first(:css, "a#invisible", :visible => false)).not_to be_nil
+      expect(@session.first(:css, "a#visible", :visible => false)).not_to be_nil
     end
 
     it "should find nodes regardless of whether they are invisible when :all" do
-      @session.first(:css, "a#invisible", :visible => :all).should_not be_nil
-      @session.first(:css, "a#visible", :visible => :all).should_not be_nil
+      expect(@session.first(:css, "a#invisible", :visible => :all)).not_to be_nil
+      expect(@session.first(:css, "a#visible", :visible => :all)).not_to be_nil
     end
 
     it "should find only hidden nodes when :hidden" do
-      @session.first(:css, "a#invisible", :visible => :hidden).should_not be_nil
-      @session.first(:css, "a#visible", :visible => :hidden).should be_nil
+      expect(@session.first(:css, "a#invisible", :visible => :hidden)).not_to be_nil
+      expect(@session.first(:css, "a#visible", :visible => :hidden)).to be_nil
     end
 
     it "should find only visible nodes when :visible" do
-      @session.first(:css, "a#invisible", :visible => :visible).should be_nil
-      @session.first(:css, "a#visible", :visible => :visible).should_not be_nil
+      expect(@session.first(:css, "a#invisible", :visible => :visible)).to be_nil
+      expect(@session.first(:css, "a#visible", :visible => :visible)).not_to be_nil
     end
 
     it "should default to Capybara.ignore_hidden_elements" do
       Capybara.ignore_hidden_elements = true
-      @session.first(:css, "a#invisible").should be_nil
+      expect(@session.first(:css, "a#invisible")).to be_nil
       Capybara.ignore_hidden_elements = false
-      @session.first(:css, "a#invisible").should_not be_nil
-      @session.first(:css, "a").should_not be_nil
+      expect(@session.first(:css, "a#invisible")).not_to be_nil
+      expect(@session.first(:css, "a")).not_to be_nil
     end
   end
 
@@ -81,7 +81,7 @@ Capybara::SpecHelper.spec '#first' do
 
     it "should find the first element using the given locator" do
       @session.within(:xpath, "//div[@id='for_bar']") do
-        @session.first('.//form').should_not be_nil
+        expect(@session.first('.//form')).not_to be_nil
       end
     end
   end

--- a/lib/capybara/spec/session/go_back_spec.rb
+++ b/lib/capybara/spec/session/go_back_spec.rb
@@ -1,10 +1,10 @@
 Capybara::SpecHelper.spec '#go_back', :requires => [:js] do
   it "should fetch a response from the driver from the previous page" do
     @session.visit('/')
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
     @session.visit('/foo')
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
     @session.go_back
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
   end
 end

--- a/lib/capybara/spec/session/go_forward_spec.rb
+++ b/lib/capybara/spec/session/go_forward_spec.rb
@@ -1,12 +1,12 @@
 Capybara::SpecHelper.spec '#go_forward', :requires => [:js] do
   it "should fetch a response from the driver from the previous page" do
     @session.visit('/')
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
     @session.visit('/foo')
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
     @session.go_back
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
     @session.go_forward
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
   end
 end

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -4,25 +4,25 @@ Capybara::SpecHelper.spec '#has_button?' do
   end
 
   it "should be true if the given button is on the page" do
-    @session.should have_button('med')
-    @session.should have_button('crap321')
-    @session.should have_button(:'crap321')
+    expect(@session).to have_button('med')
+    expect(@session).to have_button('crap321')
+    expect(@session).to have_button(:'crap321')
   end
 
   it "should be true for disabled buttons if :disabled => true" do
-    @session.should have_button('Disabled button', :disabled => true)
+    expect(@session).to have_button('Disabled button', :disabled => true)
   end
 
   it "should be false if the given button is not on the page" do
-    @session.should_not have_button('monkey')
+    expect(@session).not_to have_button('monkey')
   end
 
   it "should be false for disabled buttons by default" do
-    @session.should_not have_button('Disabled button')
+    expect(@session).not_to have_button('Disabled button')
   end
 
   it "should be false for disabled buttons if :disabled => false" do
-    @session.should_not have_button('Disabled button', :disabled => false)
+    expect(@session).not_to have_button('Disabled button', :disabled => false)
   end
 end
 
@@ -32,23 +32,23 @@ Capybara::SpecHelper.spec '#has_no_button?' do
   end
 
   it "should be true if the given button is on the page" do
-    @session.should_not have_no_button('med')
-    @session.should_not have_no_button('crap321')
+    expect(@session).not_to have_no_button('med')
+    expect(@session).not_to have_no_button('crap321')
   end
 
   it "should be true for disabled buttons if :disabled => true" do
-    @session.should_not have_no_button('Disabled button', :disabled => true)
+    expect(@session).not_to have_no_button('Disabled button', :disabled => true)
   end
 
   it "should be false if the given button is not on the page" do
-    @session.should have_no_button('monkey')
+    expect(@session).to have_no_button('monkey')
   end
 
   it "should be false for disabled buttons by default" do
-    @session.should have_no_button('Disabled button')
+    expect(@session).to have_no_button('Disabled button')
   end
 
   it "should be false for disabled buttons if :disabled => false" do
-    @session.should have_no_button('Disabled button', :disabled => false)
+    expect(@session).to have_no_button('Disabled button', :disabled => false)
   end
 end

--- a/lib/capybara/spec/session/has_css_spec.rb
+++ b/lib/capybara/spec/session/has_css_spec.rb
@@ -4,111 +4,111 @@ Capybara::SpecHelper.spec '#has_css?' do
   end
 
   it "should be true if the given selector is on the page" do
-    @session.should have_css("p")
-    @session.should have_css("p a#foo")
+    expect(@session).to have_css("p")
+    expect(@session).to have_css("p a#foo")
   end
 
   it "should be false if the given selector is not on the page" do
-    @session.should_not have_css("abbr")
-    @session.should_not have_css("p a#doesnotexist")
-    @session.should_not have_css("p.nosuchclass")
+    expect(@session).not_to have_css("abbr")
+    expect(@session).not_to have_css("p a#doesnotexist")
+    expect(@session).not_to have_css("p.nosuchclass")
   end
 
   it "should respect scopes" do
     @session.within "//p[@id='first']" do
-      @session.should have_css("a#foo")
-      @session.should_not have_css("a#red")
+      expect(@session).to have_css("a#foo")
+      expect(@session).not_to have_css("a#red")
     end
   end
 
   it "should wait for content to appear", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.should have_css("input[type='submit'][value='New Here']")
+    expect(@session).to have_css("input[type='submit'][value='New Here']")
   end
 
   context "with between" do
     it "should be true if the content occurs within the range given" do
-      @session.should have_css("p", :between => 1..4)
-      @session.should have_css("p a#foo", :between => 1..3)
-      @session.should have_css("p a.doesnotexist", :between => 0..8)
+      expect(@session).to have_css("p", :between => 1..4)
+      expect(@session).to have_css("p a#foo", :between => 1..3)
+      expect(@session).to have_css("p a.doesnotexist", :between => 0..8)
     end
 
     it "should be false if the content occurs more or fewer times than range" do
-      @session.should_not have_css("p", :between => 6..11 )
-      @session.should_not have_css("p a#foo", :between => 4..7)
-      @session.should_not have_css("p a.doesnotexist", :between => 3..8)
+      expect(@session).not_to have_css("p", :between => 6..11 )
+      expect(@session).not_to have_css("p a#foo", :between => 4..7)
+      expect(@session).not_to have_css("p a.doesnotexist", :between => 3..8)
     end
   end
 
   context "with count" do
     it "should be true if the content occurs the given number of times" do
-      @session.should have_css("p", :count => 3)
-      @session.should have_css("p a#foo", :count => 1)
-      @session.should have_css("p a.doesnotexist", :count => 0)
+      expect(@session).to have_css("p", :count => 3)
+      expect(@session).to have_css("p a#foo", :count => 1)
+      expect(@session).to have_css("p a.doesnotexist", :count => 0)
     end
 
     it "should be false if the content occurs a different number of times than the given" do
-      @session.should_not have_css("p", :count => 6)
-      @session.should_not have_css("p a#foo", :count => 2)
-      @session.should_not have_css("p a.doesnotexist", :count => 1)
+      expect(@session).not_to have_css("p", :count => 6)
+      expect(@session).not_to have_css("p a#foo", :count => 2)
+      expect(@session).not_to have_css("p a.doesnotexist", :count => 1)
     end
 
     it "should coerce count to an integer" do
-      @session.should have_css("p", :count => "3")
-      @session.should have_css("p a#foo", :count => "1")
+      expect(@session).to have_css("p", :count => "3")
+      expect(@session).to have_css("p a#foo", :count => "1")
     end
   end
 
   context "with maximum" do
     it "should be true when content occurs same or fewer times than given" do
-      @session.should have_css("h2.head", :maximum => 5) # edge case
-      @session.should have_css("h2", :maximum => 10)
-      @session.should have_css("p a.doesnotexist", :maximum => 1)
-      @session.should have_css("p a.doesnotexist", :maximum => 0)
+      expect(@session).to have_css("h2.head", :maximum => 5) # edge case
+      expect(@session).to have_css("h2", :maximum => 10)
+      expect(@session).to have_css("p a.doesnotexist", :maximum => 1)
+      expect(@session).to have_css("p a.doesnotexist", :maximum => 0)
     end
 
     it "should be false when content occurs more times than given" do
-      @session.should_not have_css("h2.head", :maximum => 4) # edge case
-      @session.should_not have_css("h2", :maximum => 3)
-      @session.should_not have_css("p", :maximum => 1)
+      expect(@session).not_to have_css("h2.head", :maximum => 4) # edge case
+      expect(@session).not_to have_css("h2", :maximum => 3)
+      expect(@session).not_to have_css("p", :maximum => 1)
     end
 
     it "should coerce maximum to an integer" do
-      @session.should have_css("h2.head", :maximum => "5") # edge case
-      @session.should have_css("h2", :maximum => "10")
+      expect(@session).to have_css("h2.head", :maximum => "5") # edge case
+      expect(@session).to have_css("h2", :maximum => "10")
     end
   end
 
   context "with minimum" do
     it "should be true when content occurs same or more times than given" do
-      @session.should have_css("h2.head", :minimum => 5) # edge case
-      @session.should have_css("h2", :minimum => 3)
-      @session.should have_css("p a.doesnotexist", :minimum => 0)
+      expect(@session).to have_css("h2.head", :minimum => 5) # edge case
+      expect(@session).to have_css("h2", :minimum => 3)
+      expect(@session).to have_css("p a.doesnotexist", :minimum => 0)
     end
 
     it "should be false when content occurs fewer times than given" do
-      @session.should_not have_css("h2.head", :minimum => 6) # edge case
-      @session.should_not have_css("h2", :minimum => 8)
-      @session.should_not have_css("p", :minimum => 10)
-      @session.should_not have_css("p a.doesnotexist", :minimum => 1)
+      expect(@session).not_to have_css("h2.head", :minimum => 6) # edge case
+      expect(@session).not_to have_css("h2", :minimum => 8)
+      expect(@session).not_to have_css("p", :minimum => 10)
+      expect(@session).not_to have_css("p a.doesnotexist", :minimum => 1)
     end
 
     it "should coerce minimum to an integer" do
-      @session.should have_css("h2.head", :minimum => "5") # edge case
-      @session.should have_css("h2", :minimum => "3")
+      expect(@session).to have_css("h2.head", :minimum => "5") # edge case
+      expect(@session).to have_css("h2", :minimum => "3")
     end
   end
 
   context "with text" do
     it "should discard all matches where the given string is not contained" do
-      @session.should have_css("p a", :text => "Redirect", :count => 1)
-      @session.should_not have_css("p a", :text => "Doesnotexist")
+      expect(@session).to have_css("p a", :text => "Redirect", :count => 1)
+      expect(@session).not_to have_css("p a", :text => "Doesnotexist")
     end
 
     it "should discard all matches where the given regexp is not matched" do
-      @session.should have_css("p a", :text => /re[dab]i/i, :count => 1)
-      @session.should_not have_css("p a", :text => /Red$/)
+      expect(@session).to have_css("p a", :text => /re[dab]i/i, :count => 1)
+      expect(@session).not_to have_css("p a", :text => /Red$/)
     end
   end
 end
@@ -119,110 +119,110 @@ Capybara::SpecHelper.spec '#has_no_css?' do
   end
 
   it "should be false if the given selector is on the page" do
-    @session.should_not have_no_css("p")
-    @session.should_not have_no_css("p a#foo")
+    expect(@session).not_to have_no_css("p")
+    expect(@session).not_to have_no_css("p a#foo")
   end
 
   it "should be true if the given selector is not on the page" do
-    @session.should have_no_css("abbr")
-    @session.should have_no_css("p a#doesnotexist")
-    @session.should have_no_css("p.nosuchclass")
+    expect(@session).to have_no_css("abbr")
+    expect(@session).to have_no_css("p a#doesnotexist")
+    expect(@session).to have_no_css("p.nosuchclass")
   end
 
   it "should respect scopes" do
     @session.within "//p[@id='first']" do
-      @session.should_not have_no_css("a#foo")
-      @session.should have_no_css("a#red")
+      expect(@session).not_to have_no_css("a#foo")
+      expect(@session).to have_no_css("a#red")
     end
   end
 
   it "should wait for content to disappear", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.should have_no_css("p#change")
+    expect(@session).to have_no_css("p#change")
   end
 
   context "with between" do
     it "should be false if the content occurs within the range given" do
-      @session.should_not have_no_css("p", :between => 1..4)
-      @session.should_not have_no_css("p a#foo", :between => 1..3)
-      @session.should_not have_no_css("p a.doesnotexist", :between => 0..2)
+      expect(@session).not_to have_no_css("p", :between => 1..4)
+      expect(@session).not_to have_no_css("p a#foo", :between => 1..3)
+      expect(@session).not_to have_no_css("p a.doesnotexist", :between => 0..2)
     end
 
     it "should be true if the content occurs more or fewer times than range" do
-      @session.should have_no_css("p", :between => 6..11 )
-      @session.should have_no_css("p a#foo", :between => 4..7)
-      @session.should have_no_css("p a.doesnotexist", :between => 3..8)
+      expect(@session).to have_no_css("p", :between => 6..11 )
+      expect(@session).to have_no_css("p a#foo", :between => 4..7)
+      expect(@session).to have_no_css("p a.doesnotexist", :between => 3..8)
     end
   end
 
   context "with count" do
     it "should be false if the content is on the page the given number of times" do
-      @session.should_not have_no_css("p", :count => 3)
-      @session.should_not have_no_css("p a#foo", :count => 1)
-      @session.should_not have_no_css("p a.doesnotexist", :count => 0)
+      expect(@session).not_to have_no_css("p", :count => 3)
+      expect(@session).not_to have_no_css("p a#foo", :count => 1)
+      expect(@session).not_to have_no_css("p a.doesnotexist", :count => 0)
     end
 
     it "should be true if the content is on the page the given number of times" do
-      @session.should have_no_css("p", :count => 6)
-      @session.should have_no_css("p a#foo", :count => 2)
-      @session.should have_no_css("p a.doesnotexist", :count => 1)
+      expect(@session).to have_no_css("p", :count => 6)
+      expect(@session).to have_no_css("p a#foo", :count => 2)
+      expect(@session).to have_no_css("p a.doesnotexist", :count => 1)
     end
 
     it "should coerce count to an integer" do
-      @session.should_not have_no_css("p", :count => "3")
-      @session.should_not have_no_css("p a#foo", :count => "1")
+      expect(@session).not_to have_no_css("p", :count => "3")
+      expect(@session).not_to have_no_css("p a#foo", :count => "1")
     end
   end
 
   context "with maximum" do
     it "should be false when content occurs same or fewer times than given" do
-      @session.should_not have_no_css("h2.head", :maximum => 5) # edge case
-      @session.should_not have_no_css("h2", :maximum => 10)
-      @session.should_not have_no_css("p a.doesnotexist", :maximum => 0)
+      expect(@session).not_to have_no_css("h2.head", :maximum => 5) # edge case
+      expect(@session).not_to have_no_css("h2", :maximum => 10)
+      expect(@session).not_to have_no_css("p a.doesnotexist", :maximum => 0)
     end
 
     it "should be true when content occurs more times than given" do
-      @session.should have_no_css("h2.head", :maximum => 4) # edge case
-      @session.should have_no_css("h2", :maximum => 3)
-      @session.should have_no_css("p", :maximum => 1)
+      expect(@session).to have_no_css("h2.head", :maximum => 4) # edge case
+      expect(@session).to have_no_css("h2", :maximum => 3)
+      expect(@session).to have_no_css("p", :maximum => 1)
     end
 
     it "should coerce maximum to an integer" do
-      @session.should_not have_no_css("h2.head", :maximum => "5") # edge case
-      @session.should_not have_no_css("h2", :maximum => "10")
+      expect(@session).not_to have_no_css("h2.head", :maximum => "5") # edge case
+      expect(@session).not_to have_no_css("h2", :maximum => "10")
     end
   end
 
   context "with minimum" do
     it "should be false when content occurs same or more times than given" do
-      @session.should_not have_no_css("h2.head", :minimum => 5) # edge case
-      @session.should_not have_no_css("h2", :minimum => 3)
-      @session.should_not have_no_css("p a.doesnotexist", :minimum => 0)
+      expect(@session).not_to have_no_css("h2.head", :minimum => 5) # edge case
+      expect(@session).not_to have_no_css("h2", :minimum => 3)
+      expect(@session).not_to have_no_css("p a.doesnotexist", :minimum => 0)
     end
 
     it "should be true when content occurs fewer times than given" do
-      @session.should have_no_css("h2.head", :minimum => 6) # edge case
-      @session.should have_no_css("h2", :minimum => 8)
-      @session.should have_no_css("p", :minimum => 15)
-      @session.should have_no_css("p a.doesnotexist", :minimum => 1)
+      expect(@session).to have_no_css("h2.head", :minimum => 6) # edge case
+      expect(@session).to have_no_css("h2", :minimum => 8)
+      expect(@session).to have_no_css("p", :minimum => 15)
+      expect(@session).to have_no_css("p a.doesnotexist", :minimum => 1)
     end
 
     it "should coerce minimum to an integer" do
-      @session.should_not have_no_css("h2.head", :minimum => "4") # edge case
-      @session.should_not have_no_css("h2", :minimum => "3")
+      expect(@session).not_to have_no_css("h2.head", :minimum => "4") # edge case
+      expect(@session).not_to have_no_css("h2", :minimum => "3")
     end
   end
 
   context "with text" do
     it "should discard all matches where the given string is not contained" do
-      @session.should_not have_no_css("p a", :text => "Redirect", :count => 1)
-      @session.should have_no_css("p a", :text => "Doesnotexist")
+      expect(@session).not_to have_no_css("p a", :text => "Redirect", :count => 1)
+      expect(@session).to have_no_css("p a", :text => "Doesnotexist")
     end
 
     it "should discard all matches where the given regexp is not matched" do
-      @session.should_not have_no_css("p a", :text => /re[dab]i/i, :count => 1)
-      @session.should have_no_css("p a", :text => /Red$/)
+      expect(@session).not_to have_no_css("p a", :text => /re[dab]i/i, :count => 1)
+      expect(@session).to have_no_css("p a", :text => /Red$/)
     end
   end
 end

--- a/lib/capybara/spec/session/has_field_spec.rb
+++ b/lib/capybara/spec/session/has_field_spec.rb
@@ -2,56 +2,56 @@ Capybara::SpecHelper.spec '#has_field' do
   before { @session.visit('/form') }
 
   it "should be true if the field is on the page" do
-    @session.should have_field('Dog')
-    @session.should have_field('form_description')
-    @session.should have_field('Region')
-    @session.should have_field(:'Region')
+    expect(@session).to have_field('Dog')
+    expect(@session).to have_field('form_description')
+    expect(@session).to have_field('Region')
+    expect(@session).to have_field(:'Region')
   end
 
   it "should be false if the field is not on the page" do
-    @session.should_not have_field('Monkey')
+    expect(@session).not_to have_field('Monkey')
   end
 
   context 'with value' do
     it "should be true if a field with the given value is on the page" do
-      @session.should have_field('First Name', :with => 'John')
-      @session.should have_field('Phone', :with => '+1 555 7021')
-      @session.should have_field('Street', :with => 'Sesame street 66')
-      @session.should have_field('Description', :with => 'Descriptive text goes here')
+      expect(@session).to have_field('First Name', :with => 'John')
+      expect(@session).to have_field('Phone', :with => '+1 555 7021')
+      expect(@session).to have_field('Street', :with => 'Sesame street 66')
+      expect(@session).to have_field('Description', :with => 'Descriptive text goes here')
     end
 
     it "should be false if the given field is not on the page" do
-      @session.should_not have_field('First Name', :with => 'Peter')
-      @session.should_not have_field('Wrong Name', :with => 'John')
-      @session.should_not have_field('Description', :with => 'Monkey')
+      expect(@session).not_to have_field('First Name', :with => 'Peter')
+      expect(@session).not_to have_field('Wrong Name', :with => 'John')
+      expect(@session).not_to have_field('Description', :with => 'Monkey')
     end
 
     it "should be true after the field has been filled in with the given value" do
       @session.fill_in('First Name', :with => 'Jonas')
-      @session.should have_field('First Name', :with => 'Jonas')
+      expect(@session).to have_field('First Name', :with => 'Jonas')
     end
 
     it "should be false after the field has been filled in with a different value" do
       @session.fill_in('First Name', :with => 'Jonas')
-      @session.should_not have_field('First Name', :with => 'John')
+      expect(@session).not_to have_field('First Name', :with => 'John')
     end
   end
 
   context 'with type' do
     it "should be true if a field with the given type is on the page" do
-      @session.should have_field('First Name', :type => 'text')
-      @session.should have_field('Html5 Email', :type => 'email')
-      @session.should have_field('Html5 Tel', :type => 'tel')
-      @session.should have_field('Description', :type => 'textarea')
-      @session.should have_field('Languages', :type => 'select')
+      expect(@session).to have_field('First Name', :type => 'text')
+      expect(@session).to have_field('Html5 Email', :type => 'email')
+      expect(@session).to have_field('Html5 Tel', :type => 'tel')
+      expect(@session).to have_field('Description', :type => 'textarea')
+      expect(@session).to have_field('Languages', :type => 'select')
     end
 
     it "should be false if the given field is not on the page" do
-      @session.should_not have_field('First Name', :type => 'textarea')
-      @session.should_not have_field('Html5 Email', :type => 'tel')
-      @session.should_not have_field('Description', :type => '')
-      @session.should_not have_field('Description', :type => 'email')
-      @session.should_not have_field('Languages', :type => 'textarea')
+      expect(@session).not_to have_field('First Name', :type => 'textarea')
+      expect(@session).not_to have_field('Html5 Email', :type => 'tel')
+      expect(@session).not_to have_field('Description', :type => '')
+      expect(@session).not_to have_field('Description', :type => 'email')
+      expect(@session).not_to have_field('Languages', :type => 'textarea')
     end
   end
 end
@@ -60,55 +60,55 @@ Capybara::SpecHelper.spec '#has_no_field' do
   before { @session.visit('/form') }
 
   it "should be false if the field is on the page" do
-    @session.should_not have_no_field('Dog')
-    @session.should_not have_no_field('form_description')
-    @session.should_not have_no_field('Region')
+    expect(@session).not_to have_no_field('Dog')
+    expect(@session).not_to have_no_field('form_description')
+    expect(@session).not_to have_no_field('Region')
   end
 
   it "should be true if the field is not on the page" do
-    @session.should have_no_field('Monkey')
+    expect(@session).to have_no_field('Monkey')
   end
 
   context 'with value' do
     it "should be false if a field with the given value is on the page" do
-      @session.should_not have_no_field('First Name', :with => 'John')
-      @session.should_not have_no_field('Phone', :with => '+1 555 7021')
-      @session.should_not have_no_field('Street', :with => 'Sesame street 66')
-      @session.should_not have_no_field('Description', :with => 'Descriptive text goes here')
+      expect(@session).not_to have_no_field('First Name', :with => 'John')
+      expect(@session).not_to have_no_field('Phone', :with => '+1 555 7021')
+      expect(@session).not_to have_no_field('Street', :with => 'Sesame street 66')
+      expect(@session).not_to have_no_field('Description', :with => 'Descriptive text goes here')
     end
 
     it "should be true if the given field is not on the page" do
-      @session.should have_no_field('First Name', :with => 'Peter')
-      @session.should have_no_field('Wrong Name', :with => 'John')
-      @session.should have_no_field('Description', :with => 'Monkey')
+      expect(@session).to have_no_field('First Name', :with => 'Peter')
+      expect(@session).to have_no_field('Wrong Name', :with => 'John')
+      expect(@session).to have_no_field('Description', :with => 'Monkey')
     end
 
     it "should be false after the field has been filled in with the given value" do
       @session.fill_in('First Name', :with => 'Jonas')
-      @session.should_not have_no_field('First Name', :with => 'Jonas')
+      expect(@session).not_to have_no_field('First Name', :with => 'Jonas')
     end
 
     it "should be true after the field has been filled in with a different value" do
       @session.fill_in('First Name', :with => 'Jonas')
-      @session.should have_no_field('First Name', :with => 'John')
+      expect(@session).to have_no_field('First Name', :with => 'John')
     end
   end
 
   context 'with type' do
     it "should be false if a field with the given type is on the page" do
-      @session.should_not have_no_field('First Name', :type => 'text')
-      @session.should_not have_no_field('Html5 Email', :type => 'email')
-      @session.should_not have_no_field('Html5 Tel', :type => 'tel')
-      @session.should_not have_no_field('Description', :type => 'textarea')
-      @session.should_not have_no_field('Languages', :type => 'select')
+      expect(@session).not_to have_no_field('First Name', :type => 'text')
+      expect(@session).not_to have_no_field('Html5 Email', :type => 'email')
+      expect(@session).not_to have_no_field('Html5 Tel', :type => 'tel')
+      expect(@session).not_to have_no_field('Description', :type => 'textarea')
+      expect(@session).not_to have_no_field('Languages', :type => 'select')
     end
 
     it "should be true if the given field is not on the page" do
-      @session.should have_no_field('First Name', :type => 'textarea')
-      @session.should have_no_field('Html5 Email', :type => 'tel')
-      @session.should have_no_field('Description', :type => '')
-      @session.should have_no_field('Description', :type => 'email')
-      @session.should have_no_field('Languages', :type => 'textarea')
+      expect(@session).to have_no_field('First Name', :type => 'textarea')
+      expect(@session).to have_no_field('Html5 Email', :type => 'tel')
+      expect(@session).to have_no_field('Description', :type => '')
+      expect(@session).to have_no_field('Description', :type => 'email')
+      expect(@session).to have_no_field('Languages', :type => 'textarea')
     end
   end
 end
@@ -117,49 +117,49 @@ Capybara::SpecHelper.spec '#has_checked_field?' do
   before { @session.visit('/form') }
 
   it "should be true if a checked field is on the page" do
-    @session.should have_checked_field('gender_female')
-    @session.should have_checked_field('Hamster')
+    expect(@session).to have_checked_field('gender_female')
+    expect(@session).to have_checked_field('Hamster')
   end
 
   it "should be true for disabled checkboxes if :disabled => true" do
-    @session.should have_checked_field('Disabled Checkbox', :disabled => true)
+    expect(@session).to have_checked_field('Disabled Checkbox', :disabled => true)
   end
 
   it "should be false if an unchecked field is on the page" do
-    @session.should_not have_checked_field('form_pets_cat')
-    @session.should_not have_checked_field('Male')
+    expect(@session).not_to have_checked_field('form_pets_cat')
+    expect(@session).not_to have_checked_field('Male')
   end
 
   it "should be false if no field is on the page" do
-    @session.should_not have_checked_field('Does Not Exist')
+    expect(@session).not_to have_checked_field('Does Not Exist')
   end
 
   it "should be false for disabled checkboxes by default" do
-    @session.should_not have_checked_field('Disabled Checkbox')
+    expect(@session).not_to have_checked_field('Disabled Checkbox')
   end
 
   it "should be false for disabled checkboxes if :disabled => false" do
-    @session.should_not have_checked_field('Disabled Checkbox', :disabled => false)
+    expect(@session).not_to have_checked_field('Disabled Checkbox', :disabled => false)
   end
 
   it "should be true after an unchecked checkbox is checked" do
     @session.check('form_pets_cat')
-    @session.should have_checked_field('form_pets_cat')
+    expect(@session).to have_checked_field('form_pets_cat')
   end
 
   it "should be false after a checked checkbox is unchecked" do
     @session.uncheck('form_pets_dog')
-    @session.should_not have_checked_field('form_pets_dog')
+    expect(@session).not_to have_checked_field('form_pets_dog')
   end
 
   it "should be true after an unchecked radio button is chosen" do
     @session.choose('gender_male')
-    @session.should have_checked_field('gender_male')
+    expect(@session).to have_checked_field('gender_male')
   end
 
   it "should be false after another radio button in the group is chosen" do
     @session.choose('gender_male')
-    @session.should_not have_checked_field('gender_female')
+    expect(@session).not_to have_checked_field('gender_female')
   end
 end
 
@@ -167,29 +167,29 @@ Capybara::SpecHelper.spec '#has_no_checked_field?' do
   before { @session.visit('/form') }
 
   it "should be false if a checked field is on the page" do
-    @session.should_not have_no_checked_field('gender_female')
-    @session.should_not have_no_checked_field('Hamster')
+    expect(@session).not_to have_no_checked_field('gender_female')
+    expect(@session).not_to have_no_checked_field('Hamster')
   end
 
   it "should be false for disabled checkboxes if :disabled => true" do
-    @session.should_not have_no_checked_field('Disabled Checkbox', :disabled => true)
+    expect(@session).not_to have_no_checked_field('Disabled Checkbox', :disabled => true)
   end
 
   it "should be true if an unchecked field is on the page" do
-    @session.should have_no_checked_field('form_pets_cat')
-    @session.should have_no_checked_field('Male')
+    expect(@session).to have_no_checked_field('form_pets_cat')
+    expect(@session).to have_no_checked_field('Male')
   end
 
   it "should be true if no field is on the page" do
-    @session.should have_no_checked_field('Does Not Exist')
+    expect(@session).to have_no_checked_field('Does Not Exist')
   end
 
   it "should be true for disabled checkboxes by default" do
-    @session.should have_no_checked_field('Disabled Checkbox')
+    expect(@session).to have_no_checked_field('Disabled Checkbox')
   end
 
   it "should be true for disabled checkboxes if :disabled => false" do
-    @session.should have_no_checked_field('Disabled Checkbox', :disabled => false)
+    expect(@session).to have_no_checked_field('Disabled Checkbox', :disabled => false)
   end
 end
 
@@ -197,49 +197,49 @@ Capybara::SpecHelper.spec '#has_unchecked_field?' do
   before { @session.visit('/form') }
 
   it "should be false if a checked field is on the page" do
-    @session.should_not have_unchecked_field('gender_female')
-    @session.should_not have_unchecked_field('Hamster')
+    expect(@session).not_to have_unchecked_field('gender_female')
+    expect(@session).not_to have_unchecked_field('Hamster')
   end
 
   it "should be true if an unchecked field is on the page" do
-    @session.should have_unchecked_field('form_pets_cat')
-    @session.should have_unchecked_field('Male')
+    expect(@session).to have_unchecked_field('form_pets_cat')
+    expect(@session).to have_unchecked_field('Male')
   end
 
   it "should be true for disabled unchecked fields if :disabled => true" do
-    @session.should have_unchecked_field('Disabled Unchecked Checkbox', :disabled => true)
+    expect(@session).to have_unchecked_field('Disabled Unchecked Checkbox', :disabled => true)
   end
 
   it "should be false if no field is on the page" do
-    @session.should_not have_unchecked_field('Does Not Exist')
+    expect(@session).not_to have_unchecked_field('Does Not Exist')
   end
 
   it "should be false for disabled unchecked fields by default" do
-    @session.should_not have_unchecked_field('Disabled Unchecked Checkbox')
+    expect(@session).not_to have_unchecked_field('Disabled Unchecked Checkbox')
   end
 
   it "should be false for disabled unchecked fields if :disabled => false" do
-    @session.should_not have_unchecked_field('Disabled Unchecked Checkbox', :disabled => false)
+    expect(@session).not_to have_unchecked_field('Disabled Unchecked Checkbox', :disabled => false)
   end
 
   it "should be false after an unchecked checkbox is checked" do
     @session.check('form_pets_cat')
-    @session.should_not have_unchecked_field('form_pets_cat')
+    expect(@session).not_to have_unchecked_field('form_pets_cat')
   end
 
   it "should be true after a checked checkbox is unchecked" do
     @session.uncheck('form_pets_dog')
-    @session.should have_unchecked_field('form_pets_dog')
+    expect(@session).to have_unchecked_field('form_pets_dog')
   end
 
   it "should be false after an unchecked radio button is chosen" do
     @session.choose('gender_male')
-    @session.should_not have_unchecked_field('gender_male')
+    expect(@session).not_to have_unchecked_field('gender_male')
   end
 
   it "should be true after another radio button in the group is chosen" do
     @session.choose('gender_male')
-    @session.should have_unchecked_field('gender_female')
+    expect(@session).to have_unchecked_field('gender_female')
   end
 end
 
@@ -247,28 +247,28 @@ Capybara::SpecHelper.spec '#has_no_unchecked_field?' do
   before { @session.visit('/form') }
 
   it "should be true if a checked field is on the page" do
-    @session.should have_no_unchecked_field('gender_female')
-    @session.should have_no_unchecked_field('Hamster')
+    expect(@session).to have_no_unchecked_field('gender_female')
+    expect(@session).to have_no_unchecked_field('Hamster')
   end
 
   it "should be false if an unchecked field is on the page" do
-    @session.should_not have_no_unchecked_field('form_pets_cat')
-    @session.should_not have_no_unchecked_field('Male')
+    expect(@session).not_to have_no_unchecked_field('form_pets_cat')
+    expect(@session).not_to have_no_unchecked_field('Male')
   end
 
   it "should be false for disabled unchecked fields if :disabled => true" do
-    @session.should_not have_no_unchecked_field('Disabled Unchecked Checkbox', :disabled => true)
+    expect(@session).not_to have_no_unchecked_field('Disabled Unchecked Checkbox', :disabled => true)
   end
 
   it "should be true if no field is on the page" do
-    @session.should have_no_unchecked_field('Does Not Exist')
+    expect(@session).to have_no_unchecked_field('Does Not Exist')
   end
 
   it "should be true for disabled unchecked fields by default" do
-    @session.should have_no_unchecked_field('Disabled Unchecked Checkbox')
+    expect(@session).to have_no_unchecked_field('Disabled Unchecked Checkbox')
   end
 
   it "should be true for disabled unchecked fields if :disabled => false" do
-    @session.should have_no_unchecked_field('Disabled Unchecked Checkbox', :disabled => false)
+    expect(@session).to have_no_unchecked_field('Disabled Unchecked Checkbox', :disabled => false)
   end
 end

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -4,15 +4,15 @@ Capybara::SpecHelper.spec '#has_link?' do
   end
 
   it "should be true if the given link is on the page" do
-    @session.should have_link('foo')
-    @session.should have_link('awesome title')
-    @session.should have_link('A link', :href => '/with_simple_html')
-    @session.should have_link(:'A link', :href => :'/with_simple_html')
+    expect(@session).to have_link('foo')
+    expect(@session).to have_link('awesome title')
+    expect(@session).to have_link('A link', :href => '/with_simple_html')
+    expect(@session).to have_link(:'A link', :href => :'/with_simple_html')
   end
 
   it "should be false if the given link is not on the page" do
-    @session.should_not have_link('monkey')
-    @session.should_not have_link('A link', :href => '/non-existant-href')
+    expect(@session).not_to have_link('monkey')
+    expect(@session).not_to have_link('A link', :href => '/non-existant-href')
   end
 end
 
@@ -22,13 +22,13 @@ Capybara::SpecHelper.spec '#has_no_link?' do
   end
 
   it "should be false if the given link is on the page" do
-    @session.should_not have_no_link('foo')
-    @session.should_not have_no_link('awesome title')
-    @session.should_not have_no_link('A link', :href => '/with_simple_html')
+    expect(@session).not_to have_no_link('foo')
+    expect(@session).not_to have_no_link('awesome title')
+    expect(@session).not_to have_no_link('A link', :href => '/with_simple_html')
   end
 
   it "should be true if the given link is not on the page" do
-    @session.should have_no_link('monkey')
-    @session.should have_no_link('A link', :href => '/non-existant-href')
+    expect(@session).to have_no_link('monkey')
+    expect(@session).to have_no_link('A link', :href => '/non-existant-href')
   end
 end

--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -2,60 +2,60 @@ Capybara::SpecHelper.spec '#has_select?' do
   before { @session.visit('/form') }
 
   it "should be true if the field is on the page" do
-    @session.should have_select('Locale')
-    @session.should have_select('form_region')
-    @session.should have_select('Languages')
-    @session.should have_select(:'Languages')
+    expect(@session).to have_select('Locale')
+    expect(@session).to have_select('form_region')
+    expect(@session).to have_select('Languages')
+    expect(@session).to have_select(:'Languages')
   end
 
   it "should be false if the field is not on the page" do
-    @session.should_not have_select('Monkey')
+    expect(@session).not_to have_select('Monkey')
   end
 
   context 'with selected value' do
     it "should be true if a field with the given value is on the page" do
-      @session.should have_select('form_locale', :selected => 'English')
-      @session.should have_select('Region', :selected => 'Norway')
-      @session.should have_select('Underwear', :selected => [
+      expect(@session).to have_select('form_locale', :selected => 'English')
+      expect(@session).to have_select('Region', :selected => 'Norway')
+      expect(@session).to have_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
 
     it "should be false if the given field is not on the page" do
-      @session.should_not have_select('Locale', :selected => 'Swedish')
-      @session.should_not have_select('Does not exist', :selected => 'John')
-      @session.should_not have_select('City', :selected => 'Not there')
-      @session.should_not have_select('Underwear', :selected => [
+      expect(@session).not_to have_select('Locale', :selected => 'Swedish')
+      expect(@session).not_to have_select('Does not exist', :selected => 'John')
+      expect(@session).not_to have_select('City', :selected => 'Not there')
+      expect(@session).not_to have_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns', 'Nonexistant'
       ])
-      @session.should_not have_select('Underwear', :selected => [
+      expect(@session).not_to have_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Boxers', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
-      @session.should_not have_select('Underwear', :selected => [
+      expect(@session).not_to have_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs','Commando', "Frenchman's Pantalons"
       ])
     end
 
     it "should be true after the given value is selected" do
       @session.select('Swedish', :from => 'Locale')
-      @session.should have_select('Locale', :selected => 'Swedish')
+      expect(@session).to have_select('Locale', :selected => 'Swedish')
     end
 
     it "should be false after a different value is selected" do
       @session.select('Swedish', :from => 'Locale')
-      @session.should_not have_select('Locale', :selected => 'English')
+      expect(@session).not_to have_select('Locale', :selected => 'English')
     end
 
     it "should be true after the given values are selected" do
       @session.select('Boxers', :from => 'Underwear')
-      @session.should have_select('Underwear', :selected => [
+      expect(@session).to have_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Boxers', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
 
     it "should be false after one of the values is unselected" do
       @session.unselect('Briefs', :from => 'Underwear')
-      @session.should_not have_select('Underwear', :selected => [
+      expect(@session).not_to have_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
@@ -63,29 +63,29 @@ Capybara::SpecHelper.spec '#has_select?' do
 
   context 'with exact options' do
     it "should be true if a field with the given options is on the page" do
-      @session.should have_select('Region', :options => ['Norway', 'Sweden', 'Finland'])
-      @session.should have_select('Tendency', :options => [])
+      expect(@session).to have_select('Region', :options => ['Norway', 'Sweden', 'Finland'])
+      expect(@session).to have_select('Tendency', :options => [])
     end
 
     it "should be false if the given field is not on the page" do
-      @session.should_not have_select('Locale', :options => ['Swedish'])
-      @session.should_not have_select('Does not exist', :options => ['John'])
-      @session.should_not have_select('City', :options => ['London', 'Made up city'])
-      @session.should_not have_select('Region', :options => ['Norway', 'Sweden'])
-      @session.should_not have_select('Region', :options => ['Norway', 'Norway', 'Norway'])
+      expect(@session).not_to have_select('Locale', :options => ['Swedish'])
+      expect(@session).not_to have_select('Does not exist', :options => ['John'])
+      expect(@session).not_to have_select('City', :options => ['London', 'Made up city'])
+      expect(@session).not_to have_select('Region', :options => ['Norway', 'Sweden'])
+      expect(@session).not_to have_select('Region', :options => ['Norway', 'Norway', 'Norway'])
     end
   end
 
   context 'with partial options' do
     it "should be true if a field with the given partial options is on the page" do
-      @session.should have_select('Region', :with_options => ['Norway', 'Sweden'])
-      @session.should have_select('City', :with_options => ['London'])
+      expect(@session).to have_select('Region', :with_options => ['Norway', 'Sweden'])
+      expect(@session).to have_select('City', :with_options => ['London'])
     end
 
     it "should be false if a field with the given partial options is not on the page" do
-      @session.should_not have_select('Locale', :with_options => ['Uruguayan'])
-      @session.should_not have_select('Does not exist', :with_options => ['John'])
-      @session.should_not have_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
+      expect(@session).not_to have_select('Locale', :with_options => ['Uruguayan'])
+      expect(@session).not_to have_select('Does not exist', :with_options => ['John'])
+      expect(@session).not_to have_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
     end
   end
 end
@@ -94,59 +94,59 @@ Capybara::SpecHelper.spec '#has_no_select?' do
   before { @session.visit('/form') }
 
   it "should be false if the field is on the page" do
-    @session.should_not have_no_select('Locale')
-    @session.should_not have_no_select('form_region')
-    @session.should_not have_no_select('Languages')
+    expect(@session).not_to have_no_select('Locale')
+    expect(@session).not_to have_no_select('form_region')
+    expect(@session).not_to have_no_select('Languages')
   end
 
   it "should be true if the field is not on the page" do
-    @session.should have_no_select('Monkey')
+    expect(@session).to have_no_select('Monkey')
   end
 
   context 'with selected value' do
     it "should be false if a field with the given value is on the page" do
-      @session.should_not have_no_select('form_locale', :selected => 'English')
-      @session.should_not have_no_select('Region', :selected => 'Norway')
-      @session.should_not have_no_select('Underwear', :selected => [
+      expect(@session).not_to have_no_select('form_locale', :selected => 'English')
+      expect(@session).not_to have_no_select('Region', :selected => 'Norway')
+      expect(@session).not_to have_no_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
 
     it "should be true if the given field is not on the page" do
-      @session.should have_no_select('Locale', :selected => 'Swedish')
-      @session.should have_no_select('Does not exist', :selected => 'John')
-      @session.should have_no_select('City', :selected => 'Not there')
-      @session.should have_no_select('Underwear', :selected => [
+      expect(@session).to have_no_select('Locale', :selected => 'Swedish')
+      expect(@session).to have_no_select('Does not exist', :selected => 'John')
+      expect(@session).to have_no_select('City', :selected => 'Not there')
+      expect(@session).to have_no_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns', 'Nonexistant'
       ])
-      @session.should have_no_select('Underwear', :selected => [
+      expect(@session).to have_no_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Boxers', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
-      @session.should have_no_select('Underwear', :selected => [
+      expect(@session).to have_no_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs','Commando', "Frenchman's Pantalons"
       ])
     end
 
     it "should be false after the given value is selected" do
       @session.select('Swedish', :from => 'Locale')
-      @session.should_not have_no_select('Locale', :selected => 'Swedish')
+      expect(@session).not_to have_no_select('Locale', :selected => 'Swedish')
     end
 
     it "should be true after a different value is selected" do
       @session.select('Swedish', :from => 'Locale')
-      @session.should have_no_select('Locale', :selected => 'English')
+      expect(@session).to have_no_select('Locale', :selected => 'English')
     end
 
     it "should be false after the given values are selected" do
       @session.select('Boxers', :from => 'Underwear')
-      @session.should_not have_no_select('Underwear', :selected => [
+      expect(@session).not_to have_no_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Boxers', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
 
     it "should be true after one of the values is unselected" do
       @session.unselect('Briefs', :from => 'Underwear')
-      @session.should have_no_select('Underwear', :selected => [
+      expect(@session).to have_no_select('Underwear', :selected => [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
     end
@@ -154,28 +154,28 @@ Capybara::SpecHelper.spec '#has_no_select?' do
 
   context 'with exact options' do
     it "should be false if a field with the given options is on the page" do
-      @session.should_not have_no_select('Region', :options => ['Norway', 'Sweden', 'Finland'])
+      expect(@session).not_to have_no_select('Region', :options => ['Norway', 'Sweden', 'Finland'])
     end
 
     it "should be true if the given field is not on the page" do
-      @session.should have_no_select('Locale', :options => ['Swedish'])
-      @session.should have_no_select('Does not exist', :options => ['John'])
-      @session.should have_no_select('City', :options => ['London', 'Made up city'])
-      @session.should have_no_select('Region', :options => ['Norway', 'Sweden'])
-      @session.should have_no_select('Region', :options => ['Norway', 'Norway', 'Norway'])
+      expect(@session).to have_no_select('Locale', :options => ['Swedish'])
+      expect(@session).to have_no_select('Does not exist', :options => ['John'])
+      expect(@session).to have_no_select('City', :options => ['London', 'Made up city'])
+      expect(@session).to have_no_select('Region', :options => ['Norway', 'Sweden'])
+      expect(@session).to have_no_select('Region', :options => ['Norway', 'Norway', 'Norway'])
     end
   end
 
   context 'with partial options' do
     it "should be false if a field with the given partial options is on the page" do
-      @session.should_not have_no_select('Region', :with_options => ['Norway', 'Sweden'])
-      @session.should_not have_no_select('City', :with_options => ['London'])
+      expect(@session).not_to have_no_select('Region', :with_options => ['Norway', 'Sweden'])
+      expect(@session).not_to have_no_select('City', :with_options => ['London'])
     end
 
     it "should be true if a field with the given partial options is not on the page" do
-      @session.should have_no_select('Locale', :with_options => ['Uruguayan'])
-      @session.should have_no_select('Does not exist', :with_options => ['John'])
-      @session.should have_no_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
+      expect(@session).to have_no_select('Locale', :with_options => ['Uruguayan'])
+      expect(@session).to have_no_select('Does not exist', :with_options => ['John'])
+      expect(@session).to have_no_select('Region', :with_options => ['Norway', 'Sweden', 'Finland', 'Latvia'])
     end
   end
 end

--- a/lib/capybara/spec/session/has_selector_spec.rb
+++ b/lib/capybara/spec/session/has_selector_spec.rb
@@ -4,67 +4,67 @@ Capybara::SpecHelper.spec '#has_selector?' do
   end
 
   it "should be true if the given selector is on the page" do
-    @session.should have_selector(:xpath, "//p")
-    @session.should have_selector(:css, "p a#foo")
-    @session.should have_selector("//p[contains(.,'est')]")
+    expect(@session).to have_selector(:xpath, "//p")
+    expect(@session).to have_selector(:css, "p a#foo")
+    expect(@session).to have_selector("//p[contains(.,'est')]")
   end
 
   it "should be false if the given selector is not on the page" do
-    @session.should_not have_selector(:xpath, "//abbr")
-    @session.should_not have_selector(:css, "p a#doesnotexist")
-    @session.should_not have_selector("//p[contains(.,'thisstringisnotonpage')]")
+    expect(@session).not_to have_selector(:xpath, "//abbr")
+    expect(@session).not_to have_selector(:css, "p a#doesnotexist")
+    expect(@session).not_to have_selector("//p[contains(.,'thisstringisnotonpage')]")
   end
 
   it "should use default selector" do
     Capybara.default_selector = :css
-    @session.should_not have_selector("p a#doesnotexist")
-    @session.should have_selector("p a#foo")
+    expect(@session).not_to have_selector("p a#doesnotexist")
+    expect(@session).to have_selector("p a#foo")
   end
 
   it "should respect scopes" do
     @session.within "//p[@id='first']" do
-      @session.should have_selector(".//a[@id='foo']")
-      @session.should_not have_selector(".//a[@id='red']")
+      expect(@session).to have_selector(".//a[@id='foo']")
+      expect(@session).not_to have_selector(".//a[@id='red']")
     end
   end
 
   context "with count" do
     it "should be true if the content is on the page the given number of times" do
-      @session.should have_selector("//p", :count => 3)
-      @session.should have_selector("//p//a[@id='foo']", :count => 1)
-      @session.should have_selector("//p[contains(.,'est')]", :count => 1)
+      expect(@session).to have_selector("//p", :count => 3)
+      expect(@session).to have_selector("//p//a[@id='foo']", :count => 1)
+      expect(@session).to have_selector("//p[contains(.,'est')]", :count => 1)
     end
 
     it "should be false if the content is on the page the given number of times" do
-      @session.should_not have_selector("//p", :count => 6)
-      @session.should_not have_selector("//p//a[@id='foo']", :count => 2)
-      @session.should_not have_selector("//p[contains(.,'est')]", :count => 5)
+      expect(@session).not_to have_selector("//p", :count => 6)
+      expect(@session).not_to have_selector("//p//a[@id='foo']", :count => 2)
+      expect(@session).not_to have_selector("//p[contains(.,'est')]", :count => 5)
     end
 
     it "should be false if the content isn't on the page at all" do
-      @session.should_not have_selector("//abbr", :count => 2)
-      @session.should_not have_selector("//p//a[@id='doesnotexist']", :count => 1)
+      expect(@session).not_to have_selector("//abbr", :count => 2)
+      expect(@session).not_to have_selector("//p//a[@id='doesnotexist']", :count => 1)
     end
   end
 
   context "with text" do
     it "should discard all matches where the given string is not contained" do
-      @session.should have_selector("//p//a", :text => "Redirect", :count => 1)
-      @session.should_not have_selector("//p", :text => "Doesnotexist")
+      expect(@session).to have_selector("//p//a", :text => "Redirect", :count => 1)
+      expect(@session).not_to have_selector("//p", :text => "Doesnotexist")
     end
 
     it "should respect visibility setting" do
-      @session.should have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => false)
-      @session.should_not have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => true)
+      expect(@session).to have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => false)
+      expect(@session).not_to have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => true)
       Capybara.ignore_hidden_elements = false
-      @session.should have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => false)
+      expect(@session).to have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => false)
       Capybara.visible_text_only = true
-      @session.should_not have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => true)
+      expect(@session).not_to have_selector(:id, "hidden-text", :text => "Some of this text is hidden!", :visible => true)
     end
 
     it "should discard all matches where the given regexp is not matched" do
-      @session.should have_selector("//p//a", :text => /re[dab]i/i, :count => 1)
-      @session.should_not have_selector("//p//a", :text => /Red$/)
+      expect(@session).to have_selector("//p//a", :text => /re[dab]i/i, :count => 1)
+      expect(@session).not_to have_selector("//p//a", :text => /Red$/)
     end
   end
 end
@@ -75,58 +75,58 @@ Capybara::SpecHelper.spec '#has_no_selector?' do
   end
 
   it "should be false if the given selector is on the page" do
-    @session.should_not have_no_selector(:xpath, "//p")
-    @session.should_not have_no_selector(:css, "p a#foo")
-    @session.should_not have_no_selector("//p[contains(.,'est')]")
+    expect(@session).not_to have_no_selector(:xpath, "//p")
+    expect(@session).not_to have_no_selector(:css, "p a#foo")
+    expect(@session).not_to have_no_selector("//p[contains(.,'est')]")
   end
 
   it "should be true if the given selector is not on the page" do
-    @session.should have_no_selector(:xpath, "//abbr")
-    @session.should have_no_selector(:css, "p a#doesnotexist")
-    @session.should have_no_selector("//p[contains(.,'thisstringisnotonpage')]")
+    expect(@session).to have_no_selector(:xpath, "//abbr")
+    expect(@session).to have_no_selector(:css, "p a#doesnotexist")
+    expect(@session).to have_no_selector("//p[contains(.,'thisstringisnotonpage')]")
   end
 
   it "should use default selector" do
     Capybara.default_selector = :css
-    @session.should have_no_selector("p a#doesnotexist")
-    @session.should_not have_no_selector("p a#foo")
+    expect(@session).to have_no_selector("p a#doesnotexist")
+    expect(@session).not_to have_no_selector("p a#foo")
   end
 
   it "should respect scopes" do
     @session.within "//p[@id='first']" do
-      @session.should_not have_no_selector(".//a[@id='foo']")
-      @session.should have_no_selector(".//a[@id='red']")
+      expect(@session).not_to have_no_selector(".//a[@id='foo']")
+      expect(@session).to have_no_selector(".//a[@id='red']")
     end
   end
 
   context "with count" do
     it "should be false if the content is on the page the given number of times" do
-      @session.should_not have_no_selector("//p", :count => 3)
-      @session.should_not have_no_selector("//p//a[@id='foo']", :count => 1)
-      @session.should_not have_no_selector("//p[contains(.,'est')]", :count => 1)
+      expect(@session).not_to have_no_selector("//p", :count => 3)
+      expect(@session).not_to have_no_selector("//p//a[@id='foo']", :count => 1)
+      expect(@session).not_to have_no_selector("//p[contains(.,'est')]", :count => 1)
     end
 
     it "should be true if the content is on the page the wrong number of times" do
-      @session.should have_no_selector("//p", :count => 6)
-      @session.should have_no_selector("//p//a[@id='foo']", :count => 2)
-      @session.should have_no_selector("//p[contains(.,'est')]", :count => 5)
+      expect(@session).to have_no_selector("//p", :count => 6)
+      expect(@session).to have_no_selector("//p//a[@id='foo']", :count => 2)
+      expect(@session).to have_no_selector("//p[contains(.,'est')]", :count => 5)
     end
 
     it "should be true if the content isn't on the page at all" do
-      @session.should have_no_selector("//abbr", :count => 2)
-      @session.should have_no_selector("//p//a[@id='doesnotexist']", :count => 1)
+      expect(@session).to have_no_selector("//abbr", :count => 2)
+      expect(@session).to have_no_selector("//p//a[@id='doesnotexist']", :count => 1)
     end
   end
 
   context "with text" do
     it "should discard all matches where the given string is contained" do
-      @session.should_not have_no_selector("//p//a", :text => "Redirect", :count => 1)
-      @session.should have_no_selector("//p", :text => "Doesnotexist")
+      expect(@session).not_to have_no_selector("//p//a", :text => "Redirect", :count => 1)
+      expect(@session).to have_no_selector("//p", :text => "Doesnotexist")
     end
 
     it "should discard all matches where the given regexp is matched" do
-      @session.should_not have_no_selector("//p//a", :text => /re[dab]i/i, :count => 1)
-      @session.should have_no_selector("//p//a", :text => /Red$/)
+      expect(@session).not_to have_no_selector("//p//a", :text => /re[dab]i/i, :count => 1)
+      expect(@session).to have_no_selector("//p//a", :text => /Red$/)
     end
   end
 end

--- a/lib/capybara/spec/session/has_table_spec.rb
+++ b/lib/capybara/spec/session/has_table_spec.rb
@@ -4,13 +4,13 @@ Capybara::SpecHelper.spec '#has_table?' do
   end
 
   it "should be true if the table is on the page" do
-    @session.should have_table('Villain')
-    @session.should have_table('villain_table')
-    @session.should have_table(:'villain_table')
+    expect(@session).to have_table('Villain')
+    expect(@session).to have_table('villain_table')
+    expect(@session).to have_table(:'villain_table')
   end
 
   it "should be false if the table is not on the page" do
-    @session.should_not have_table('Monkey')
+    expect(@session).not_to have_table('Monkey')
   end
 end
 
@@ -20,11 +20,11 @@ Capybara::SpecHelper.spec '#has_no_table?' do
   end
 
   it "should be false if the table is on the page" do
-    @session.should_not have_no_table('Villain')
-    @session.should_not have_no_table('villain_table')
+    expect(@session).not_to have_no_table('Villain')
+    expect(@session).not_to have_no_table('villain_table')
   end
 
   it "should be true if the table is not on the page" do
-    @session.should have_no_table('Monkey')
+    expect(@session).to have_no_table('Monkey')
   end
 end

--- a/lib/capybara/spec/session/has_text_spec.rb
+++ b/lib/capybara/spec/session/has_text_spec.rb
@@ -1,193 +1,193 @@
 Capybara::SpecHelper.spec '#has_text?' do
   it "should be true if the given text is on the page at least once" do
     @session.visit('/with_html')
-    @session.should have_text('est')
-    @session.should have_text('Lorem')
-    @session.should have_text('Redirect')
-    @session.should have_text(:'Redirect')
+    expect(@session).to have_text('est')
+    expect(@session).to have_text('Lorem')
+    expect(@session).to have_text('Redirect')
+    expect(@session).to have_text(:'Redirect')
   end
 
   it "should be true if scoped to an element which has the text" do
     @session.visit('/with_html')
     @session.within("//a[@title='awesome title']") do
-      @session.should have_text('labore')
+      expect(@session).to have_text('labore')
     end
   end
 
   it "should be false if scoped to an element which does not have the text" do
     @session.visit('/with_html')
     @session.within("//a[@title='awesome title']") do
-      @session.should_not have_text('monkey')
+      expect(@session).not_to have_text('monkey')
     end
   end
 
   it "should ignore tags" do
     @session.visit('/with_html')
-    @session.should_not have_text('exercitation <a href="/foo" id="foo">ullamco</a> laboris')
-    @session.should have_text('exercitation ullamco laboris')
+    expect(@session).not_to have_text('exercitation <a href="/foo" id="foo">ullamco</a> laboris')
+    expect(@session).to have_text('exercitation ullamco laboris')
   end
 
   it "should ignore extra whitespace and newlines" do
     @session.visit('/with_html')
-    @session.should have_text('text with whitespace')
+    expect(@session).to have_text('text with whitespace')
   end
 
   it "should ignore whitespace and newlines in the search string" do
     @session.visit('/with_html')
-    @session.should have_text("text     with \n\n whitespace")
+    expect(@session).to have_text("text     with \n\n whitespace")
   end
 
   it "should be false if the given text is not on the page" do
     @session.visit('/with_html')
-    @session.should_not have_text('xxxxyzzz')
-    @session.should_not have_text('monkey')
+    expect(@session).not_to have_text('xxxxyzzz')
+    expect(@session).not_to have_text('monkey')
   end
 
   it 'should handle single quotes in the text' do
     @session.visit('/with-quotes')
-    @session.should have_text("can't")
+    expect(@session).to have_text("can't")
   end
 
   it 'should handle double quotes in the text' do
     @session.visit('/with-quotes')
-    @session.should have_text(%q{"No," he said})
+    expect(@session).to have_text(%q{"No," he said})
   end
 
   it 'should handle mixed single and double quotes in the text' do
     @session.visit('/with-quotes')
-    @session.should have_text(%q{"you can't do that."})
+    expect(@session).to have_text(%q{"you can't do that."})
   end
 
   it 'should be false if text is in the title tag in the head' do
     @session.visit('/with_js')
-    @session.should_not have_text('with_js')
+    expect(@session).not_to have_text('with_js')
   end
 
   it 'should be false if text is inside a script tag in the body' do
     @session.visit('/with_js')
-    @session.should_not have_text('a javascript comment')
-    @session.should_not have_text('aVar')
+    expect(@session).not_to have_text('a javascript comment')
+    expect(@session).not_to have_text('aVar')
   end
 
   it "should be false if the given text is on the page but not visible" do
     @session.visit('/with_html')
-    @session.should_not have_text('Inside element with hidden ancestor')
+    expect(@session).not_to have_text('Inside element with hidden ancestor')
   end
 
   it "should be true if :all given and text is invisible." do
     @session.visit('/with_html')
-    @session.should have_text(:all, 'Some of this text is hidden!')
+    expect(@session).to have_text(:all, 'Some of this text is hidden!')
   end
 
   it "should be true if `Capybara.ignore_hidden_elements = true` and text is invisible." do
     Capybara.ignore_hidden_elements = false
     @session.visit('/with_html')
-    @session.should have_text('Some of this text is hidden!')
+    expect(@session).to have_text('Some of this text is hidden!')
   end
 
   it "should be true if the text in the page matches given regexp" do
     @session.visit('/with_html')
-    @session.should have_text(/Lorem/)
+    expect(@session).to have_text(/Lorem/)
   end
 
   it "should be false if the text in the page doesn't match given regexp" do
     @session.visit('/with_html')
-    @session.should_not have_text(/xxxxyzzz/)
+    expect(@session).not_to have_text(/xxxxyzzz/)
   end
 
   it "should escape any characters that would have special meaning in a regexp" do
     @session.visit('/with_html')
-    @session.should_not have_text('.orem')
+    expect(@session).not_to have_text('.orem')
   end
 
   it "should accept non-string parameters" do
     @session.visit('/with_html')
-    @session.should have_text(42)
+    expect(@session).to have_text(42)
   end
 
   it "should be true when passed nil" do
     # Historical behavior; no particular reason other than compatibility.
     @session.visit('/with_html')
-    @session.should have_text(nil)
+    expect(@session).to have_text(nil)
   end
 
   it "should wait for text to appear", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.should have_text("Has been clicked")
+    expect(@session).to have_text("Has been clicked")
   end
 
   context "with between" do
     it "should be true if the text occurs within the range given" do
       @session.visit('/with_count')
-      @session.should have_text('count', between: 1..3)
-      @session.should have_text(/count/, between: 2..2)
+      expect(@session).to have_text('count', between: 1..3)
+      expect(@session).to have_text(/count/, between: 2..2)
     end
 
     it "should be false if the text occurs more or fewer times than range" do
       @session.visit('/with_count')
-      @session.should_not have_text('count', between: 0..1)
-      @session.should_not have_text('count', between: 3..10)
-      @session.should_not have_text(/count/, between: 2...2)
+      expect(@session).not_to have_text('count', between: 0..1)
+      expect(@session).not_to have_text('count', between: 3..10)
+      expect(@session).not_to have_text(/count/, between: 2...2)
     end
   end
 
   context "with count" do
     it "should be true if the text occurs the given number of times" do
       @session.visit('/with_count')
-      @session.should have_text('count', count: 2)
+      expect(@session).to have_text('count', count: 2)
     end
 
     it "should be false if the text occurs a different number of times than the given" do
       @session.visit('/with_count')
-      @session.should_not have_text('count', count: 0)
-      @session.should_not have_text('count', count: 1)
-      @session.should_not have_text(/count/, count: 3)
+      expect(@session).not_to have_text('count', count: 0)
+      expect(@session).not_to have_text('count', count: 1)
+      expect(@session).not_to have_text(/count/, count: 3)
     end
 
     it "should coerce count to an integer" do
       @session.visit('/with_count')
-      @session.should have_text('count', count: '2')
-      @session.should_not have_text('count', count: '3')
+      expect(@session).to have_text('count', count: '2')
+      expect(@session).not_to have_text('count', count: '3')
     end
   end
 
   context "with maximum" do
     it "should be true when text occurs same or fewer times than given" do
       @session.visit('/with_count')
-      @session.should have_text('count', maximum: 2)
-      @session.should have_text(/count/, maximum: 3)
+      expect(@session).to have_text('count', maximum: 2)
+      expect(@session).to have_text(/count/, maximum: 3)
     end
 
     it "should be false when text occurs more times than given" do
       @session.visit('/with_count')
-      @session.should_not have_text('count', maximum: 1)
-      @session.should_not have_text('count', maximum: 0)
+      expect(@session).not_to have_text('count', maximum: 1)
+      expect(@session).not_to have_text('count', maximum: 0)
     end
 
     it "should coerce maximum to an integer" do
       @session.visit('/with_count')
-      @session.should have_text('count', maximum: '2')
-      @session.should_not have_text('count', maximum: '1')
+      expect(@session).to have_text('count', maximum: '2')
+      expect(@session).not_to have_text('count', maximum: '1')
     end
   end
 
   context "with minimum" do
     it "should be true when text occurs same or more times than given" do
       @session.visit('/with_count')
-      @session.should have_text('count', minimum: 2)
-      @session.should have_text(/count/, minimum: 0)
+      expect(@session).to have_text('count', minimum: 2)
+      expect(@session).to have_text(/count/, minimum: 0)
     end
 
     it "should be false when text occurs fewer times than given" do
       @session.visit('/with_count')
-      @session.should_not have_text('count', minimum: 3)
+      expect(@session).not_to have_text('count', minimum: 3)
     end
 
     it "should coerce minimum to an integer" do
       @session.visit('/with_count')
-      @session.should have_text('count', minimum: '2')
-      @session.should_not have_text('count', minimum: '3')
+      expect(@session).to have_text('count', minimum: '2')
+      expect(@session).not_to have_text('count', minimum: '3')
     end
   end
 
@@ -196,7 +196,7 @@ Capybara::SpecHelper.spec '#has_text?' do
       Capybara.using_wait_time(0.1) do
         @session.visit('/with_js')
         @session.click_link('Click me')
-        @session.should have_text('Has been clicked', :wait => 0.9)
+        expect(@session).to have_text('Has been clicked', :wait => 0.9)
       end
     end
   end
@@ -205,105 +205,105 @@ end
 Capybara::SpecHelper.spec '#has_no_text?' do
   it "should be false if the given text is on the page at least once" do
     @session.visit('/with_html')
-    @session.should_not have_no_text('est')
-    @session.should_not have_no_text('Lorem')
-    @session.should_not have_no_text('Redirect')
+    expect(@session).not_to have_no_text('est')
+    expect(@session).not_to have_no_text('Lorem')
+    expect(@session).not_to have_no_text('Redirect')
   end
 
   it "should be false if scoped to an element which has the text" do
     @session.visit('/with_html')
     @session.within("//a[@title='awesome title']") do
-      @session.should_not have_no_text('labore')
+      expect(@session).not_to have_no_text('labore')
     end
   end
 
   it "should be true if scoped to an element which does not have the text" do
     @session.visit('/with_html')
     @session.within("//a[@title='awesome title']") do
-      @session.should have_no_text('monkey')
+      expect(@session).to have_no_text('monkey')
     end
   end
 
   it "should ignore tags" do
     @session.visit('/with_html')
-    @session.should have_no_text('exercitation <a href="/foo" id="foo">ullamco</a> laboris')
-    @session.should_not have_no_text('exercitation ullamco laboris')
+    expect(@session).to have_no_text('exercitation <a href="/foo" id="foo">ullamco</a> laboris')
+    expect(@session).not_to have_no_text('exercitation ullamco laboris')
   end
 
   it "should be true if the given text is not on the page" do
     @session.visit('/with_html')
-    @session.should have_no_text('xxxxyzzz')
-    @session.should have_no_text('monkey')
+    expect(@session).to have_no_text('xxxxyzzz')
+    expect(@session).to have_no_text('monkey')
   end
 
   it 'should handle single quotes in the text' do
     @session.visit('/with-quotes')
-    @session.should_not have_no_text("can't")
+    expect(@session).not_to have_no_text("can't")
   end
 
   it 'should handle double quotes in the text' do
     @session.visit('/with-quotes')
-    @session.should_not have_no_text(%q{"No," he said})
+    expect(@session).not_to have_no_text(%q{"No," he said})
   end
 
   it 'should handle mixed single and double quotes in the text' do
     @session.visit('/with-quotes')
-    @session.should_not have_no_text(%q{"you can't do that."})
+    expect(@session).not_to have_no_text(%q{"you can't do that."})
   end
 
   it 'should be true if text is in the title tag in the head' do
     @session.visit('/with_js')
-    @session.should have_no_text('with_js')
+    expect(@session).to have_no_text('with_js')
   end
 
   it 'should be true if text is inside a script tag in the body' do
     @session.visit('/with_js')
-    @session.should have_no_text('a javascript comment')
-    @session.should have_no_text('aVar')
+    expect(@session).to have_no_text('a javascript comment')
+    expect(@session).to have_no_text('aVar')
   end
 
   it "should be true if the given text is on the page but not visible" do
     @session.visit('/with_html')
-    @session.should have_no_text('Inside element with hidden ancestor')
+    expect(@session).to have_no_text('Inside element with hidden ancestor')
   end
 
   it "should be false if :all given and text is invisible." do
     @session.visit('/with_html')
-    @session.should_not have_no_text(:all, 'Some of this text is hidden!')
+    expect(@session).not_to have_no_text(:all, 'Some of this text is hidden!')
   end
 
   it "should be false if `Capybara.ignore_hidden_elements = true` and text is invisible." do
     Capybara.ignore_hidden_elements = false
     @session.visit('/with_html')
-    @session.should_not have_no_text('Some of this text is hidden!')
+    expect(@session).not_to have_no_text('Some of this text is hidden!')
   end
 
   it "should be true if the text in the page doesn't match given regexp" do
     @session.visit('/with_html')
-    @session.should have_no_text(/xxxxyzzz/)
+    expect(@session).to have_no_text(/xxxxyzzz/)
   end
 
   it "should be false if the text in the page  matches given regexp" do
     @session.visit('/with_html')
-    @session.should_not have_no_text(/Lorem/)
+    expect(@session).not_to have_no_text(/Lorem/)
   end
 
   it "should escape any characters that would have special meaning in a regexp" do
     @session.visit('/with_html')
-    @session.should have_no_text('.orem')
+    expect(@session).to have_no_text('.orem')
   end
 
   it "should wait for text to disappear", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.should have_no_text("I changed it")
+    expect(@session).to have_no_text("I changed it")
   end
 
   context "with wait", :requires => [:js] do
     it "should not find element if it appears after given wait duration" do
       @session.visit('/with_js')
       @session.click_link('Click me')
-      @session.should have_no_text('Has been clicked', :wait => 0.1)
+      expect(@session).to have_no_text('Has been clicked', :wait => 0.1)
     end
   end
 end

--- a/lib/capybara/spec/session/has_title_spec.rb
+++ b/lib/capybara/spec/session/has_title_spec.rb
@@ -4,21 +4,21 @@ Capybara::SpecHelper.spec '#has_title?' do
   end
 
   it "should be true if the page has the given title" do
-    @session.should have_title('with_js')
+    expect(@session).to have_title('with_js')
   end
 
   it "should allow regexp matches" do
-    @session.should have_title(/w[a-z]{3}_js/)
-    @session.should_not have_title(/monkey/)
+    expect(@session).to have_title(/w[a-z]{3}_js/)
+    expect(@session).not_to have_title(/monkey/)
   end
 
   it "should wait for title", :requires => [:js] do
     @session.click_link("Change title")
-    @session.should have_title("changed title")
+    expect(@session).to have_title("changed title")
   end
 
   it "should be false if the page has not the given title" do
-    @session.should_not have_title('monkey')
+    expect(@session).not_to have_title('monkey')
   end
 end
 
@@ -28,20 +28,20 @@ Capybara::SpecHelper.spec '#has_no_title?' do
   end
 
   it "should be false if the page has the given title" do
-    @session.should_not have_no_title('with_js')
+    expect(@session).not_to have_no_title('with_js')
   end
 
   it "should allow regexp matches" do
-    @session.should_not have_no_title(/w[a-z]{3}_js/)
-    @session.should have_no_title(/monkey/)
+    expect(@session).not_to have_no_title(/w[a-z]{3}_js/)
+    expect(@session).to have_no_title(/monkey/)
   end
 
   it "should wait for title to disappear", :requires => [:js] do
     @session.click_link("Change title")
-    @session.should have_no_title('with_js')
+    expect(@session).to have_no_title('with_js')
   end
 
   it "should be true if the page has not the given title" do
-    @session.should have_no_title('monkey')
+    expect(@session).to have_no_title('monkey')
   end
 end

--- a/lib/capybara/spec/session/has_xpath_spec.rb
+++ b/lib/capybara/spec/session/has_xpath_spec.rb
@@ -4,60 +4,60 @@ Capybara::SpecHelper.spec '#has_xpath?' do
   end
 
   it "should be true if the given selector is on the page" do
-    @session.should have_xpath("//p")
-    @session.should have_xpath("//p//a[@id='foo']")
-    @session.should have_xpath("//p[contains(.,'est')]")
+    expect(@session).to have_xpath("//p")
+    expect(@session).to have_xpath("//p//a[@id='foo']")
+    expect(@session).to have_xpath("//p[contains(.,'est')]")
   end
 
   it "should be false if the given selector is not on the page" do
-    @session.should_not have_xpath("//abbr")
-    @session.should_not have_xpath("//p//a[@id='doesnotexist']")
-    @session.should_not have_xpath("//p[contains(.,'thisstringisnotonpage')]")
+    expect(@session).not_to have_xpath("//abbr")
+    expect(@session).not_to have_xpath("//p//a[@id='doesnotexist']")
+    expect(@session).not_to have_xpath("//p[contains(.,'thisstringisnotonpage')]")
   end
 
   it "should use xpath even if default selector is CSS" do
     Capybara.default_selector = :css
-    @session.should_not have_xpath("//p//a[@id='doesnotexist']")
+    expect(@session).not_to have_xpath("//p//a[@id='doesnotexist']")
   end
 
   it "should respect scopes" do
     @session.within "//p[@id='first']" do
-      @session.should have_xpath(".//a[@id='foo']")
-      @session.should_not have_xpath(".//a[@id='red']")
+      expect(@session).to have_xpath(".//a[@id='foo']")
+      expect(@session).not_to have_xpath(".//a[@id='red']")
     end
   end
 
   it "should wait for content to appear", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.should have_xpath("//input[@type='submit' and @value='New Here']")
+    expect(@session).to have_xpath("//input[@type='submit' and @value='New Here']")
   end
 
   context "with count" do
     it "should be true if the content occurs the given number of times" do
-      @session.should have_xpath("//p", :count => 3)
-      @session.should have_xpath("//p//a[@id='foo']", :count => 1)
-      @session.should have_xpath("//p[contains(.,'est')]", :count => 1)
-      @session.should have_xpath("//p//a[@id='doesnotexist']", :count => 0)
+      expect(@session).to have_xpath("//p", :count => 3)
+      expect(@session).to have_xpath("//p//a[@id='foo']", :count => 1)
+      expect(@session).to have_xpath("//p[contains(.,'est')]", :count => 1)
+      expect(@session).to have_xpath("//p//a[@id='doesnotexist']", :count => 0)
     end
 
     it "should be false if the content occurs a different number of times than the given" do
-      @session.should_not have_xpath("//p", :count => 6)
-      @session.should_not have_xpath("//p//a[@id='foo']", :count => 2)
-      @session.should_not have_xpath("//p[contains(.,'est')]", :count => 5)
-      @session.should_not have_xpath("//p//a[@id='doesnotexist']", :count => 1)
+      expect(@session).not_to have_xpath("//p", :count => 6)
+      expect(@session).not_to have_xpath("//p//a[@id='foo']", :count => 2)
+      expect(@session).not_to have_xpath("//p[contains(.,'est')]", :count => 5)
+      expect(@session).not_to have_xpath("//p//a[@id='doesnotexist']", :count => 1)
     end
   end
 
   context "with text" do
     it "should discard all matches where the given string is not contained" do
-      @session.should have_xpath("//p//a", :text => "Redirect", :count => 1)
-      @session.should_not have_xpath("//p", :text => "Doesnotexist")
+      expect(@session).to have_xpath("//p//a", :text => "Redirect", :count => 1)
+      expect(@session).not_to have_xpath("//p", :text => "Doesnotexist")
     end
 
     it "should discard all matches where the given regexp is not matched" do
-      @session.should have_xpath("//p//a", :text => /re[dab]i/i, :count => 1)
-      @session.should_not have_xpath("//p//a", :text => /Red$/)
+      expect(@session).to have_xpath("//p//a", :text => /re[dab]i/i, :count => 1)
+      expect(@session).not_to have_xpath("//p//a", :text => /Red$/)
     end
   end
 end
@@ -68,60 +68,60 @@ Capybara::SpecHelper.spec '#has_no_xpath?' do
   end
 
   it "should be false if the given selector is on the page" do
-    @session.should_not have_no_xpath("//p")
-    @session.should_not have_no_xpath("//p//a[@id='foo']")
-    @session.should_not have_no_xpath("//p[contains(.,'est')]")
+    expect(@session).not_to have_no_xpath("//p")
+    expect(@session).not_to have_no_xpath("//p//a[@id='foo']")
+    expect(@session).not_to have_no_xpath("//p[contains(.,'est')]")
   end
 
   it "should be true if the given selector is not on the page" do
-    @session.should have_no_xpath("//abbr")
-    @session.should have_no_xpath("//p//a[@id='doesnotexist']")
-    @session.should have_no_xpath("//p[contains(.,'thisstringisnotonpage')]")
+    expect(@session).to have_no_xpath("//abbr")
+    expect(@session).to have_no_xpath("//p//a[@id='doesnotexist']")
+    expect(@session).to have_no_xpath("//p[contains(.,'thisstringisnotonpage')]")
   end
 
   it "should use xpath even if default selector is CSS" do
     Capybara.default_selector = :css
-    @session.should have_no_xpath("//p//a[@id='doesnotexist']")
+    expect(@session).to have_no_xpath("//p//a[@id='doesnotexist']")
   end
 
   it "should respect scopes" do
     @session.within "//p[@id='first']" do
-      @session.should_not have_no_xpath(".//a[@id='foo']")
-      @session.should have_no_xpath(".//a[@id='red']")
+      expect(@session).not_to have_no_xpath(".//a[@id='foo']")
+      expect(@session).to have_no_xpath(".//a[@id='red']")
     end
   end
 
   it "should wait for content to disappear", :requires => [:js] do
     @session.visit('/with_js')
     @session.click_link('Click me')
-    @session.should have_no_xpath("//p[@id='change']")
+    expect(@session).to have_no_xpath("//p[@id='change']")
   end
 
   context "with count" do
     it "should be false if the content occurs the given number of times" do
-      @session.should_not have_no_xpath("//p", :count => 3)
-      @session.should_not have_no_xpath("//p//a[@id='foo']", :count => 1)
-      @session.should_not have_no_xpath("//p[contains(.,'est')]", :count => 1)
-      @session.should_not have_no_xpath("//p//a[@id='doesnotexist']", :count => 0)
+      expect(@session).not_to have_no_xpath("//p", :count => 3)
+      expect(@session).not_to have_no_xpath("//p//a[@id='foo']", :count => 1)
+      expect(@session).not_to have_no_xpath("//p[contains(.,'est')]", :count => 1)
+      expect(@session).not_to have_no_xpath("//p//a[@id='doesnotexist']", :count => 0)
     end
 
     it "should be true if the content occurs a different number of times than the given" do
-      @session.should have_no_xpath("//p", :count => 6)
-      @session.should have_no_xpath("//p//a[@id='foo']", :count => 2)
-      @session.should have_no_xpath("//p[contains(.,'est')]", :count => 5)
-      @session.should have_no_xpath("//p//a[@id='doesnotexist']", :count => 1)
+      expect(@session).to have_no_xpath("//p", :count => 6)
+      expect(@session).to have_no_xpath("//p//a[@id='foo']", :count => 2)
+      expect(@session).to have_no_xpath("//p[contains(.,'est')]", :count => 5)
+      expect(@session).to have_no_xpath("//p//a[@id='doesnotexist']", :count => 1)
     end
   end
 
   context "with text" do
     it "should discard all matches where the given string is contained" do
-      @session.should_not have_no_xpath("//p//a", :text => "Redirect", :count => 1)
-      @session.should have_no_xpath("//p", :text => "Doesnotexist")
+      expect(@session).not_to have_no_xpath("//p//a", :text => "Redirect", :count => 1)
+      expect(@session).to have_no_xpath("//p", :text => "Doesnotexist")
     end
 
     it "should discard all matches where the given regexp is matched" do
-      @session.should_not have_no_xpath("//p//a", :text => /re[dab]i/i, :count => 1)
-      @session.should have_no_xpath("//p//a", :text => /Red$/)
+      expect(@session).not_to have_no_xpath("//p//a", :text => /re[dab]i/i, :count => 1)
+      expect(@session).to have_no_xpath("//p//a", :text => /Red$/)
     end
   end
 end

--- a/lib/capybara/spec/session/headers.rb
+++ b/lib/capybara/spec/session/headers.rb
@@ -1,6 +1,6 @@
 Capybara::SpecHelper.spec '#response_headers' do
   it "should return response headers", :requires => [:response_headers] do
     @session.visit('/with_simple_html')
-    @session.response_headers['Content-Type'].should =~ %r(text/html)
+    expect(@session.response_headers['Content-Type']).to match %r(text/html)
   end
 end

--- a/lib/capybara/spec/session/html_spec.rb
+++ b/lib/capybara/spec/session/html_spec.rb
@@ -1,38 +1,38 @@
 Capybara::SpecHelper.spec '#html' do
   it "should return the unmodified page body" do
     @session.visit('/')
-    @session.html.should include('Hello world!')
+    expect(@session.html).to include('Hello world!')
   end
 
   it "should return the current state of the page", :requires => [:js] do
     @session.visit('/with_js')
-    @session.html.should include('I changed it')
-    @session.html.should_not include('This is text')
+    expect(@session.html).to include('I changed it')
+    expect(@session.html).not_to include('This is text')
   end
 end
 
 Capybara::SpecHelper.spec '#source' do
   it "should return the unmodified page source" do
     @session.visit('/')
-    @session.source.should include('Hello world!')
+    expect(@session.source).to include('Hello world!')
   end
 
   it "should return the current state of the page", :requires => [:js] do
     @session.visit('/with_js')
-    @session.source.should include('I changed it')
-    @session.source.should_not include('This is text')
+    expect(@session.source).to include('I changed it')
+    expect(@session.source).not_to include('This is text')
   end
 end
 
 Capybara::SpecHelper.spec '#body' do
   it "should return the unmodified page source" do
     @session.visit('/')
-    @session.body.should include('Hello world!')
+    expect(@session.body).to include('Hello world!')
   end
 
   it "should return the current state of the page", :requires => [:js] do
     @session.visit('/with_js')
-    @session.body.should include('I changed it')
-    @session.body.should_not include('This is text')
+    expect(@session.body).to include('I changed it')
+    expect(@session.body).not_to include('This is text')
   end
 end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -6,191 +6,191 @@ Capybara::SpecHelper.spec "node" do
   it "should act like a session object" do
     @session.visit('/form')
     @form = @session.find(:css, '#get-form')
-    @form.should have_field('Middle Name')
-    @form.should have_no_field('Languages')
+    expect(@form).to have_field('Middle Name')
+    expect(@form).to have_no_field('Languages')
     @form.fill_in('Middle Name', :with => 'Monkey')
     @form.click_button('med')
-    extract_results(@session)['middle_name'].should == 'Monkey'
+    expect(extract_results(@session)['middle_name']).to eq('Monkey')
   end
 
   it "should scope CSS selectors" do
-    @session.find(:css, '#second').should have_no_css('h1')
+    expect(@session.find(:css, '#second')).to have_no_css('h1')
   end
 
   describe "#parent" do
     it "should have a reference to its parent if there is one" do
       @node = @session.find(:css, '#first')
-      @node.parent.should == @node.session.document
-      @node.find(:css, '#foo').parent.should == @node
+      expect(@node.parent).to eq(@node.session.document)
+      expect(@node.find(:css, '#foo').parent).to eq(@node)
     end
   end
 
   describe "#text" do
     it "should extract node texts" do
-      @session.all('//a')[0].text.should == 'labore'
-      @session.all('//a')[1].text.should == 'ullamco'
+      expect(@session.all('//a')[0].text).to eq('labore')
+      expect(@session.all('//a')[1].text).to eq('ullamco')
     end
 
     it "should return document text on /html selector" do
       @session.visit('/with_simple_html')
-      @session.all('/html')[0].text.should == 'Bar'
+      expect(@session.all('/html')[0].text).to eq('Bar')
     end
   end
 
   describe "#[]" do
     it "should extract node attributes" do
-      @session.all('//a')[0][:class].should == 'simple'
-      @session.all('//a')[1][:id].should == 'foo'
-      @session.all('//input')[0][:type].should == 'text'
+      expect(@session.all('//a')[0][:class]).to eq('simple')
+      expect(@session.all('//a')[1][:id]).to eq('foo')
+      expect(@session.all('//input')[0][:type]).to eq('text')
     end
 
     it "should extract boolean node attributes" do
-      @session.find('//input[@id="checked_field"]')[:checked].should be_true
+      expect(@session.find('//input[@id="checked_field"]')[:checked]).to be_truthy
     end
   end
 
   describe "#value" do
     it "should allow retrieval of the value" do
-      @session.find('//textarea[@id="normal"]').value.should == 'banana'
+      expect(@session.find('//textarea[@id="normal"]').value).to eq('banana')
     end
 
     it "should not swallow extra newlines in textarea" do
-      @session.find('//textarea[@id="additional_newline"]').value.should == "\nbanana"
+      expect(@session.find('//textarea[@id="additional_newline"]').value).to eq("\nbanana")
     end
 
     it "should not swallow leading newlines for set content in textarea" do
       @session.find('//textarea[@id="normal"]').set("\nbanana")
-      @session.find('//textarea[@id="normal"]').value.should == "\nbanana"
+      expect(@session.find('//textarea[@id="normal"]').value).to eq("\nbanana")
     end
 
     it "return any HTML content in textarea" do
       @session.find('//textarea[1]').set("some <em>html</em> here")
-      @session.find('//textarea[1]').value.should == "some <em>html</em> here"
+      expect(@session.find('//textarea[1]').value).to eq("some <em>html</em> here")
     end
     
     it "defaults to 'on' for checkbox" do
       @session.visit('/form')
-      @session.find('//input[@id="valueless_checkbox"]').value.should == 'on'
+      expect(@session.find('//input[@id="valueless_checkbox"]').value).to eq('on')
     end
 
     it "defaults to 'on' for radio buttons" do
       @session.visit('/form')
-      @session.find('//input[@id="valueless_radio"]').value.should == 'on'
+      expect(@session.find('//input[@id="valueless_radio"]').value).to eq('on')
     end    
   end
 
   describe "#set" do
     it "should allow assignment of field value" do
-      @session.first('//input').value.should == 'monkey'
+      expect(@session.first('//input').value).to eq('monkey')
       @session.first('//input').set('gorilla')
-      @session.first('//input').value.should == 'gorilla'
+      expect(@session.first('//input').value).to eq('gorilla')
     end
 
     it "should fill the field even if the caret was not at the end", :requires => [:js] do
       @session.execute_script("var el = document.getElementById('test_field'); el.focus(); el.setSelectionRange(0, 0);")
       @session.first('//input').set('')
-      @session.first('//input').value.should == ''
+      expect(@session.first('//input').value).to eq('')
     end
 
     it "should not set if the text field is readonly" do
-      @session.first('//input[@readonly]').value.should == 'should not change'
+      expect(@session.first('//input[@readonly]').value).to eq('should not change')
       @session.first('//input[@readonly]').set('changed')
-      @session.first('//input[@readonly]').value.should == 'should not change'
+      expect(@session.first('//input[@readonly]').value).to eq('should not change')
     end
 
     it "should not set if the textarea is readonly" do
-      @session.first('//textarea[@readonly]').value.should == 'textarea should not change'
+      expect(@session.first('//textarea[@readonly]').value).to eq('textarea should not change')
       @session.first('//textarea[@readonly]').set('changed')
-      @session.first('//textarea[@readonly]').value.should == 'textarea should not change'
+      expect(@session.first('//textarea[@readonly]').value).to eq('textarea should not change')
     end
 
     it 'should allow me to change the contents of a contenteditable element', :requires => [:js] do
       @session.visit('/with_js')
       @session.find(:css,'#existing_content_editable').set('WYSIWYG')
-      @session.find(:css,'#existing_content_editable').text.should == 'WYSIWYG'
+      expect(@session.find(:css,'#existing_content_editable').text).to eq('WYSIWYG')
     end
 
     it 'should allow me to set the contents of a contenteditable element', :requires => [:js] do
       @session.visit('/with_js')
       @session.find(:css,'#blank_content_editable').set('WYSIWYG')
-      @session.find(:css,'#blank_content_editable').text.should == 'WYSIWYG'
+      expect(@session.find(:css,'#blank_content_editable').text).to eq('WYSIWYG')
     end
 
     it 'should allow me to change the contents of a contenteditable elements child', :requires => [:js] do
       pending "Selenium doesn't like editing nested contents"
       @session.visit('/with_js')
       @session.find(:css,'#existing_content_editable_child').set('WYSIWYG')
-      @session.find(:css,'#existing_content_editable_child').text.should == 'WYSIWYG'
+      expect(@session.find(:css,'#existing_content_editable_child').text).to eq('WYSIWYG')
     end
   end
 
   describe "#tag_name" do
     it "should extract node tag name" do
-      @session.all('//a')[0].tag_name.should == 'a'
-      @session.all('//a')[1].tag_name.should == 'a'
-      @session.all('//p')[1].tag_name.should == 'p'
+      expect(@session.all('//a')[0].tag_name).to eq('a')
+      expect(@session.all('//a')[1].tag_name).to eq('a')
+      expect(@session.all('//p')[1].tag_name).to eq('p')
     end
   end
 
   describe "#disabled?" do
     it "should extract disabled node" do
       @session.visit('/form')
-      @session.find('//input[@id="customer_name"]').should be_disabled
-      @session.find('//input[@id="customer_email"]').should_not be_disabled
+      expect(@session.find('//input[@id="customer_name"]')).to be_disabled
+      expect(@session.find('//input[@id="customer_email"]')).not_to be_disabled
     end
 
     it "should see disabled options as disabled" do
       @session.visit('/form')
-      @session.find('//select[@id="form_title"]/option[1]').should_not be_disabled
-      @session.find('//select[@id="form_title"]/option[@disabled]').should be_disabled
+      expect(@session.find('//select[@id="form_title"]/option[1]')).not_to be_disabled
+      expect(@session.find('//select[@id="form_title"]/option[@disabled]')).to be_disabled
     end
 
     it "should see enabled options in disabled select as disabled" do
       @session.visit('/form')
-      @session.find('//select[@id="form_disabled_select"]/option').should be_disabled
-      @session.find('//select[@id="form_title"]/option[1]').should_not be_disabled
+      expect(@session.find('//select[@id="form_disabled_select"]/option')).to be_disabled
+      expect(@session.find('//select[@id="form_title"]/option[1]')).not_to be_disabled
     end
   end
 
   describe "#visible?" do
     it "should extract node visibility" do
       Capybara.ignore_hidden_elements = false
-      @session.first('//a').should be_visible
+      expect(@session.first('//a')).to be_visible
 
-      @session.find('//div[@id="hidden"]').should_not be_visible
-      @session.find('//div[@id="hidden_via_ancestor"]').should_not be_visible
-      @session.find('//div[@id="hidden_attr"]').should_not be_visible
-      @session.find('//a[@id="hidden_attr_via_ancestor"]').should_not be_visible
+      expect(@session.find('//div[@id="hidden"]')).not_to be_visible
+      expect(@session.find('//div[@id="hidden_via_ancestor"]')).not_to be_visible
+      expect(@session.find('//div[@id="hidden_attr"]')).not_to be_visible
+      expect(@session.find('//a[@id="hidden_attr_via_ancestor"]')).not_to be_visible
     end
   end
 
   describe "#checked?" do
     it "should extract node checked state" do
       @session.visit('/form')
-      @session.find('//input[@id="gender_female"]').should be_checked
-      @session.find('//input[@id="gender_male"]').should_not be_checked
-      @session.first('//h1').should_not be_checked
+      expect(@session.find('//input[@id="gender_female"]')).to be_checked
+      expect(@session.find('//input[@id="gender_male"]')).not_to be_checked
+      expect(@session.first('//h1')).not_to be_checked
     end
   end
 
   describe "#selected?" do
     it "should extract node selected state" do
       @session.visit('/form')
-      @session.find('//option[@value="en"]').should be_selected
-      @session.find('//option[@value="sv"]').should_not be_selected
-      @session.first('//h1').should_not be_selected
+      expect(@session.find('//option[@value="en"]')).to be_selected
+      expect(@session.find('//option[@value="sv"]')).not_to be_selected
+      expect(@session.first('//h1')).not_to be_selected
     end
   end
 
   describe "#==" do
     it "preserve object identity" do
-      (@session.find('//h1') == @session.find('//h1')).should be_true
-      (@session.find('//h1') === @session.find('//h1')).should be_true
-      (@session.find('//h1').eql? @session.find('//h1')).should be_false
+      expect(@session.find('//h1') == @session.find('//h1')).to be true
+      expect(@session.find('//h1') === @session.find('//h1')).to be true
+      expect(@session.find('//h1').eql? @session.find('//h1')).to be false
     end
 
     it "returns false for unrelated object" do
-      (@session.find('//h1') == "Not Capybara::Node::Base").should be_false
+      expect(@session.find('//h1') == "Not Capybara::Node::Base").to be false
     end
   end
 
@@ -198,7 +198,7 @@ Capybara::SpecHelper.spec "node" do
     it "should allow triggering of custom JS events" do
       @session.visit('/with_js')
       @session.find(:css, '#with_focus_event').trigger(:focus)
-      @session.should have_css('#focus_event_triggered')
+      expect(@session).to have_css('#focus_event_triggered')
     end
   end
 
@@ -208,16 +208,16 @@ Capybara::SpecHelper.spec "node" do
       element = @session.find('//div[@id="drag"]')
       target = @session.find('//div[@id="drop"]')
       element.drag_to(target)
-      @session.find('//div[contains(., "Dropped!")]').should_not be_nil
+      expect(@session.find('//div[contains(., "Dropped!")]')).not_to be_nil
     end
   end
 
   describe '#hover', :requires => [:hover] do
     it "should allow hovering on an element" do
       @session.visit('/with_hover')
-      @session.find(:css,'.hidden_until_hover', :visible => false).should_not be_visible
+      expect(@session.find(:css,'.hidden_until_hover', :visible => false)).not_to be_visible
       @session.find(:css,'.wrapper').hover
-      @session.find(:css, '.hidden_until_hover', :visible => false).should be_visible
+      expect(@session.find(:css, '.hidden_until_hover', :visible => false)).to be_visible
     end
   end
   
@@ -225,7 +225,7 @@ Capybara::SpecHelper.spec "node" do
     it "should double click an element" do
       @session.visit('/with_js')
       @session.find(:css, '#click-test').double_click
-      @session.find(:css, '#has-been-double-clicked').should be
+      expect(@session.find(:css, '#has-been-double-clicked')).to be
     end
   end
 
@@ -233,7 +233,7 @@ Capybara::SpecHelper.spec "node" do
     it "should double click an element" do
       @session.visit('/with_js')
       @session.find(:css, '#click-test').right_click
-      @session.find(:css, '#has-been-right-clicked').should be
+      expect(@session.find(:css, '#has-been-right-clicked')).to be
     end
   end  
 
@@ -245,8 +245,8 @@ Capybara::SpecHelper.spec "node" do
         node = @session.find(:css, '#reload-me')
         @session.click_link('Reload!')
         sleep(0.3)
-        node.reload.text.should == 'has been reloaded'
-        node.text.should == 'has been reloaded'
+        expect(node.reload.text).to eq('has been reloaded')
+        expect(node.text).to eq('has been reloaded')
       end
 
       it "should reload a parent node" do
@@ -254,8 +254,8 @@ Capybara::SpecHelper.spec "node" do
         node = @session.find(:css, '#reload-me').find(:css, 'em')
         @session.click_link('Reload!')
         sleep(0.3)
-        node.reload.text.should == 'has been reloaded'
-        node.text.should == 'has been reloaded'
+        expect(node.reload.text).to eq('has been reloaded')
+        expect(node.text).to eq('has been reloaded')
       end
 
       it "should not automatically reload" do
@@ -274,7 +274,7 @@ Capybara::SpecHelper.spec "node" do
         node = @session.find(:css, '#reload-me')
         @session.click_link('Reload!')
         sleep(0.3)
-        node.text.should == 'has been reloaded'
+        expect(node.text).to eq('has been reloaded')
       end
 
       it "should reload a parent node automatically" do
@@ -282,7 +282,7 @@ Capybara::SpecHelper.spec "node" do
         node = @session.find(:css, '#reload-me').find(:css, 'em')
         @session.click_link('Reload!')
         sleep(0.3)
-        node.text.should == 'has been reloaded'
+        expect(node.text).to eq('has been reloaded')
       end
 
       it "should reload a node automatically when using find" do
@@ -290,7 +290,7 @@ Capybara::SpecHelper.spec "node" do
         node = @session.find(:css, '#reload-me')
         @session.click_link('Reload!')
         sleep(0.3)
-        node.find(:css, 'a').text.should == 'has been reloaded'
+        expect(node.find(:css, 'a').text).to eq('has been reloaded')
       end
 
       it "should not reload nodes which haven't been found" do
@@ -307,7 +307,7 @@ Capybara::SpecHelper.spec "node" do
         node = @session.find(:css, 'em', :text => "reloaded")
         @session.click_link('Reload!')
         sleep(1)
-        node.text.should == 'has been reloaded'
+        expect(node.text).to eq('has been reloaded')
       end
     end
   end

--- a/lib/capybara/spec/session/reset_session_spec.rb
+++ b/lib/capybara/spec/session/reset_session_spec.rb
@@ -2,39 +2,39 @@ Capybara::SpecHelper.spec '#reset_session!' do
   it "removes cookies" do
     @session.visit('/set_cookie')
     @session.visit('/get_cookie')
-    @session.should have_content('test_cookie')
+    expect(@session).to have_content('test_cookie')
 
     @session.reset_session!
     @session.visit('/get_cookie')
-    @session.body.should_not include('test_cookie')
+    expect(@session.body).not_to include('test_cookie')
   end
 
   it "resets current url, host, path" do
     @session.visit '/foo'
-    @session.current_url.should_not be_empty
-    @session.current_host.should_not be_empty
-    @session.current_path.should == '/foo'
+    expect(@session.current_url).not_to be_empty
+    expect(@session.current_host).not_to be_empty
+    expect(@session.current_path).to eq('/foo')
 
     @session.reset_session!
-    [nil, '', 'about:blank'].should include(@session.current_url)
-    ['', nil].should include(@session.current_path)
-    @session.current_host.should be_nil
+    expect([nil, '', 'about:blank']).to include(@session.current_url)
+    expect(['', nil]).to include(@session.current_path)
+    expect(@session.current_host).to be_nil
   end
 
   it "resets page body" do
     @session.visit('/with_html')
-    @session.should have_content('This is a test')
-    @session.find('.//h1').text.should include('This is a test')
+    expect(@session).to have_content('This is a test')
+    expect(@session.find('.//h1').text).to include('This is a test')
 
     @session.reset_session!
-    @session.body.should_not include('This is a test')
-    @session.should have_no_selector('.//h1')
+    expect(@session.body).not_to include('This is a test')
+    expect(@session).to have_no_selector('.//h1')
   end
 
   it "is synchronous" do
     @session.visit("/with_html")
     @session.reset_session!
-    @session.should have_no_selector :xpath, "/html/body/*", wait: false
+    expect(@session).to have_no_selector :xpath, "/html/body/*", wait: false
   end
 
   it "raises any errors caught inside the server", :requires => [:server] do
@@ -43,7 +43,7 @@ Capybara::SpecHelper.spec '#reset_session!' do
       @session.reset_session!
     end.to raise_error(TestApp::TestAppError)
     @session.visit("/")
-    @session.current_path.should == "/"
+    expect(@session.current_path).to eq("/")
   end
 
   it "ignores server errors when `Capybara.raise_server_errors = false`", :requires => [:server] do
@@ -51,6 +51,6 @@ Capybara::SpecHelper.spec '#reset_session!' do
     quietly { @session.visit("/error") }
     @session.reset_session!
     @session.visit("/")
-    @session.current_path.should == "/"
+    expect(@session.current_path).to eq("/")
   end
 end

--- a/lib/capybara/spec/session/response_code.rb
+++ b/lib/capybara/spec/session/response_code.rb
@@ -1,6 +1,6 @@
 Capybara::SpecHelper.spec '#status_code' do
   it "should return response codes", :requires => [:status_code] do
     @session.visit('/with_simple_html')
-    @session.status_code.should == 200
+    expect(@session.status_code).to eq(200)
   end
 end

--- a/lib/capybara/spec/session/save_page_spec.rb
+++ b/lib/capybara/spec/session/save_page_spec.rb
@@ -15,39 +15,39 @@ Capybara::SpecHelper.spec '#save_page' do
   it "saves the page in the root directory" do
     @session.save_page
     path = Dir.glob("capybara-*.html").first
-    File.read(path).should include("Another World")
+    expect(File.read(path)).to include("Another World")
   end
 
   it "generates a sensible filename" do
     @session.save_page
     path = Dir.glob("capybara-*.html").first
     filename = path.split("/").last
-    filename.should =~ /^capybara-\d+\.html$/
+    expect(filename).to match /^capybara-\d+\.html$/
   end
 
   it "can store files in a specified directory" do
     Capybara.save_and_open_page_path = alternative_path
     @session.save_page
     path = Dir.glob(alternative_path + "/capybara-*.html").first
-    File.read(path).should include("Another World")
+    expect(File.read(path)).to include("Another World")
   end
 
   it "uses the given filename" do
     @session.save_page("capybara-001122.html")
-    File.read("capybara-001122.html").should include("Another World")
+    expect(File.read("capybara-001122.html")).to include("Another World")
   end
 
   it "returns an absolute path in pwd" do
     result = @session.save_page
     path = File.expand_path(Dir.glob("capybara-*.html").first, Dir.pwd)
-    result.should == path
+    expect(result).to eq(path)
   end
 
   it "returns an absolute path in given directory" do
     Capybara.save_and_open_page_path = alternative_path
     result = @session.save_page
     path = File.expand_path(Dir.glob(alternative_path + "/capybara-*.html").first, alternative_path)
-    result.should == path
+    expect(result).to eq(path)
   end
 
   context "asset_host contains a string" do
@@ -59,7 +59,7 @@ Capybara::SpecHelper.spec '#save_page' do
       path = @session.save_page
 
       result = File.read(path)
-      result.should include("<head><base href='http://example.com' />")
+      expect(result).to include("<head><base href='http://example.com' />")
     end
 
     it "doesn't prepend base tag to pages when asset_host is nil" do
@@ -68,7 +68,7 @@ Capybara::SpecHelper.spec '#save_page' do
       path = @session.save_page
 
       result = File.read(path)
-      result.should_not include("http://example.com")
+      expect(result).not_to include("http://example.com")
     end
 
     it "doesn't prepend base tag to pages which already have it" do
@@ -76,7 +76,7 @@ Capybara::SpecHelper.spec '#save_page' do
       path = @session.save_page
 
       result = File.read(path)
-      result.should_not include("http://example.com")
+      expect(result).not_to include("http://example.com")
     end
   end
 end

--- a/lib/capybara/spec/session/screenshot.rb
+++ b/lib/capybara/spec/session/screenshot.rb
@@ -9,6 +9,6 @@ Capybara::SpecHelper.spec "#save_screenshot" do
 
   it "should generate PNG file", :requires => [:screenshot] do
     magic = File.read(image_path, 4)
-    magic.should eq "\x89PNG"
+    expect(magic).to eq "\x89PNG"
   end
 end

--- a/lib/capybara/spec/session/select_spec.rb
+++ b/lib/capybara/spec/session/select_spec.rb
@@ -4,22 +4,22 @@ Capybara::SpecHelper.spec "#select" do
   end
 
   it "should return value of the first option" do
-    @session.find_field('Title').value.should == 'Mrs'
+    expect(@session.find_field('Title').value).to eq('Mrs')
   end
 
   it "should return value of the selected option" do
     @session.select("Miss", :from => 'Title')
-    @session.find_field('Title').value.should == 'Miss'
+    expect(@session.find_field('Title').value).to eq('Miss')
   end
 
   it "should allow selecting options where there are inexact matches" do
     @session.select("Mr", :from => 'Title')
-    @session.find_field('Title').value.should == 'Mr'
+    expect(@session.find_field('Title').value).to eq('Mr')
   end
 
   it "should allow selecting options where they are the only inexact match" do
     @session.select("Mis", :from => 'Title')
-    @session.find_field('Title').value.should == 'Miss'
+    expect(@session.find_field('Title').value).to eq('Miss')
   end
 
   it "should not allow selecting options where they are the only inexact match if `Capybara.exact_options = true`" do
@@ -36,50 +36,50 @@ Capybara::SpecHelper.spec "#select" do
   end
 
   it "should return the value attribute rather than content if present" do
-    @session.find_field('Locale').value.should == 'en'
+    expect(@session.find_field('Locale').value).to eq('en')
   end
 
   it "should select an option from a select box by id" do
     @session.select("Finish", :from => 'form_locale')
     @session.click_button('awesome')
-    extract_results(@session)['locale'].should == 'fi'
+    expect(extract_results(@session)['locale']).to eq('fi')
   end
 
   it "should select an option from a select box by label" do
     @session.select("Finish", :from => 'Locale')
     @session.click_button('awesome')
-    extract_results(@session)['locale'].should == 'fi'
+    expect(extract_results(@session)['locale']).to eq('fi')
   end
 
   it "should select an option without giving a select box" do
     @session.select("Swedish")
     @session.click_button('awesome')
-    extract_results(@session)['locale'].should == 'sv'
+    expect(extract_results(@session)['locale']).to eq('sv')
   end
 
   it "should escape quotes" do
     @session.select("John's made-up language", :from => 'Locale')
     @session.click_button('awesome')
-    extract_results(@session)['locale'].should == 'jo'
+    expect(extract_results(@session)['locale']).to eq('jo')
   end
 
   it "should obey from" do
     @session.select("Miss", :from => "Other title")
     @session.click_button('awesome')
     results = extract_results(@session)
-    results['other_title'].should == "Miss"
-    results['title'].should_not == "Miss"
+    expect(results['other_title']).to eq("Miss")
+    expect(results['title']).not_to eq("Miss")
   end
 
   it "show match labels with preceding or trailing whitespace" do
     @session.select("Lojban", :from => 'Locale')
     @session.click_button('awesome')
-    extract_results(@session)['locale'].should == 'jbo'
+    expect(extract_results(@session)['locale']).to eq('jbo')
   end
 
   it "casts to string" do
     @session.select(:"Miss", :from => :'Title')
-    @session.find_field('Title').value.should == 'Miss'
+    expect(@session.find_field('Title').value).to eq('Miss')
   end
 
   context "with a locator that doesn't exist" do
@@ -110,26 +110,26 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with multiple select" do
     it "should return an empty value" do
-      @session.find_field('Language').value.should == []
+      expect(@session.find_field('Language').value).to eq([])
     end
 
     it "should return value of the selected options" do
       @session.select("Ruby",       :from => 'Language')
       @session.select("Javascript", :from => 'Language')
-      @session.find_field('Language').value.should include('Ruby', 'Javascript')
+      expect(@session.find_field('Language').value).to include('Ruby', 'Javascript')
     end
 
     it "should select one option" do
       @session.select("Ruby", :from => 'Language')
       @session.click_button('awesome')
-      extract_results(@session)['languages'].should == ['Ruby']
+      expect(extract_results(@session)['languages']).to eq(['Ruby'])
     end
 
     it "should select multiple options" do
       @session.select("Ruby",       :from => 'Language')
       @session.select("Javascript", :from => 'Language')
       @session.click_button('awesome')
-      extract_results(@session)['languages'].should include('Ruby', 'Javascript')
+      expect(extract_results(@session)['languages']).to include('Ruby', 'Javascript')
     end
 
     it "should remain selected if already selected" do
@@ -137,11 +137,11 @@ Capybara::SpecHelper.spec "#select" do
       @session.select("Javascript", :from => 'Language')
       @session.select("Ruby",       :from => 'Language')
       @session.click_button('awesome')
-      extract_results(@session)['languages'].should include('Ruby', 'Javascript')
+      expect(extract_results(@session)['languages']).to include('Ruby', 'Javascript')
     end
 
     it "should return value attribute rather than content if present" do
-      @session.find_field('Underwear').value.should include('thermal')
+      expect(@session.find_field('Underwear').value).to include('thermal')
     end
   end
 
@@ -150,19 +150,19 @@ Capybara::SpecHelper.spec "#select" do
       it "can match select box approximately" do
         @session.select("Finish", :from => "Loc", :exact => false)
         @session.click_button("awesome")
-        extract_results(@session)["locale"].should == "fi"
+        expect(extract_results(@session)["locale"]).to eq("fi")
       end
 
       it "can match option approximately" do
         @session.select("Fin", :from => "Locale", :exact => false)
         @session.click_button("awesome")
-        extract_results(@session)["locale"].should == "fi"
+        expect(extract_results(@session)["locale"]).to eq("fi")
       end
 
       it "can match option approximately when :from not given" do
         @session.select("made-up language", :exact => false)
         @session.click_button("awesome")
-        extract_results(@session)["locale"].should == "jo"
+        expect(extract_results(@session)["locale"]).to eq("jo")
       end
     end
 

--- a/lib/capybara/spec/session/text_spec.rb
+++ b/lib/capybara/spec/session/text_spec.rb
@@ -1,45 +1,45 @@
 Capybara::SpecHelper.spec '#text' do
   it "should print the text of the page" do
     @session.visit('/with_simple_html')
-    @session.text.should == 'Bar'
+    expect(@session.text).to eq('Bar')
   end
 
   it "ignores invisible text by default" do
     @session.visit('/with_html')
-    @session.find(:id, "hidden-text").text.should == 'Some of this text is'
+    expect(@session.find(:id, "hidden-text").text).to eq('Some of this text is')
   end
 
   it "shows invisible text if `:all` given" do
     @session.visit('/with_html')
-    @session.find(:id, "hidden-text").text(:all).should == 'Some of this text is hidden!'
+    expect(@session.find(:id, "hidden-text").text(:all)).to eq('Some of this text is hidden!')
   end
 
   it "ignores invisible text if `:visible` given" do
     Capybara.ignore_hidden_elements = false
     @session.visit('/with_html')
-    @session.find(:id, "hidden-text").text(:visible).should == 'Some of this text is'
+    expect(@session.find(:id, "hidden-text").text(:visible)).to eq('Some of this text is')
   end
 
   it "ignores invisible text if `Capybara.ignore_hidden_elements = true`" do
     @session.visit('/with_html')
-    @session.find(:id, "hidden-text").text.should == 'Some of this text is'
+    expect(@session.find(:id, "hidden-text").text).to eq('Some of this text is')
     Capybara.ignore_hidden_elements = false
-    @session.find(:id, "hidden-text").text.should == 'Some of this text is hidden!'
+    expect(@session.find(:id, "hidden-text").text).to eq('Some of this text is hidden!')
   end
 
   it "ignores invisible text if `Capybara.visible_text_only = true`" do
     @session.visit('/with_html')
     Capybara.visible_text_only = true
-    @session.find(:id, "hidden-text").text.should == 'Some of this text is'
+    expect(@session.find(:id, "hidden-text").text).to eq('Some of this text is')
     Capybara.ignore_hidden_elements = false
-    @session.find(:id, "hidden-text").text.should == 'Some of this text is'
+    expect(@session.find(:id, "hidden-text").text).to eq('Some of this text is')
   end
 
   context "with css as default selector" do
     before { Capybara.default_selector = :css }
     it "should print the text of the page" do
       @session.visit('/with_simple_html')
-      @session.text.should == 'Bar'
+      expect(@session.text).to eq('Bar')
     end
     after { Capybara.default_selector = :xpath }
   end
@@ -47,7 +47,7 @@ Capybara::SpecHelper.spec '#text' do
   it "should strip whitespace" do
     @session.visit('/with_html')
     n = @session.find(:css, '#second')
-    @session.find(:css, '#second').text.should =~ \
+    expect(@session.find(:css, '#second').text).to match \
       /\ADuis aute .* text with whitespace .* est laborum\.\z/
   end
 end

--- a/lib/capybara/spec/session/title_spec.rb
+++ b/lib/capybara/spec/session/title_spec.rb
@@ -2,14 +2,14 @@ Capybara::SpecHelper.spec '#title' do
 
   it "should print the title of the page" do
     @session.visit('/with_title')
-    @session.title.should == 'Test Title'
+    expect(@session.title).to eq('Test Title')
   end
 
   context "with css as default selector" do
     before { Capybara.default_selector = :css }
     it "should print the title of the page" do
       @session.visit('/with_title')
-      @session.title.should == 'Test Title'
+      expect(@session.title).to eq('Test Title')
     end
     after { Capybara.default_selector = :xpath }
   end

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -6,29 +6,29 @@ Capybara::SpecHelper.spec "#uncheck" do
   it "should uncheck a checkbox by id" do
     @session.uncheck("form_pets_hamster")
     @session.click_button('awesome')
-    extract_results(@session)['pets'].should include('dog')
-    extract_results(@session)['pets'].should_not include('hamster')
+    expect(extract_results(@session)['pets']).to include('dog')
+    expect(extract_results(@session)['pets']).not_to include('hamster')
   end
 
   it "should uncheck a checkbox by label" do
     @session.uncheck("Hamster")
     @session.click_button('awesome')
-    extract_results(@session)['pets'].should include('dog')
-    extract_results(@session)['pets'].should_not include('hamster')
+    expect(extract_results(@session)['pets']).to include('dog')
+    expect(extract_results(@session)['pets']).not_to include('hamster')
   end
 
   it "casts to string" do
     @session.uncheck(:"form_pets_hamster")
     @session.click_button('awesome')
-    extract_results(@session)['pets'].should include('dog')
-    extract_results(@session)['pets'].should_not include('hamster')
+    expect(extract_results(@session)['pets']).to include('dog')
+    expect(extract_results(@session)['pets']).not_to include('hamster')
   end
 
   context "with :exact option" do
     it "should accept partial matches when false" do
       @session.uncheck('Ham', :exact => false)
       @session.click_button('awesome')
-      extract_results(@session)['pets'].should_not include('hamster')
+      expect(extract_results(@session)['pets']).not_to include('hamster')
     end
 
     it "should not accept partial matches when true" do

--- a/lib/capybara/spec/session/unselect_spec.rb
+++ b/lib/capybara/spec/session/unselect_spec.rb
@@ -7,42 +7,42 @@ Capybara::SpecHelper.spec "#unselect" do
     it "should unselect an option from a select box by id" do
       @session.unselect('Commando', :from => 'form_underwear')
       @session.click_button('awesome')
-      extract_results(@session)['underwear'].should include('Briefs', 'Boxerbriefs')
-      extract_results(@session)['underwear'].should_not include('Commando')
+      expect(extract_results(@session)['underwear']).to include('Briefs', 'Boxerbriefs')
+      expect(extract_results(@session)['underwear']).not_to include('Commando')
     end
 
     it "should unselect an option without a select box" do
       @session.unselect('Commando')
       @session.click_button('awesome')
-      extract_results(@session)['underwear'].should include('Briefs', 'Boxerbriefs')
-      extract_results(@session)['underwear'].should_not include('Commando')
+      expect(extract_results(@session)['underwear']).to include('Briefs', 'Boxerbriefs')
+      expect(extract_results(@session)['underwear']).not_to include('Commando')
     end
 
     it "should unselect an option from a select box by label" do
       @session.unselect('Commando', :from => 'Underwear')
       @session.click_button('awesome')
-      extract_results(@session)['underwear'].should include('Briefs', 'Boxerbriefs')
-      extract_results(@session)['underwear'].should_not include('Commando')
+      expect(extract_results(@session)['underwear']).to include('Briefs', 'Boxerbriefs')
+      expect(extract_results(@session)['underwear']).not_to include('Commando')
     end
 
     it "should favour exact matches to option labels" do
       @session.unselect("Briefs", :from => 'Underwear')
       @session.click_button('awesome')
-      extract_results(@session)['underwear'].should include('Commando', 'Boxerbriefs')
-      extract_results(@session)['underwear'].should_not include('Briefs')
+      expect(extract_results(@session)['underwear']).to include('Commando', 'Boxerbriefs')
+      expect(extract_results(@session)['underwear']).not_to include('Briefs')
     end
 
     it "should escape quotes" do
       @session.unselect("Frenchman's Pantalons", :from => 'Underwear')
       @session.click_button('awesome')
-      extract_results(@session)['underwear'].should_not include("Frenchman's Pantalons")
+      expect(extract_results(@session)['underwear']).not_to include("Frenchman's Pantalons")
     end
 
     it "casts to string" do
       @session.unselect(:"Briefs", :from => :'Underwear')
       @session.click_button('awesome')
-      extract_results(@session)['underwear'].should include('Commando', 'Boxerbriefs')
-      extract_results(@session)['underwear'].should_not include('Briefs')
+      expect(extract_results(@session)['underwear']).to include('Commando', 'Boxerbriefs')
+      expect(extract_results(@session)['underwear']).not_to include('Briefs')
     end
   end
 
@@ -75,19 +75,19 @@ Capybara::SpecHelper.spec "#unselect" do
       it "can match select box approximately" do
         @session.unselect("Boxerbriefs", :from => "Under", :exact => false)
         @session.click_button("awesome")
-        extract_results(@session)["underwear"].should_not include("Boxerbriefs")
+        expect(extract_results(@session)["underwear"]).not_to include("Boxerbriefs")
       end
 
       it "can match option approximately" do
         @session.unselect("Boxerbr", :from => "Underwear", :exact => false)
         @session.click_button("awesome")
-        extract_results(@session)["underwear"].should_not include("Boxerbriefs")
+        expect(extract_results(@session)["underwear"]).not_to include("Boxerbriefs")
       end
 
       it "can match option approximately when :from not given" do
         @session.unselect("Boxerbr", :exact => false)
         @session.click_button("awesome")
-        extract_results(@session)["underwear"].should_not include("Boxerbriefs")
+        expect(extract_results(@session)["underwear"]).not_to include("Boxerbriefs")
       end
     end
 

--- a/lib/capybara/spec/session/visit_spec.rb
+++ b/lib/capybara/spec/session/visit_spec.rb
@@ -1,9 +1,9 @@
 Capybara::SpecHelper.spec '#visit' do
   it "should fetch a response from the driver with a relative url" do
     @session.visit('/')
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
     @session.visit('/foo')
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
   end
 
   it "should fetch a response from the driver with an absolute url with a port" do
@@ -12,9 +12,9 @@ Capybara::SpecHelper.spec '#visit' do
     root_uri = URI.parse(@session.current_url)
 
     @session.visit("http://#{root_uri.host}:#{root_uri.port}/")
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
     @session.visit("http://#{root_uri.host}:#{root_uri.port}/foo")
-    @session.should have_content('Another World')
+    expect(@session).to have_content('Another World')
   end
 
   it "should fetch a response when absolute URI doesn't have a trailing slash" do
@@ -23,7 +23,7 @@ Capybara::SpecHelper.spec '#visit' do
     root_uri = URI.parse(@session.current_url)
 
     @session.visit("http://localhost:#{root_uri.port}")
-    @session.should have_content('Hello world!')
+    expect(@session).to have_content('Hello world!')
   end
 
   it "raises any errors caught inside the server", :requires => [:server] do
@@ -50,12 +50,12 @@ Capybara::SpecHelper.spec '#visit' do
 
     it "should fetch a response from the driver with an absolute url without a port" do
       @session.visit("http://#{root_uri.host}/")
-      URI.parse(@session.current_url).port.should == root_uri.port
-      @session.should have_content('Hello world!')
+      expect(URI.parse(@session.current_url).port).to eq(root_uri.port)
+      expect(@session).to have_content('Hello world!')
 
       @session.visit("http://#{root_uri.host}/foo")
-      URI.parse(@session.current_url).port.should == root_uri.port
-      @session.should have_content('Another World')
+      expect(URI.parse(@session.current_url).port).to eq(root_uri.port)
+      expect(@session).to have_content('Another World')
     end
   end
 
@@ -64,49 +64,49 @@ Capybara::SpecHelper.spec '#visit' do
       serverless_session = Capybara::Session.new(@session.mode, nil)
       Capybara.app_host = "http://#{@session.server.host}:#{@session.server.port}"
       serverless_session.visit("/foo")
-      serverless_session.should have_content("Another World")
+      expect(serverless_session).to have_content("Another World")
     end
 
     it "should visit a fully qualified URL" do
       serverless_session = Capybara::Session.new(@session.mode, nil)
       serverless_session.visit("http://#{@session.server.host}:#{@session.server.port}/foo")
-      serverless_session.should have_content("Another World")
+      expect(serverless_session).to have_content("Another World")
     end
   end
 
   it "should send no referer when visiting a page" do
     @session.visit '/get_referer'
-    @session.should have_content 'No referer'
+    expect(@session).to have_content 'No referer'
   end
 
   it "should send no referer when visiting a second page" do
     @session.visit '/get_referer'
     @session.visit '/get_referer'
-    @session.should have_content 'No referer'
+    expect(@session).to have_content 'No referer'
   end
 
   it "should send a referer when following a link" do
     @session.visit '/referer_base'
     @session.find('//a[@href="/get_referer"]').click
-    @session.should have_content %r{http://.*/referer_base}
+    expect(@session).to have_content %r{http://.*/referer_base}
   end
 
   it "should preserve the original referer URL when following a redirect" do
     @session.visit('/referer_base')
     @session.find('//a[@href="/redirect_to_get_referer"]').click
-    @session.should have_content %r{http://.*/referer_base}
+    expect(@session).to have_content %r{http://.*/referer_base}
   end
 
   it "should send a referer when submitting a form" do
     @session.visit '/referer_base'
     @session.find('//input').click
-    @session.should have_content %r{http://.*/referer_base}
+    expect(@session).to have_content %r{http://.*/referer_base}
   end
 
   it "can set cookie if a blank path is specified" do
     @session.visit("")
     @session.visit('/get_cookie')
-    @session.should have_content('root cookie')
+    expect(@session).to have_content('root cookie')
   end
 
 end

--- a/lib/capybara/spec/session/within_frame_spec.rb
+++ b/lib/capybara/spec/session/within_frame_spec.rb
@@ -5,33 +5,33 @@ Capybara::SpecHelper.spec '#within_frame', :requires => [:frames] do
 
   it "should find the div in frameOne" do
     @session.within_frame("frameOne") do
-      @session.find("//*[@id='divInFrameOne']").text.should eql 'This is the text of divInFrameOne'
+      expect(@session.find("//*[@id='divInFrameOne']").text).to eql 'This is the text of divInFrameOne'
     end
   end
   it "should find the div in FrameTwo" do
     @session.within_frame("frameTwo") do
-      @session.find("//*[@id='divInFrameTwo']").text.should eql 'This is the text of divInFrameTwo'
+      expect(@session.find("//*[@id='divInFrameTwo']").text).to eql 'This is the text of divInFrameTwo'
     end
   end
   it "should find the text div in the main window after finding text in frameOne" do
     @session.within_frame("frameOne") do
-      @session.find("//*[@id='divInFrameOne']").text.should eql 'This is the text of divInFrameOne'
+      expect(@session.find("//*[@id='divInFrameOne']").text).to eql 'This is the text of divInFrameOne'
     end
-    @session.find("//*[@id='divInMainWindow']").text.should eql 'This is the text for divInMainWindow'
+    expect(@session.find("//*[@id='divInMainWindow']").text).to eql 'This is the text for divInMainWindow'
   end
   it "should find the text div in the main window after finding text in frameTwo" do
     @session.within_frame("frameTwo") do
-      @session.find("//*[@id='divInFrameTwo']").text.should eql 'This is the text of divInFrameTwo'
+      expect(@session.find("//*[@id='divInFrameTwo']").text).to eql 'This is the text of divInFrameTwo'
     end
-    @session.find("//*[@id='divInMainWindow']").text.should eql 'This is the text for divInMainWindow'
+    expect(@session.find("//*[@id='divInMainWindow']").text).to eql 'This is the text for divInMainWindow'
   end
   it "should return the result of executing the block" do
-    @session.within_frame("frameOne") { "return value" }.should eql "return value"
+    expect(@session.within_frame("frameOne") { "return value" }).to eql "return value"
   end
   it "should find the div given Element" do
     element = @session.find(:id, 'frameOne')
     @session.within_frame element do
-      @session.find("//*[@id='divInFrameOne']").text.should eql 'This is the text of divInFrameOne'
+      expect(@session.find("//*[@id='divInFrameOne']").text).to eql 'This is the text of divInFrameOne'
     end
   end
   it "should find multiple nested frames" do
@@ -45,7 +45,7 @@ Capybara::SpecHelper.spec '#within_frame', :requires => [:frames] do
   it "should reset scope when changing frames" do
     @session.within(:css, '#divInMainWindow') do
       @session.within_frame 'parentFrame' do
-        @session.has_selector?(:css, "iframe#childFrame").should be_true
+        expect(@session.has_selector?(:css, "iframe#childFrame")).to be true
       end
     end
   end

--- a/lib/capybara/spec/session/within_spec.rb
+++ b/lib/capybara/spec/session/within_spec.rb
@@ -8,21 +8,21 @@ Capybara::SpecHelper.spec '#within' do
       @session.within(:css, "#for_bar li", text: 'With Simple HTML') do
         @session.click_link('Go')
       end
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
 
     it "should assert content in the given scope" do
       @session.within(:css, "#for_foo") do
-        @session.should_not have_content('First Name')
+        expect(@session).not_to have_content('First Name')
       end
-      @session.should have_content('First Name')
+      expect(@session).to have_content('First Name')
     end
 
     it "should accept additional options" do
       @session.within(:css, "#for_bar li", :text => 'With Simple HTML') do
         @session.click_link('Go')
       end
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
@@ -31,7 +31,7 @@ Capybara::SpecHelper.spec '#within' do
       @session.within(:xpath, "//div[@id='for_bar']//li[contains(.,'With Simple HTML')]") do
         @session.click_link('Go')
       end
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
@@ -40,7 +40,7 @@ Capybara::SpecHelper.spec '#within' do
       @session.within("//div[@id='for_bar']//li[contains(.,'With Simple HTML')]") do
         @session.click_link('Go')
       end
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
@@ -51,7 +51,7 @@ Capybara::SpecHelper.spec '#within' do
       @session.within(node_of_interest) do
         @session.click_link('Go')
       end
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
   end
 
@@ -61,7 +61,7 @@ Capybara::SpecHelper.spec '#within' do
       @session.within("#for_bar li", text: 'With Simple HTML') do
         @session.click_link('Go')
       end
-      @session.should have_content('Bar')
+      expect(@session).to have_content('Bar')
     end
     after { Capybara.default_selector = :xpath }
   end
@@ -73,7 +73,7 @@ Capybara::SpecHelper.spec '#within' do
           @session.click_link('Go')
         end
       end
-      @session.should have_content('Another World')
+      expect(@session).to have_content('Another World')
     end
 
     it "should respect the outer scope" do
@@ -82,7 +82,7 @@ Capybara::SpecHelper.spec '#within' do
           @session.click_link('Go')
         end
       end
-      @session.should have_content('Hello world')
+      expect(@session).to have_content('Hello world')
     end
   end
 
@@ -110,13 +110,13 @@ Capybara::SpecHelper.spec '#within' do
     @session.within("//li[contains(.,'Bar')]") do
       @session.click_button('Go')
     end
-    extract_results(@session)['first_name'].should == 'Peter'
+    expect(extract_results(@session)['first_name']).to eq('Peter')
     @session.visit('/with_scope')
     @session.within("//li[contains(.,'Bar')]") do
       @session.fill_in('First Name', :with => 'Dagobert')
       @session.click_button('Go')
     end
-    extract_results(@session)['first_name'].should == 'Dagobert'
+    expect(extract_results(@session)['first_name']).to eq('Dagobert')
   end
 end
 
@@ -130,7 +130,7 @@ Capybara::SpecHelper.spec '#within_fieldset' do
       @session.fill_in("Name", :with => 'Goldfinger')
       @session.click_button("Create")
     end
-    extract_results(@session)['villain_name'].should == 'Goldfinger'
+    expect(extract_results(@session)['villain_name']).to eq('Goldfinger')
   end
 
   it "should restrict scope to a fieldset given by legend" do
@@ -138,7 +138,7 @@ Capybara::SpecHelper.spec '#within_fieldset' do
       @session.fill_in("Name", :with => 'Goldfinger')
       @session.click_button("Create")
     end
-    extract_results(@session)['villain_name'].should == 'Goldfinger'
+    expect(extract_results(@session)['villain_name']).to eq('Goldfinger')
   end
 end
 
@@ -152,7 +152,7 @@ Capybara::SpecHelper.spec '#within_table' do
       @session.fill_in("Name", :with => 'Christmas')
       @session.click_button("Create")
     end
-    extract_results(@session)['girl_name'].should == 'Christmas'
+    expect(extract_results(@session)['girl_name']).to eq('Christmas')
   end
 
   it "should restrict scope to a fieldset given by legend" do
@@ -160,6 +160,6 @@ Capybara::SpecHelper.spec '#within_table' do
       @session.fill_in("Name", :with => 'Quantum')
       @session.click_button("Create")
     end
-    extract_results(@session)['villain_name'].should == 'Quantum'
+    expect(extract_results(@session)['villain_name']).to eq('Quantum')
   end
 end

--- a/lib/capybara/spec/session/within_window_spec.rb
+++ b/lib/capybara/spec/session/within_window_spec.rb
@@ -13,32 +13,32 @@ Capybara::SpecHelper.spec '#within_window', :requires => [:windows] do
 
   it "should find the div in firstPopup" do
     @session.within_window("firstPopup") do
-      @session.find("//*[@id='divInPopupOne']").text.should eql 'This is the text of divInPopupOne'
+      expect(@session.find("//*[@id='divInPopupOne']").text).to eql 'This is the text of divInPopupOne'
     end
   end
   it "should find the div in secondPopup" do
     @session.within_window("secondPopup") do
-      @session.find("//*[@id='divInPopupTwo']").text.should eql 'This is the text of divInPopupTwo'
+      expect(@session.find("//*[@id='divInPopupTwo']").text).to eql 'This is the text of divInPopupTwo'
     end
   end
   it "should find the divs in both popups" do
     @session.within_window("secondPopup") do
-      @session.find("//*[@id='divInPopupTwo']").text.should eql 'This is the text of divInPopupTwo'
+      expect(@session.find("//*[@id='divInPopupTwo']").text).to eql 'This is the text of divInPopupTwo'
     end
     @session.within_window("firstPopup") do
-      @session.find("//*[@id='divInPopupOne']").text.should eql 'This is the text of divInPopupOne'
+      expect(@session.find("//*[@id='divInPopupOne']").text).to eql 'This is the text of divInPopupOne'
     end
   end
   it "should find the div in the main window after finding a div in a popup" do
     @session.within_window("secondPopup") do
-      @session.find("//*[@id='divInPopupTwo']").text.should eql 'This is the text of divInPopupTwo'
+      expect(@session.find("//*[@id='divInPopupTwo']").text).to eql 'This is the text of divInPopupTwo'
     end
-    @session.find("//*[@id='divInMainWindow']").text.should eql 'This is the text for divInMainWindow'
+    expect(@session.find("//*[@id='divInMainWindow']").text).to eql 'This is the text for divInMainWindow'
   end
   it "should reset scope when switching windows" do
     @session.within(:css, '#divInMainWindow') do
       @session.within_window("secondPopup") do
-        @session.find("//*[@id='divInPopupTwo']").text.should eql 'This is the text of divInPopupTwo'
+        expect(@session.find("//*[@id='divInPopupTwo']").text).to eql 'This is the text of divInPopupTwo'
       end
     end
   end

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -4,6 +4,15 @@ require "capybara/rspec" # Required here instead of in rspec_spec to avoid RSpec
 require "capybara/spec/test_app"
 require "nokogiri"
 
+# Alias be_truthy/be_falsey if not already defined to be able to use in RSpec 2 and 3
+unless RSpec::Matchers.method_defined?(:be_truthy)
+  RSpec::Matchers.module_eval do
+    alias be_truthy be_true
+    alias be_falsey be_false
+    alias be_falsy be_false
+  end
+end
+
 module Capybara
   module SpecHelper
     class << self
@@ -27,9 +36,9 @@ module Capybara
       end
 
       def filter(requires, metadata)
-        if requires and metadata[:skip]
+        if requires and metadata[:capybara_skip]
           requires.any? do |require|
-            metadata[:skip].include?(require)
+            metadata[:capybara_skip].include?(require)
           end
         else
           false

--- a/spec/basic_node_spec.rb
+++ b/spec/basic_node_spec.rb
@@ -44,96 +44,96 @@ describe Capybara do
     end
 
     it "allows using matchers" do
-      string.should have_css('#page')
-      string.should_not have_css('#does-not-exist')
+      expect(string).to have_css('#page')
+      expect(string).not_to have_css('#does-not-exist')
     end
 
     it "allows using custom matchers" do
       Capybara.add_selector :lifeform do
         xpath { |name| "//option[contains(.,'#{name}')]" }
       end
-      string.should have_selector(:id, "page")
-      string.should_not have_selector(:id, 'does-not-exist')
-      string.should have_selector(:lifeform, "Monkey")
-      string.should_not have_selector(:lifeform, "Gorilla")
+      expect(string).to have_selector(:id, "page")
+      expect(string).not_to have_selector(:id, 'does-not-exist')
+      expect(string).to have_selector(:lifeform, "Monkey")
+      expect(string).not_to have_selector(:lifeform, "Gorilla")
     end
 
     it 'allows custom matcher using css' do
       Capybara.add_selector :section do
         css { |css_class| "section .#{css_class}" }
       end
-      string.should     have_selector(:section, 'subsection')
-      string.should_not have_selector(:section, 'section_8')
+      expect(string).to     have_selector(:section, 'subsection')
+      expect(string).not_to have_selector(:section, 'section_8')
     end
 
     it "allows using matchers with text option" do
-      string.should have_css('h1', :text => 'Totally awesome')
-      string.should_not have_css('h1', :text => 'Not so awesome')
+      expect(string).to have_css('h1', :text => 'Totally awesome')
+      expect(string).not_to have_css('h1', :text => 'Not so awesome')
     end
 
     it "allows finding only visible nodes" do
-      string.all(:css, '#secret', :visible => true).should be_empty
-      string.all(:css, '#secret', :visible => false).should have(1).element
+      expect(string.all(:css, '#secret', :visible => true)).to be_empty
+      expect(string.all(:css, '#secret', :visible => false).size).to eq(1)
     end
 
     it "allows finding elements and extracting text from them" do
-      string.find('//h1').text.should == 'Totally awesome'
+      expect(string.find('//h1').text).to eq('Totally awesome')
     end
 
     it "allows finding elements and extracting attributes from them" do
-      string.find('//h1')[:data].should == 'fantastic'
+      expect(string.find('//h1')[:data]).to eq('fantastic')
     end
 
     it "allows finding elements and extracting the tag name from them" do
-      string.find('//h1').tag_name.should == 'h1'
+      expect(string.find('//h1').tag_name).to eq('h1')
     end
 
     it "allows finding elements and extracting the path" do
-      string.find('//h1').path.should == '/html/body/div/div[1]/h1'
+      expect(string.find('//h1').path).to eq('/html/body/div/div[1]/h1')
     end
 
     it "allows finding elements and extracting the path" do
-      string.find('//div/input').value.should == 'bar'
-      string.find('//select').value.should == 'Capybara'
+      expect(string.find('//div/input').value).to eq('bar')
+      expect(string.find('//select').value).to eq('Capybara')
     end
 
     it "allows finding elements and checking if they are visible" do
-      string.find('//h1').should be_visible
-      string.find(:css, "#secret", :visible => false).should_not be_visible
+      expect(string.find('//h1')).to be_visible
+      expect(string.find(:css, "#secret", :visible => false)).not_to be_visible
     end
 
     it "allows finding elements and checking if they are disabled" do
-      string.find('//form/input[@name="bleh"]').should be_disabled
-      string.find('//form/input[@name="meh"]').should_not be_disabled
+      expect(string.find('//form/input[@name="bleh"]')).to be_disabled
+      expect(string.find('//form/input[@name="meh"]')).not_to be_disabled
     end
 
     describe "#title" do
       it "returns the page title" do
-        string.title.should == "simple_node"
+        expect(string.title).to eq("simple_node")
       end
     end
 
     describe "#has_title?" do
       it "returns whether the page has the given title" do
-        string.has_title?('simple_node').should be_true
-        string.has_title?('monkey').should be_false
+        expect(string.has_title?('simple_node')).to be_truthy
+        expect(string.has_title?('monkey')).to be_falsey
       end
 
       it "allows regexp matches" do
-        string.has_title?(/s[a-z]+_node/).should be_true
-        string.has_title?(/monkey/).should be_false
+        expect(string.has_title?(/s[a-z]+_node/)).to be_truthy
+        expect(string.has_title?(/monkey/)).to be_falsey
       end
     end
 
     describe '#has_no_title?' do
       it "returns whether the page does not have the given title" do
-        string.has_no_title?('simple_node').should be_false
-        string.has_no_title?('monkey').should be_true
+        expect(string.has_no_title?('simple_node')).to be_falsey
+        expect(string.has_no_title?('monkey')).to be_truthy
       end
 
       it "allows regexp matches" do
-        string.has_no_title?(/s[a-z]+_node/).should be_false
-        string.has_no_title?(/monkey/).should be_true
+        expect(string.has_no_title?(/s[a-z]+_node/)).to be_falsey
+        expect(string.has_no_title?(/monkey/)).to be_truthy
       end
     end
   end

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -10,7 +10,7 @@ describe Capybara do
     it "should be changeable" do
       @previous_default_time = Capybara.default_wait_time
       Capybara.default_wait_time = 5
-      Capybara.default_wait_time.should == 5
+      expect(Capybara.default_wait_time).to eq(5)
     end
   end
 
@@ -21,7 +21,7 @@ describe Capybara do
       end
       session = Capybara::Session.new(:schmoo, TestApp)
       session.visit('/')
-      session.body.should include("Hello world!")
+      expect(session.body).to include("Hello world!")
     end
   end
 
@@ -32,14 +32,14 @@ describe Capybara do
 
     it "should default to a proc that calls run_default_server" do
       mock_app = double('app')
-      Capybara.should_receive(:run_default_server).with(mock_app, 8000)
+      expect(Capybara).to receive(:run_default_server).with(mock_app, 8000)
       Capybara.server.call(mock_app, 8000)
     end
 
     it "should return a custom server proc" do
       server = lambda {|app, port|}
       Capybara.server(&server)
-      Capybara.server.should == server
+      expect(Capybara.server).to eq(server)
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -5,7 +5,7 @@ class TestClass
   include Capybara::DSL
 end
 
-Capybara::SpecHelper.run_specs TestClass.new, "DSL", :skip => [
+Capybara::SpecHelper.run_specs TestClass.new, "DSL", :capybara_skip => [
   :js,
   :screenshot,
   :frames,
@@ -25,36 +25,36 @@ describe Capybara::DSL do
 
   describe '#default_driver' do
     it "should default to rack_test" do
-      Capybara.default_driver.should == :rack_test
+      expect(Capybara.default_driver).to eq(:rack_test)
     end
 
     it "should be changeable" do
       Capybara.default_driver = :culerity
-      Capybara.default_driver.should == :culerity
+      expect(Capybara.default_driver).to eq(:culerity)
     end
   end
 
   describe '#current_driver' do
     it "should default to the default driver" do
-      Capybara.current_driver.should == :rack_test
+      expect(Capybara.current_driver).to eq(:rack_test)
       Capybara.default_driver = :culerity
-      Capybara.current_driver.should == :culerity
+      expect(Capybara.current_driver).to eq(:culerity)
     end
 
     it "should be changeable" do
       Capybara.current_driver = :culerity
-      Capybara.current_driver.should == :culerity
+      expect(Capybara.current_driver).to eq(:culerity)
     end
   end
 
   describe '#javascript_driver' do
     it "should default to selenium" do
-      Capybara.javascript_driver.should == :selenium
+      expect(Capybara.javascript_driver).to eq(:selenium)
     end
 
     it "should be changeable" do
       Capybara.javascript_driver = :culerity
-      Capybara.javascript_driver.should == :culerity
+      expect(Capybara.javascript_driver).to eq(:culerity)
     end
   end
 
@@ -62,26 +62,26 @@ describe Capybara::DSL do
     it "should restore the default driver" do
       Capybara.current_driver = :culerity
       Capybara.use_default_driver
-      Capybara.current_driver.should == :rack_test
+      expect(Capybara.current_driver).to eq(:rack_test)
     end
   end
 
   describe '#using_driver' do
     before do
-      Capybara.current_driver.should_not == :selenium
+      expect(Capybara.current_driver).not_to eq(:selenium)
     end
 
     it 'should set the driver using Capybara.current_driver=' do
       driver = nil
       Capybara.using_driver(:selenium) { driver = Capybara.current_driver }
-      driver.should == :selenium
+      expect(driver).to eq(:selenium)
     end
 
     it 'should return the driver to default if it has not been changed' do
       Capybara.using_driver(:selenium) do
-        Capybara.current_driver.should == :selenium
+        expect(Capybara.current_driver).to eq(:selenium)
       end
-      Capybara.current_driver.should == Capybara.default_driver
+      expect(Capybara.current_driver).to eq(Capybara.default_driver)
     end
 
     it 'should reset the driver even if an exception occurs' do
@@ -90,24 +90,24 @@ describe Capybara::DSL do
         Capybara.using_driver(:selenium) { raise "ohnoes!" }
       rescue Exception
       end
-      Capybara.current_driver.should == driver_before_block
+      expect(Capybara.current_driver).to eq(driver_before_block)
     end
 
     it 'should return the driver to what it was previously' do
       Capybara.current_driver = :selenium
       Capybara.using_driver(:culerity) do
         Capybara.using_driver(:rack_test) do
-          Capybara.current_driver.should == :rack_test
+          expect(Capybara.current_driver).to eq(:rack_test)
         end
-        Capybara.current_driver.should == :culerity
+        expect(Capybara.current_driver).to eq(:culerity)
       end
-      Capybara.current_driver.should == :selenium
+      expect(Capybara.current_driver).to eq(:selenium)
     end
 
     it 'should yield the passed block' do
       called = false
       Capybara.using_driver(:selenium) { called = true }
-      called.should == true
+      expect(called).to eq(true)
     end
   end
 
@@ -125,8 +125,8 @@ describe Capybara::DSL do
       Capybara.using_wait_time 6 do
         in_block = Capybara.default_wait_time
       end
-      in_block.should == 6
-      Capybara.default_wait_time.should == @previous_wait_time
+      expect(in_block).to eq(6)
+      expect(Capybara.default_wait_time).to eq(@previous_wait_time)
     end
 
     it "should ensure wait time is reset" do
@@ -135,70 +135,70 @@ describe Capybara::DSL do
           raise "hell"
         end
       end.to raise_error
-      Capybara.default_wait_time.should == @previous_wait_time
+      expect(Capybara.default_wait_time).to eq(@previous_wait_time)
     end
   end
 
   describe '#app' do
     it "should be changeable" do
       Capybara.app = "foobar"
-      Capybara.app.should == 'foobar'
+      expect(Capybara.app).to eq('foobar')
     end
   end
 
   describe '#current_session' do
     it "should choose a session object of the current driver type" do
-      Capybara.current_session.should be_a(Capybara::Session)
+      expect(Capybara.current_session).to be_a(Capybara::Session)
     end
 
     it "should use #app as the application" do
       Capybara.app = proc {}
-      Capybara.current_session.app.should == Capybara.app
+      expect(Capybara.current_session.app).to eq(Capybara.app)
     end
 
     it "should change with the current driver" do
-      Capybara.current_session.mode.should == :rack_test
+      expect(Capybara.current_session.mode).to eq(:rack_test)
       Capybara.current_driver = :selenium
-      Capybara.current_session.mode.should == :selenium
+      expect(Capybara.current_session.mode).to eq(:selenium)
     end
 
     it "should be persistent even across driver changes" do
       object_id = Capybara.current_session.object_id
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.current_session.object_id).to eq(object_id)
       Capybara.current_driver = :selenium
-      Capybara.current_session.mode.should == :selenium
-      Capybara.current_session.object_id.should_not == object_id
+      expect(Capybara.current_session.mode).to eq(:selenium)
+      expect(Capybara.current_session.object_id).not_to eq(object_id)
 
       Capybara.current_driver = :rack_test
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.current_session.object_id).to eq(object_id)
     end
 
     it "should change when changing application" do
       object_id = Capybara.current_session.object_id
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.current_session.object_id).to eq(object_id)
       Capybara.app = proc {}
-      Capybara.current_session.object_id.should_not == object_id
-      Capybara.current_session.app.should == Capybara.app
+      expect(Capybara.current_session.object_id).not_to eq(object_id)
+      expect(Capybara.current_session.app).to eq(Capybara.app)
     end
 
     it "should change when the session name changes" do
       object_id = Capybara.current_session.object_id
       Capybara.session_name = :administrator
-      Capybara.session_name.should == :administrator
-      Capybara.current_session.object_id.should_not == object_id
+      expect(Capybara.session_name).to eq(:administrator)
+      expect(Capybara.current_session.object_id).not_to eq(object_id)
       Capybara.session_name = :default
-      Capybara.session_name.should == :default
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.session_name).to eq(:default)
+      expect(Capybara.current_session.object_id).to eq(object_id)
     end
   end
 
   describe "#using_session" do
     it "should change the session name for the duration of the block" do
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to eq(:default)
       Capybara.using_session(:administrator) do
-        Capybara.session_name.should == :administrator
+        expect(Capybara.session_name).to eq(:administrator)
       end
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to eq(:default)
     end
 
     it "should reset the session to the default, even if an exception occurs" do
@@ -208,19 +208,19 @@ describe Capybara::DSL do
         end
       rescue Exception
       end
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to eq(:default)
     end
 
     it "should yield the passed block" do
       called = false
       Capybara.using_session(:administrator) { called = true }
-      called.should == true
+      expect(called).to eq(true)
     end
   end
 
   describe "#session_name" do
     it "should default to :default" do
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to eq(:default)
     end
   end
 
@@ -232,22 +232,22 @@ describe Capybara::DSL do
     it "should be possible to include it in another class" do
       @session.visit('/with_html')
       @session.click_link('ullamco')
-      @session.body.should include('Another World')
+      expect(@session.body).to include('Another World')
     end
 
     it "should provide a 'page' shortcut for more expressive tests" do
       @session.page.visit('/with_html')
       @session.page.click_link('ullamco')
-      @session.page.body.should include('Another World')
+      expect(@session.page.body).to include('Another World')
     end
 
     it "should provide an 'using_session' shortcut" do
-      Capybara.should_receive(:using_session).with(:name)
+      expect(Capybara).to receive(:using_session).with(:name)
       @session.using_session(:name)
     end
 
     it "should provide a 'using_wait_time' shortcut" do
-      Capybara.should_receive(:using_wait_time).with(6)
+      expect(Capybara).to receive(:using_wait_time).with(6)
       @session.using_wait_time(6)
     end
   end

--- a/spec/fixtures/selenium_driver_rspec_failure.rb
+++ b/spec/fixtures/selenium_driver_rspec_failure.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Capybara::Selenium::Driver do
   it "should exit with a non-zero exit status" do
     browser = Capybara::Selenium::Driver.new(TestApp).browser
-    true.should == false
+    expect(true).to eq(false)
   end
 end

--- a/spec/fixtures/selenium_driver_rspec_success.rb
+++ b/spec/fixtures/selenium_driver_rspec_success.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Capybara::Selenium::Driver do
   it "should exit with a zero exit status" do
     browser = Capybara::Selenium::Driver.new(TestApp).browser
-    true.should == true
+    expect(true).to eq(true)
   end
 end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -4,7 +4,7 @@ module TestSessions
   RackTest = Capybara::Session.new(:rack_test, TestApp)
 end
 
-Capybara::SpecHelper.run_specs TestSessions::RackTest, "RackTest", :skip => [
+Capybara::SpecHelper.run_specs TestSessions::RackTest, "RackTest", :capybara_skip => [
   :js,
   :screenshot,
   :frames,
@@ -21,13 +21,13 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a rack test driver" do
-        @session.driver.should be_an_instance_of(Capybara::RackTest::Driver)
+        expect(@session.driver).to be_an_instance_of(Capybara::RackTest::Driver)
       end
     end
 
     describe '#mode' do
       it "should remember the mode" do
-        @session.mode.should == :rack_test
+        expect(@session.mode).to eq(:rack_test)
       end
     end
 
@@ -36,21 +36,21 @@ describe Capybara::Session do
         @session.driver.options[:respect_data_method] = true
         @session.visit "/with_html"
         @session.click_link "A link with data-method"
-        @session.html.should include('The requested object was deleted')
+        expect(@session.html).to include('The requested object was deleted')
       end
 
       it "should not use data-method if option is false" do
         @session.driver.options[:respect_data_method] = false
         @session.visit "/with_html"
         @session.click_link "A link with data-method"
-        @session.html.should include('Not deleted')
+        expect(@session.html).to include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         @session.driver.options[:respect_data_method] = true
         @session.visit "/with_html"
         @session.click_link "A link with capitalized data-method"
-        @session.html.should include('The requested object was deleted')
+        expect(@session.html).to include('The requested object was deleted')
       end
 
       after do
@@ -63,7 +63,7 @@ describe Capybara::Session do
         it "should submit an empty form-data section if no file is submitted" do
           @session.visit("/form")
           @session.click_button("Upload Empty")
-          @session.html.should include('Successfully ignored empty file field.')
+          expect(@session.html).to include('Successfully ignored empty file field.')
         end
       end
     end
@@ -79,27 +79,27 @@ describe Capybara::RackTest::Driver do
     it 'should always set headers' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header')
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
 
     it 'should keep headers on link clicks' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find_xpath('.//a').first.click
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
 
     it 'should keep headers on form submit' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find_xpath('.//input').first.click
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
 
     it 'should keep headers on redirects' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header_via_redirect')
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
   end
 
@@ -108,16 +108,16 @@ describe Capybara::RackTest::Driver do
       @driver = Capybara::RackTest::Driver.new(TestApp)
 
       @driver.visit('/redirect')
-      @driver.response.header['Location'].should be_nil
-      @driver.browser.current_url.should match %r{/landed$}
+      expect(@driver.response.header['Location']).to be_nil
+      expect(@driver.browser.current_url).to match %r{/landed$}
     end
 
     it "is possible to not follow redirects" do
       @driver = Capybara::RackTest::Driver.new(TestApp, :follow_redirects => false)
 
       @driver.visit('/redirect')
-      @driver.response.header['Location'].should match %r{/redirect_again$}
-      @driver.browser.current_url.should match %r{/redirect$}
+      expect(@driver.response.header['Location']).to match %r{/redirect_again$}
+      expect(@driver.browser.current_url).to match %r{/redirect$}
     end
   end
 
@@ -129,7 +129,7 @@ describe Capybara::RackTest::Driver do
 
       it "should follow 5 redirects" do
         @driver.visit("/redirect/5/times")
-        @driver.html.should include('redirection complete')
+        expect(@driver.html).to include('redirection complete')
       end
 
       it "should not follow more than 6 redirects" do
@@ -146,7 +146,7 @@ describe Capybara::RackTest::Driver do
 
       it "should follow 21 redirects" do
         @driver.visit("/redirect/21/times")
-        @driver.html.should include('redirection complete')
+        expect(@driver.html).to include('redirection complete')
       end
 
       it "should not follow more than 21 redirects" do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -17,7 +17,7 @@ describe Capybara::Result do
   end
 
   it "has a length" do
-    result.length.should == 4
+    expect(result.length).to eq(4)
   end
 
   it "has a first element" do
@@ -29,37 +29,37 @@ describe Capybara::Result do
   end
 
   it 'can supports values_at method' do
-    result.values_at(0, 2).map(&:text).should == %w(Alpha Gamma)
+    expect(result.values_at(0, 2).map(&:text)).to eq(%w(Alpha Gamma))
   end
 
   it "can return an element by its index" do
-    result.at(1).text.should == 'Beta'
-    result[2].text.should == 'Gamma'
+    expect(result.at(1).text).to eq('Beta')
+    expect(result[2].text).to eq('Gamma')
   end
 
   it "can be mapped" do
-    result.map(&:text).should == %w(Alpha Beta Gamma Delta)
+    expect(result.map(&:text)).to eq(%w(Alpha Beta Gamma Delta))
   end
 
   it "can be selected" do
-    result.select do |element|
+    expect(result.select do |element|
       element.text.include? 't'
-    end.length.should == 2
+    end.length).to eq(2)
   end
 
   it "can be reduced" do
-    result.reduce('') do |memo, element|
+    expect(result.reduce('') do |memo, element|
       memo += element.text[0]
-    end.should == 'ABGD'
+    end).to eq('ABGD')
   end
 
   it 'can be sampled' do
-    result.should include(result.sample)
+    expect(result).to include(result.sample)
   end
 
   it 'can be indexed' do
-    result.index do |el|
+    expect(result.index do |el|
       el.text == 'Gamma'
-    end.should == 2
+    end).to eq(2)
   end
 end

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -5,48 +5,53 @@ RSpec.configuration.before(:each, :example_group => {:file_path => "./spec/rspec
   @in_filtered_hook = true
 end
 
-feature "Capybara's feature DSL" do
+feature "Capybara's feature DSL" do    
   background do
     @in_background = true
+  end
+  
+  def current_example(context)
+    RSpec.respond_to?(:current_example) ? RSpec.current_example : context.example
   end
 
   scenario "includes Capybara" do
     visit('/')
-    page.should have_content('Hello world!')
+    expect(page).to have_content('Hello world!')
   end
 
-  scenario "preserves description" do
-    example.metadata[:full_description].should == "Capybara's feature DSL preserves description"
+  scenario "preserves description" do 
+    expect(current_example(self).metadata[:full_description])
+      .to eq("Capybara's feature DSL preserves description")
   end
 
   scenario "allows driver switching", :driver => :selenium do
-    Capybara.current_driver.should == :selenium
+    expect(Capybara.current_driver).to eq(:selenium)
   end
 
   scenario "runs background" do
-    @in_background.should be_true
+    expect(@in_background).to be_truthy
   end
 
   scenario "runs hooks filtered by file path" do
-    @in_filtered_hook.should be_true
+    expect(@in_filtered_hook).to be_truthy
   end
 
   scenario "doesn't pollute the Object namespace" do
-    Object.new.respond_to?(:feature, true).should be_false
+    expect(Object.new.respond_to?(:feature, true)).to be_falsey
   end
 
   feature 'nested features' do
     scenario 'work as expected' do
       visit '/'
-      page.should have_content 'Hello world!'
+      expect(page).to have_content 'Hello world!'
     end
 
     scenario 'are marked in the metadata as capybara_feature' do
-      example.metadata[:capybara_feature].should be_true
+      expect(current_example(self).metadata[:capybara_feature]).to be_truthy
     end
 
     scenario 'have a type of :feature' do
-      example.metadata[:type].should eq :feature
+      expect(current_example(self).metadata[:type]).to eq :feature
     end
   end
 end
@@ -56,12 +61,12 @@ feature "given and given! aliases to let and let!" do
   given!(:value_in_background) { :available }
 
   background do
-    value_in_background.should be(:available)
+    expect(value_in_background).to be(:available)
   end
 
   scenario "given and given! work as intended" do
-    value.should be(:available)
-    value_in_background.should be(:available)
+    expect(value).to be(:available)
+    expect(value_in_background).to be(:available)
   end
 end
 
@@ -72,6 +77,6 @@ end
 
 feature "Capybara's feature DSL with driver", :driver => :culerity do
   scenario "switches driver" do
-    Capybara.current_driver.should == :culerity
+    expect(Capybara.current_driver).to eq(:culerity)
   end
 end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -8,46 +8,46 @@ describe Capybara::RSpecMatchers do
 
   describe "have_css matcher" do
     it "gives proper description" do
-      have_css('h1').description.should == "have css \"h1\""
+      expect(have_css('h1').description).to eq("have css \"h1\"")
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_css? returns true" do
-          "<h1>Text</h1>".should have_css('h1')
+          expect("<h1>Text</h1>").to have_css('h1')
         end
 
         it "fails if has_css? returns false" do
           expect do
-            "<h1>Text</h1>".should have_css('h2')
+            expect("<h1>Text</h1>").to have_css('h2')
           end.to raise_error(/expected to find css "h2" but there were no matches/)
         end
 
         it "passes if matched node count equals expected count" do
-          "<h1>Text</h1>".should have_css('h1', :count => 1)
+          expect("<h1>Text</h1>").to have_css('h1', :count => 1)
         end
 
         it "fails if matched node count does not equal expected count" do
           expect do
-            "<h1>Text</h1>".should have_css('h1', count: 2)
+            expect("<h1>Text</h1>").to have_css('h1', count: 2)
           end.to raise_error("expected to find css \"h1\" 2 times, found 1 match: \"Text\"")
         end
 
         it "fails if matched node count is less than expected minimum count" do
           expect do
-            "<h1>Text</h1>".should have_css('p', minimum: 1)
+            expect("<h1>Text</h1>").to have_css('p', minimum: 1)
           end.to raise_error("expected to find css \"p\" at least 1 time but there were no matches")
         end
 
         it "fails if matched node count is more than expected maximum count" do
           expect do
-            "<h1>Text</h1><h1>Text</h1><h1>Text</h1>".should have_css('h1', maximum: 2)
+            expect("<h1>Text</h1><h1>Text</h1><h1>Text</h1>").to have_css('h1', maximum: 2)
           end.to raise_error('expected to find css "h1" at most 2 times, found 3 matches: "Text", "Text", "Text"')
         end
 
         it "fails if matched node count does not belong to expected range" do
           expect do
-            "<h1>Text</h1>".should have_css('h1', between: 2..3)
+            expect("<h1>Text</h1>").to have_css('h1', between: 2..3)
           end.to raise_error("expected to find css \"h1\" between 2 and 3 times, found 1 match: \"Text\"")
         end
 
@@ -55,22 +55,22 @@ describe Capybara::RSpecMatchers do
 
       context "with should_not" do
         it "passes if has_no_css? returns true" do
-          "<h1>Text</h1>".should_not have_css('h2')
+          expect("<h1>Text</h1>").not_to have_css('h2')
         end
 
         it "fails if has_no_css? returns false" do
           expect do
-            "<h1>Text</h1>".should_not have_css('h1')
+            expect("<h1>Text</h1>").not_to have_css('h1')
           end.to raise_error(/expected not to find css "h1"/)
         end
 
         it "passes if matched node count does not equal expected count" do
-          "<h1>Text</h1>".should_not have_css('h1', :count => 2)
+          expect("<h1>Text</h1>").not_to have_css('h1', :count => 2)
         end
 
         it "fails if matched node count equals expected count" do
           expect do
-            "<h1>Text</h1>".should_not have_css('h1', :count => 1)
+            expect("<h1>Text</h1>").not_to have_css('h1', :count => 1)
           end.to raise_error(/expected not to find css "h1"/)
         end
       end
@@ -83,24 +83,24 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_css? returns true" do
-          page.should have_css('h1')
+          expect(page).to have_css('h1')
         end
 
         it "fails if has_css? returns false" do
           expect do
-            page.should have_css('h1#doesnotexist')
+            expect(page).to have_css('h1#doesnotexist')
           end.to raise_error(/expected to find css "h1#doesnotexist" but there were no matches/)
         end
       end
 
       context "with should_not" do
         it "passes if has_no_css? returns true" do
-          page.should_not have_css('h1#doesnotexist')
+          expect(page).not_to have_css('h1#doesnotexist')
         end
 
         it "fails if has_no_css? returns false" do
           expect do
-            page.should_not have_css('h1')
+            expect(page).not_to have_css('h1')
           end.to raise_error(/expected not to find css "h1"/)
         end
       end
@@ -109,30 +109,30 @@ describe Capybara::RSpecMatchers do
 
   describe "have_xpath matcher" do
     it "gives proper description" do
-      have_xpath('//h1').description.should == "have xpath \"\/\/h1\""
+      expect(have_xpath('//h1').description).to eq("have xpath \"\/\/h1\"")
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_xpath? returns true" do
-          "<h1>Text</h1>".should have_xpath('//h1')
+          expect("<h1>Text</h1>").to have_xpath('//h1')
         end
 
         it "fails if has_xpath? returns false" do
           expect do
-            "<h1>Text</h1>".should have_xpath('//h2')
+            expect("<h1>Text</h1>").to have_xpath('//h2')
           end.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_xpath? returns true" do
-          "<h1>Text</h1>".should_not have_xpath('//h2')
+          expect("<h1>Text</h1>").not_to have_xpath('//h2')
         end
 
         it "fails if has_no_xpath? returns false" do
           expect do
-            "<h1>Text</h1>".should_not have_xpath('//h1')
+            expect("<h1>Text</h1>").not_to have_xpath('//h1')
           end.to raise_error(%r(expected not to find xpath "//h1"))
         end
       end
@@ -145,24 +145,24 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_xpath? returns true" do
-          page.should have_xpath('//h1')
+          expect(page).to have_xpath('//h1')
         end
 
         it "fails if has_xpath? returns false" do
           expect do
-            page.should have_xpath("//h1[@id='doesnotexist']")
+            expect(page).to have_xpath("//h1[@id='doesnotexist']")
           end.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_xpath? returns true" do
-          page.should_not have_xpath('//h1[@id="doesnotexist"]')
+          expect(page).not_to have_xpath('//h1[@id="doesnotexist"]')
         end
 
         it "fails if has_no_xpath? returns false" do
           expect do
-            page.should_not have_xpath('//h1')
+            expect(page).not_to have_xpath('//h1')
           end.to raise_error(%r(expected not to find xpath "//h1"))
         end
       end
@@ -172,31 +172,31 @@ describe Capybara::RSpecMatchers do
   describe "have_selector matcher" do
     it "gives proper description" do
       matcher = have_selector('//h1')
-      "<h1>Text</h1>".should matcher
-      matcher.description.should == "have xpath \"//h1\""
+      expect("<h1>Text</h1>").to matcher
+      expect(matcher.description).to eq("have xpath \"//h1\"")
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_selector? returns true" do
-          "<h1>Text</h1>".should have_selector('//h1')
+          expect("<h1>Text</h1>").to have_selector('//h1')
         end
 
         it "fails if has_selector? returns false" do
           expect do
-            "<h1>Text</h1>".should have_selector('//h2')
+            expect("<h1>Text</h1>").to have_selector('//h2')
           end.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_selector? returns true" do
-          "<h1>Text</h1>".should_not have_selector(:css, 'h2')
+          expect("<h1>Text</h1>").not_to have_selector(:css, 'h2')
         end
 
         it "fails if has_no_selector? returns false" do
           expect do
-            "<h1>Text</h1>".should_not have_selector(:css, 'h1')
+            expect("<h1>Text</h1>").not_to have_selector(:css, 'h1')
           end.to raise_error(%r(expected not to find css "h1"))
         end
       end
@@ -209,30 +209,30 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_selector? returns true" do
-          page.should have_selector('//h1', :text => 'test')
+          expect(page).to have_selector('//h1', :text => 'test')
         end
 
         it "fails if has_selector? returns false" do
           expect do
-            page.should have_selector("//h1[@id='doesnotexist']")
+            expect(page).to have_selector("//h1[@id='doesnotexist']")
           end.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
         end
 
         it "includes text in error message" do
           expect do
-            page.should have_selector("//h1", :text => 'wrong text')
+            expect(page).to have_selector("//h1", :text => 'wrong text')
           end.to raise_error(%r(expected to find xpath "//h1" with text "wrong text" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_css? returns true" do
-          page.should_not have_selector(:css, 'h1#doesnotexist')
+          expect(page).not_to have_selector(:css, 'h1#doesnotexist')
         end
 
         it "fails if has_no_selector? returns false" do
           expect do
-            page.should_not have_selector(:css, 'h1', :text => 'test')
+            expect(page).not_to have_selector(:css, 'h1', :text => 'test')
           end.to raise_error(%r(expected not to find css "h1" with text "test"))
         end
       end
@@ -241,38 +241,38 @@ describe Capybara::RSpecMatchers do
 
   describe "have_content matcher" do
     it "gives proper description" do
-      have_content('Text').description.should == "text \"Text\""
+      expect(have_content('Text').description).to eq("text \"Text\"")
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_content? returns true" do
-          "<h1>Text</h1>".should have_content('Text')
+          expect("<h1>Text</h1>").to have_content('Text')
         end
 
         it "passes if has_content? returns true using regexp" do
-          "<h1>Text</h1>".should have_content(/ext/)
+          expect("<h1>Text</h1>").to have_content(/ext/)
         end
 
         it "fails if has_content? returns false" do
           expect do
-            "<h1>Text</h1>".should have_content('No such Text')
+            expect("<h1>Text</h1>").to have_content('No such Text')
           end.to raise_error(/expected to find text "No such Text" in "Text"/)
         end
       end
 
       context "with should_not" do
         it "passes if has_no_content? returns true" do
-          "<h1>Text</h1>".should_not have_content('No such Text')
+          expect("<h1>Text</h1>").not_to have_content('No such Text')
         end
 
         it "passes because escapes any characters that would have special meaning in a regexp" do
-          "<h1>Text</h1>".should_not have_content('.')
+          expect("<h1>Text</h1>").not_to have_content('.')
         end
 
         it "fails if has_no_content? returns false" do
           expect do
-            "<h1>Text</h1>".should_not have_content('Text')
+            expect("<h1>Text</h1>").not_to have_content('Text')
           end.to raise_error(/expected not to find text "Text" in "Text"/)
         end
       end
@@ -285,16 +285,16 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_content? returns true" do
-          page.should have_content('This is a test')
+          expect(page).to have_content('This is a test')
         end
 
         it "passes if has_content? returns true using regexp" do
-          page.should have_content(/test/)
+          expect(page).to have_content(/test/)
         end
 
         it "fails if has_content? returns false" do
           expect do
-            page.should have_content('No such Text')
+            expect(page).to have_content('No such Text')
           end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
         end
 
@@ -302,7 +302,7 @@ describe Capybara::RSpecMatchers do
           before { Capybara.default_selector = :css }
           it "fails if has_content? returns false" do
             expect do
-              page.should have_content('No such Text')
+              expect(page).to have_content('No such Text')
             end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
           end
           after { Capybara.default_selector = :xpath }
@@ -311,12 +311,12 @@ describe Capybara::RSpecMatchers do
 
       context "with should_not" do
         it "passes if has_no_content? returns true" do
-          page.should_not have_content('No such Text')
+          expect(page).not_to have_content('No such Text')
         end
 
         it "fails if has_no_content? returns false" do
           expect do
-            page.should_not have_content('This is a test')
+            expect(page).not_to have_content('This is a test')
           end.to raise_error(/expected not to find text "This is a test"/)
         end
       end
@@ -325,68 +325,68 @@ describe Capybara::RSpecMatchers do
 
   describe "have_text matcher" do
     it "gives proper description" do
-      have_text('Text').description.should == "text \"Text\""
+      expect(have_text('Text').description).to eq("text \"Text\"")
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_text? returns true" do
-          "<h1>Text</h1>".should have_text('Text')
+          expect("<h1>Text</h1>").to have_text('Text')
         end
 
         it "passes if has_text? returns true using regexp" do
-          "<h1>Text</h1>".should have_text(/ext/)
+          expect("<h1>Text</h1>").to have_text(/ext/)
         end
 
         it "fails if has_text? returns false" do
           expect do
-            "<h1>Text</h1>".should have_text('No such Text')
+            expect("<h1>Text</h1>").to have_text('No such Text')
           end.to raise_error(/expected to find text "No such Text" in "Text"/)
         end
 
         it "casts Fixnum to string" do
           expect do
-            "<h1>Text</h1>".should have_text(3)
+            expect("<h1>Text</h1>").to have_text(3)
           end.to raise_error(/expected to find text "3" in "Text"/)
         end
 
         it "fails if matched text count does not equal to expected count" do
           expect do
-            "<h1>Text</h1>".should have_text('Text', count: 2)
+            expect("<h1>Text</h1>").to have_text('Text', count: 2)
           end.to raise_error(/expected to find text "Text" 2 times in "Text"/)
         end
 
         it "fails if matched text count is less than expected minimum count" do
           expect do
-            "<h1>Text</h1>".should have_text('Lorem', minimum: 1)
+            expect("<h1>Text</h1>").to have_text('Lorem', minimum: 1)
           end.to raise_error(/expected to find text "Lorem" at least 1 time in "Text"/)
         end
 
         it "fails if matched text count is more than expected maximum count" do
           expect do
-            "<h1>Text TextText</h1>".should have_text('Text', maximum: 2)
+            expect("<h1>Text TextText</h1>").to have_text('Text', maximum: 2)
           end.to raise_error(/expected to find text "Text" at most 2 times in "Text TextText"/)
         end
 
         it "fails if matched text count does not belong to expected range" do
           expect do
-            "<h1>Text</h1>".should have_text('Text', between: 2..3)
+            expect("<h1>Text</h1>").to have_text('Text', between: 2..3)
           end.to raise_error(/expected to find text "Text" between 2 and 3 times in "Text"/)
         end
       end
 
       context "with should_not" do
         it "passes if has_no_text? returns true" do
-          "<h1>Text</h1>".should_not have_text('No such Text')
+          expect("<h1>Text</h1>").not_to have_text('No such Text')
         end
 
         it "passes because escapes any characters that would have special meaning in a regexp" do
-          "<h1>Text</h1>".should_not have_text('.')
+          expect("<h1>Text</h1>").not_to have_text('.')
         end
 
         it "fails if has_no_text? returns false" do
           expect do
-            "<h1>Text</h1>".should_not have_text('Text')
+            expect("<h1>Text</h1>").not_to have_text('Text')
           end.to raise_error(/expected not to find text "Text" in "Text"/)
         end
       end
@@ -399,25 +399,25 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_text? returns true" do
-          page.should have_text('This is a test')
+          expect(page).to have_text('This is a test')
         end
 
         it "passes if has_text? returns true using regexp" do
-          page.should have_text(/test/)
+          expect(page).to have_text(/test/)
         end
 
         it "can check for all text" do
-          page.should have_text(:all, 'Some of this text is hidden!')
+          expect(page).to have_text(:all, 'Some of this text is hidden!')
         end
 
         it "can check for visible text" do
-          page.should have_text(:visible, 'Some of this text is')
-          page.should_not have_text(:visible, 'Some of this text is hidden!')
+          expect(page).to have_text(:visible, 'Some of this text is')
+          expect(page).not_to have_text(:visible, 'Some of this text is hidden!')
         end
 
         it "fails if has_text? returns false" do
           expect do
-            page.should have_text('No such Text')
+            expect(page).to have_text('No such Text')
           end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
         end
 
@@ -425,7 +425,7 @@ describe Capybara::RSpecMatchers do
           before { Capybara.default_selector = :css }
           it "fails if has_text? returns false" do
             expect do
-              page.should have_text('No such Text')
+              expect(page).to have_text('No such Text')
             end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
           end
           after { Capybara.default_selector = :xpath }
@@ -434,12 +434,12 @@ describe Capybara::RSpecMatchers do
 
       context "with should_not" do
         it "passes if has_no_text? returns true" do
-          page.should_not have_text('No such Text')
+          expect(page).not_to have_text('No such Text')
         end
 
         it "fails if has_no_text? returns false" do
           expect do
-            page.should_not have_text('This is a test')
+            expect(page).not_to have_text('This is a test')
           end.to raise_error(/expected not to find text "This is a test"/)
         end
       end
@@ -450,35 +450,35 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<a href="#">Just a link</a>' }
 
     it "gives proper description" do
-      have_link('Just a link').description.should == "have link \"Just a link\""
+      expect(have_link('Just a link').description).to eq("have link \"Just a link\"")
     end
 
     it "passes if there is such a button" do
-      html.should have_link('Just a link')
+      expect(html).to have_link('Just a link')
     end
 
     it "fails if there is no such button" do
       expect do
-        html.should have_link('No such Link')
+        expect(html).to have_link('No such Link')
       end.to raise_error(/expected to find link "No such Link"/)
     end
   end
 
   describe "have_title matcher" do
     it "gives proper description" do
-      have_title('Just a title').description.should == "have title \"Just a title\""
+      expect(have_title('Just a title').description).to eq("have title \"Just a title\"")
     end
 
     context "on a string" do
       let(:html) { '<title>Just a title</title>' }
 
       it "passes if there is such a title" do
-        html.should have_title('Just a title')
+        expect(html).to have_title('Just a title')
       end
 
       it "fails if there is no such title" do
         expect do
-          html.should have_title('No such title')
+          expect(html).to have_title('No such title')
         end.to raise_error(/expected there to be title "No such title"/)
       end
     end
@@ -489,12 +489,12 @@ describe Capybara::RSpecMatchers do
       end
 
       it "passes if there is such a title" do
-        page.should have_title('with_js')
+        expect(page).to have_title('with_js')
       end
 
       it "fails if there is no such title" do
         expect do
-          page.should have_title('No such title')
+          expect(page).to have_title('No such title')
         end.to raise_error(/expected there to be title "No such title"/)
       end
     end
@@ -504,16 +504,16 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<button>A button</button><input type="submit" value="Another button"/>' }
 
     it "gives proper description" do
-      have_button('A button').description.should == "have button \"A button\""
+      expect(have_button('A button').description).to eq("have button \"A button\"")
     end
 
     it "passes if there is such a button" do
-      html.should have_button('A button')
+      expect(html).to have_button('A button')
     end
 
     it "fails if there is no such button" do
       expect do
-        html.should have_button('No such Button')
+        expect(html).to have_button('No such Button')
       end.to raise_error(/expected to find button "No such Button"/)
     end
   end
@@ -522,30 +522,30 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<p><label>Text field<input type="text" value="some value"/></label></p>' }
 
     it "gives proper description" do
-      have_field('Text field').description.should == "have field \"Text field\""
+      expect(have_field('Text field').description).to eq("have field \"Text field\"")
     end
 
     it "gives proper description for a given value" do
-      have_field('Text field', with: 'some value').description.should == "have field \"Text field\" with value \"some value\""
+      expect(have_field('Text field', with: 'some value').description).to eq("have field \"Text field\" with value \"some value\"")
     end
 
     it "passes if there is such a field" do
-      html.should have_field('Text field')
+      expect(html).to have_field('Text field')
     end
 
     it "passes if there is such a field with value" do
-      html.should have_field('Text field', with: 'some value')
+      expect(html).to have_field('Text field', with: 'some value')
     end
 
     it "fails if there is no such field" do
       expect do
-        html.should have_field('No such Field')
+        expect(html).to have_field('No such Field')
       end.to raise_error(/expected to find field "No such Field"/)
     end
 
     it "fails if there is such field but with false value" do
       expect do
-        html.should have_field('Text field', with: 'false value')
+        expect(html).to have_field('Text field', with: 'false value')
       end.to raise_error(/expected to find field "Text field"/)
     end
 
@@ -555,7 +555,7 @@ describe Capybara::RSpecMatchers do
           "some value"
         end
       end
-      html.should have_field('Text field', with: Foo.new)
+      expect(html).to have_field('Text field', with: Foo.new)
     end
   end
 
@@ -566,23 +566,23 @@ describe Capybara::RSpecMatchers do
     end
 
     it "gives proper description" do
-      have_checked_field('it is checked').description.should == "have field \"it is checked\""
+      expect(have_checked_field('it is checked').description).to eq("have field \"it is checked\"")
     end
 
     context "with should" do
       it "passes if there is such a field and it is checked" do
-        html.should have_checked_field('it is checked')
+        expect(html).to have_checked_field('it is checked')
       end
 
       it "fails if there is such a field but it is not checked" do
         expect do
-          html.should have_checked_field('unchecked field')
+          expect(html).to have_checked_field('unchecked field')
         end.to raise_error(/expected to find field "unchecked field"/)
       end
 
       it "fails if there is no such field" do
         expect do
-          html.should have_checked_field('no such field')
+          expect(html).to have_checked_field('no such field')
         end.to raise_error(/expected to find field "no such field"/)
       end
     end
@@ -590,16 +590,16 @@ describe Capybara::RSpecMatchers do
     context "with should not" do
       it "fails if there is such a field and it is checked" do
         expect do
-          html.should_not have_checked_field('it is checked')
+          expect(html).not_to have_checked_field('it is checked')
         end.to raise_error(/expected not to find field "it is checked"/)
       end
 
       it "passes if there is such a field but it is not checked" do
-        html.should_not have_checked_field('unchecked field')
+        expect(html).not_to have_checked_field('unchecked field')
       end
 
       it "passes if there is no such field" do
-        html.should_not have_checked_field('no such field')
+        expect(html).not_to have_checked_field('no such field')
       end
     end
   end
@@ -611,23 +611,23 @@ describe Capybara::RSpecMatchers do
     end
 
     it "gives proper description" do
-      have_unchecked_field('unchecked field').description.should == "have field \"unchecked field\""
+      expect(have_unchecked_field('unchecked field').description).to eq("have field \"unchecked field\"")
     end
 
     context "with should" do
       it "passes if there is such a field and it is not checked" do
-        html.should have_unchecked_field('unchecked field')
+        expect(html).to have_unchecked_field('unchecked field')
       end
 
       it "fails if there is such a field but it is checked" do
         expect do
-          html.should have_unchecked_field('it is checked')
+          expect(html).to have_unchecked_field('it is checked')
         end.to raise_error(/expected to find field "it is checked"/)
       end
 
       it "fails if there is no such field" do
         expect do
-          html.should have_unchecked_field('no such field')
+          expect(html).to have_unchecked_field('no such field')
         end.to raise_error(/expected to find field "no such field"/)
       end
     end
@@ -635,16 +635,16 @@ describe Capybara::RSpecMatchers do
     context "with should not" do
       it "fails if there is such a field and it is not checked" do
         expect do
-          html.should_not have_unchecked_field('unchecked field')
+          expect(html).not_to have_unchecked_field('unchecked field')
         end.to raise_error(/expected not to find field "unchecked field"/)
       end
 
       it "passes if there is such a field but it is checked" do
-        html.should_not have_unchecked_field('it is checked')
+        expect(html).not_to have_unchecked_field('it is checked')
       end
 
       it "passes if there is no such field" do
-        html.should_not have_unchecked_field('no such field')
+        expect(html).not_to have_unchecked_field('no such field')
       end
     end
   end
@@ -653,16 +653,16 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<label>Select Box<select></select></label>' }
 
     it "gives proper description" do
-      have_select('Select Box').description.should == "have select box \"Select Box\""
+      expect(have_select('Select Box').description).to eq("have select box \"Select Box\"")
     end
 
     it "passes if there is such a select" do
-      html.should have_select('Select Box')
+      expect(html).to have_select('Select Box')
     end
 
     it "fails if there is no such select" do
       expect do
-        html.should have_select('No such Select box')
+        expect(html).to have_select('No such Select box')
       end.to raise_error(/expected to find select box "No such Select box"/)
     end
   end
@@ -671,16 +671,16 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<table><caption>Lovely table</caption></table>' }
 
     it "gives proper description" do
-      have_table('Lovely table').description.should == "have table \"Lovely table\""
+      expect(have_table('Lovely table').description).to eq("have table \"Lovely table\"")
     end
 
     it "passes if there is such a select" do
-      html.should have_table('Lovely table')
+      expect(html).to have_table('Lovely table')
     end
 
     it "fails if there is no such select" do
       expect do
-        html.should have_table('No such Table')
+        expect(html).to have_table('No such Table')
       end.to raise_error(/expected to find table "No such Table"/)
     end
   end

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 describe 'capybara/rspec', :type => :feature do
   it "should include Capybara in rspec" do
     visit('/foo')
-    page.body.should include('Another World')
+    expect(page.body).to include('Another World')
   end
 
   context "resetting session" do
     it "sets a cookie in one example..." do
       visit('/set_cookie')
-      page.body.should include('Cookie set to test_cookie')
+      expect(page.body).to include('Cookie set to test_cookie')
     end
 
     it "...then it is not available in the next" do
       visit('/get_cookie')
-      page.body.should_not include('test_cookie')
+      expect(page.body).not_to include('test_cookie')
     end
   end
 
@@ -24,16 +24,16 @@ describe 'capybara/rspec', :type => :feature do
     end
 
     it "...then it has returned to the default in the next example" do
-      Capybara.current_driver.should == :rack_test
+      expect(Capybara.current_driver).to eq(:rack_test)
     end
   end
 
   it "switches to the javascript driver when giving it as metadata", :js => true do
-    Capybara.current_driver.should == Capybara.javascript_driver
+    expect(Capybara.current_driver).to eq(Capybara.javascript_driver)
   end
 
   it "switches to the given driver when giving it as metadata", :driver => :culerity do
-    Capybara.current_driver.should == :culerity
+    expect(Capybara.current_driver).to eq(:culerity)
   end
 end
 
@@ -46,6 +46,6 @@ end
 feature "Feature DSL" do
   scenario "is pulled in" do
     visit('/foo')
-    page.body.should include('Another World')
+    expect(page.body).to include('Another World')
   end
 end

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -11,7 +11,7 @@ module TestSessions
   Selenium = Capybara::Session.new(:selenium_focus, TestApp)
 end
 
-Capybara::SpecHelper.run_specs TestSessions::Selenium, "selenium", :skip => [
+Capybara::SpecHelper.run_specs TestSessions::Selenium, "selenium", :capybara_skip => [
   :response_headers,
   :status_code,
   :trigger
@@ -25,13 +25,13 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a selenium driver" do
-        @session.driver.should be_an_instance_of(Capybara::Selenium::Driver)
+        expect(@session.driver).to be_an_instance_of(Capybara::Selenium::Driver)
       end
     end
 
     describe '#mode' do
       it "should remember the mode" do
-        @session.mode.should == :selenium_focus
+        expect(@session.mode).to eq(:selenium_focus)
       end
     end
 
@@ -39,7 +39,7 @@ describe Capybara::Session do
       it "freshly reset session should not be touched" do
         @session.instance_variable_set(:@touched, true)
         @session.reset!
-        @session.instance_variable_get(:@touched).should be_false
+        expect(@session.instance_variable_get(:@touched)).to eq false
       end
     end
 
@@ -55,12 +55,12 @@ describe Capybara::Session do
 
       it "should have return code 1 when running selenium_driver_rspec_failure.rb" do
         `rspec spec/fixtures/selenium_driver_rspec_failure.rb`
-        $?.exitstatus.should be 1
+        expect($?.exitstatus).to be 1
       end
 
       it "should have return code 0 when running selenium_driver_rspec_success.rb" do
         `rspec spec/fixtures/selenium_driver_rspec_success.rb`
-        $?.exitstatus.should be 0
+        expect($?.exitstatus).to be 0
       end
     end
   end
@@ -73,10 +73,10 @@ describe Capybara::Selenium::Driver do
   
   describe '#quit' do
     it "should reset browser when quit" do
-      @driver.browser.should be
+      expect(@driver.browser).to be
       @driver.quit
       #access instance variable directly so we don't create a new browser instance
-      @driver.instance_variable_get(:@browser).should be_nil
+      expect(@driver.instance_variable_get(:@browser)).to be_nil
     end
   end
 end

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -14,7 +14,7 @@ module TestSessions
   Chrome = Capybara::Session.new(:selenium_chrome, ChromeTestApp)
 end
 
-Capybara::SpecHelper.run_specs TestSessions::Chrome, "selenium_chrome", :skip => [
+Capybara::SpecHelper.run_specs TestSessions::Chrome, "selenium_chrome", :capybara_skip => [
   :response_headers,
   :status_code,
   :trigger  

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -8,7 +8,7 @@ describe Capybara::Server do
 
     @res = Net::HTTP.start(@server.host, @server.port) { |http| http.get('/') }
 
-    @res.body.should include('Hello Server')
+    expect(@res.body).to include('Hello Server')
   end
 
   it "should do nothing when no server given" do
@@ -42,7 +42,7 @@ describe Capybara::Server do
     @server = Capybara::Server.new(@app).boot
 
     @res = Net::HTTP.start(@server.host, 22789) { |http| http.get('/') }
-    @res.body.should include('Hello Server')
+    expect(@res.body).to include('Hello Server')
 
     Capybara.server_port = nil
   end
@@ -52,7 +52,7 @@ describe Capybara::Server do
     @server = Capybara::Server.new(@app, 22790).boot
 
     @res = Net::HTTP.start(@server.host, 22790) { |http| http.get('/') }
-    @res.body.should include('Hello Server')
+    expect(@res.body).to include('Hello Server')
 
     Capybara.server_port = nil
   end
@@ -65,10 +65,10 @@ describe Capybara::Server do
     @server2 = Capybara::Server.new(@app2).boot
 
     @res1 = Net::HTTP.start(@server1.host, @server1.port) { |http| http.get('/') }
-    @res1.body.should include('Hello Server')
+    expect(@res1.body).to include('Hello Server')
 
     @res2 = Net::HTTP.start(@server2.host, @server2.port) { |http| http.get('/') }
-    @res2.body.should include('Hello Second Server')
+    expect(@res2.body).to include('Hello Second Server')
   end
 
   it "should use the server if it already running" do
@@ -81,13 +81,13 @@ describe Capybara::Server do
     @server2b = Capybara::Server.new(@app2).boot
 
     @res1 = Net::HTTP.start(@server1b.host, @server1b.port) { |http| http.get('/') }
-    @res1.body.should include('Hello Server')
+    expect(@res1.body).to include('Hello Server')
 
     @res2 = Net::HTTP.start(@server2b.host, @server2b.port) { |http| http.get('/') }
-    @res2.body.should include('Hello Second Server')
+    expect(@res2.body).to include('Hello Second Server')
 
-    @server1a.port.should == @server1b.port
-    @server2a.port.should == @server2b.port
+    expect(@server1a.port).to eq(@server1b.port)
+    expect(@server2a.port).to eq(@server2b.port)
   end
 
   it "should raise server errors when the server errors before the timeout" do
@@ -97,9 +97,9 @@ describe Capybara::Server do
         raise 'kaboom'
       end
 
-      proc do
+      expect do
         Capybara::Server.new(proc {|e|}).boot
-      end.should raise_error(RuntimeError, 'kaboom')
+      end.to raise_error(RuntimeError, 'kaboom')
     ensure
       # TODO refactor out the defaults so it's reliant on unset state instead of
       # a one-time call in capybara.rb
@@ -110,7 +110,7 @@ describe Capybara::Server do
   it "is not #responsive? when Net::HTTP raises a SystemCallError" do
     app = lambda { [200, {}, ['Hello, world']] }
     server = Capybara::Server.new(app)
-    Net::HTTP.should_receive(:start).and_raise(SystemCallError.allocate)
+    expect(Net::HTTP).to receive(:start).and_raise(SystemCallError.allocate)
     expect(server.responsive?).to eq false
   end
 end


### PR DESCRIPTION
@jnicklas -  This is all the tests changed to use 'expect' syntax and changes made to get rid of all the deprecation warnings rspec 2.99.0.beta1 throws in advance of rspec 3 being released.  The downside to these changes is that the tests will no longer run with earlier rspecs than 2.99 due to the lack of the be_truthy/be_falsey matchers.  I'm not sure that its going to be possible to have tests that can ruin using either rspec 2.x or 3 without implementing our own be_truthy/be_falsey matchers if rspec doesnt have them.  Do you think this is worth continuing on currently?
