### PR TITLE
Improve save_page for binary content

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -354,7 +354,7 @@ module Capybara
 
       FileUtils.mkdir_p(File.dirname(path))
 
-      File.open(path,'w') { |f| f.write(Capybara::Helpers.inject_asset_host(body)) }
+      File.open(path,'wb') { |f| f.write(Capybara::Helpers.inject_asset_host(body)) }
       path
     end
 


### PR DESCRIPTION
In my case the response body contained a PNG file and capybara-screenshot called save_page (due to https://github.com/mattheworiordan/capybara-screenshot/pull/69). This results in an Encoding::UndefinedConversionError since the body is treated as text and a conversion from ASCII to UTF-8 is applied, but the PNG - of course - contains invalid bytes.
