### PR TITLE
Use latest Chromedriver and rbx for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,15 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode
-  - rbx-2.1.1
-  - rbx-2.0.0
+  - rbx
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.base-versions
 matrix:
-  allow_failures:
-    - rvm: rbx-2.0.0
   exclude:
     # Nokogiri 1.3.3 is not compatible with Rubinius or JRuby
     - gemfile: gemfiles/Gemfile.base-versions
-      rvm: rbx-2.1.1
-    - gemfile: gemfiles/Gemfile.base-versions
-      rvm: rbx-2.1.0
-    - gemfile: gemfiles/Gemfile.base-versions
-      rvm: rbx-2.0.0
+      rvm: rbx
     - gemfile: gemfiles/Gemfile.base-versions
       rvm: jruby-19mode
 before_install:


### PR DESCRIPTION
1. Run Travis tests on latest Chromedriver
2. Build on latest rbx version (rbx updates every month; they don't follow Semver yet; so IMO it doesn't worth to build on previous versions)
