### PR TITLE
Ensure browser gets cleared when Capybara::Selenium::Driver#quit is called

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -152,6 +152,8 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     @browser.quit if @browser
   rescue Errno::ECONNREFUSED
     # Browser must have already gone
+  ensure
+    @browser = nil
   end
 
   def invalid_element_errors

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -57,3 +57,20 @@ describe Capybara::Session do
     end
   end
 end
+
+describe Capybara::Selenium::Driver do
+  before do
+    @driver = Capybara::Selenium::Driver.new(TestApp, browser: :firefox)
+  end
+  
+  describe '#quit' do
+    it "should reset browser when quit" do
+      @driver.browser.should be
+      @driver.quit
+      #access instance variable directly so we don't create a new browser instance
+      @driver.instance_variable_get(:@browser).should be_nil
+    end
+  end
+end
+
+


### PR DESCRIPTION
The @browser instance variable was not being cleared when #quit was called, which could lead to an error if it was accessed again.  This change makes sure it gets reset to nil
