### PR TITLE
Issue #1229 - reset touched after session is reset

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -77,8 +77,8 @@ module Capybara
     def reset!
       if @touched
         driver.reset!
-        @touched = false
         assert_no_selector :xpath, "/html/body/*"
+        @touched = false
       end
       raise @server.error if Capybara.raise_server_errors and @server and @server.error
     ensure

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -35,6 +35,14 @@ describe Capybara::Session do
       end
     end
 
+    describe "#reset!" do
+      it "freshly reset session should not be touched" do
+        @session.instance_variable_set(:@touched, true)
+        @session.reset!
+        @session.instance_variable_get(:@touched).should be_false
+      end
+    end
+
     describe "exit codes" do
       before do
         @current_dir = Dir.getwd


### PR DESCRIPTION
When session.reset! is called, @touched is never getting properly reset to false. This hopefully fixes that. Added applicable test.
https://github.com/jnicklas/capybara/issues/1229
