### PR TITLE
Make absolute uri test more general

### DIFF
--- a/lib/capybara/spec/session/visit_spec.rb
+++ b/lib/capybara/spec/session/visit_spec.rb
@@ -19,10 +19,10 @@ Capybara::SpecHelper.spec '#visit' do
 
   it "should fetch a response when absolute URI doesn't have a trailing slash" do
     # Preparation
-    @session.visit('/foo/bar')
+    @session.visit('/')
     root_uri = URI.parse(@session.current_url)
 
-    @session.visit("http://localhost:#{root_uri.port}")
+    @session.visit("http://#{root_uri.host}:#{root_uri.port}")
     @session.should have_content('Hello world!')
   end
 


### PR DESCRIPTION
This test had hardcoded values which may vary for different apps and while this specs are integrated in custom driver's test suite like capybara-mechanize, it fails becouse of that (https://travis-ci.org/jeroenvandijk/capybara-mechanize/jobs/17002693#L153)

Problem occurred when I was trying to bump up capybara version for capybara-mechanize gem where app have different host (`www.local.com` not `localhost`) and don't have `/foo/bar` endpoint.
