### PR TITLE
Multiple file test should be skipped for selenium

### DIFF
--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -64,7 +64,7 @@ Capybara::SpecHelper.spec "#attach_file" do
     end
 
     it  "should not break when using HTML5 multiple file input uploading multiple files" do
-      pending "Selenium is buggy on this, see http://code.google.com/p/selenium/issues/detail?id=2239" if @session.respond_to?(:mode) && @session.mode == :selenium
+      pending "Selenium is buggy on this, see http://code.google.com/p/selenium/issues/detail?id=2239" if @session.respond_to?(:mode) && [:selenium, :selenium_focus].include?(@session.mode)
       @session.attach_file "Multiple Documents", [@test_file_path, @another_test_file_path]
       @session.click_button('Upload Multiple')
       @session.body.should include("2 | ")#number of files


### PR DESCRIPTION
The session mode was changed from :selenium to :selenium_focus in a different commit -  updated logic on test so it is still marked as pending.
