### PR TITLE
Add redirect counter to RackTest::Driver

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,12 @@
+# Version 2.2.2
+
+Release date: unreleased
+
+### Added
+
+* Add `redirects` counter and `redirected?` to `RackTest::Driver` and
+  `RackTest::Browser` [Łukasz Strzałkowski]
+
 # Version 2.2.1
 
 Release date: 2014-01-06

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -69,4 +69,12 @@ class Capybara::Driver::Base
   def needs_server?
     false
   end
+
+  def redirects
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#redirects'
+  end
+
+  def redirected?
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#redirected?'
+  end
 end

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -30,6 +30,14 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     @options[:redirect_limit]
   end
 
+  def redirects
+    browser.redirects
+  end
+
+  def redirected?
+    browser.redirected?
+  end
+
   def response
     browser.last_response
   end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -107,16 +107,22 @@ describe Capybara::RackTest::Driver do
     it "defaults to following redirects" do
       @driver = Capybara::RackTest::Driver.new(TestApp)
 
+      @driver.redirects.should == 0
       @driver.visit('/redirect')
       @driver.response.header['Location'].should be_nil
+      @driver.redirects.should == 2
+      @driver.should be_redirected
       @driver.browser.current_url.should match %r{/landed$}
     end
 
     it "is possible to not follow redirects" do
       @driver = Capybara::RackTest::Driver.new(TestApp, :follow_redirects => false)
 
+      @driver.redirects.should == 0
       @driver.visit('/redirect')
       @driver.response.header['Location'].should match %r{/redirect_again$}
+      @driver.redirects.should == 0
+      @driver.should_not be_redirected
       @driver.browser.current_url.should match %r{/redirect$}
     end
   end


### PR DESCRIPTION
In application I'm working on right know, we've monkey patched RackTest driver to keep track or redirects count. We have few cucumber steps which rely on it as an easier way to have common step checking if redirect happened. Alternative solution was checking `Location:` url but it's different for each case, thus just checking if redirect happened is was more better and applies to all cases.

This PR adds redirects counter to `RackTest::Browser` and simple proxies in `RackTest::Driver` for easier retrieval. (we've also patched both in out app)
