### PR TITLE
Fix failure message of have_text when text of node changes rapidly

### DIFF
--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -27,7 +27,7 @@ module Capybara
       # @return [String]    The text of the element
       #
       def text(type=nil)
-        native.text
+        @native_text ||= native.text
       end
 
       ##


### PR DESCRIPTION
Attempt to fix [#1179](https://github.com/jnicklas/capybara/issues/1179)

I'm not sure the best way to test this, but would this fix the mentioned issue by memoizing the text method on Capybara::Node::Simple?
