### PR TITLE
Fix to prevent current_path from breaking when current_url contains spaces

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -61,7 +61,7 @@ class Capybara::RackTest::Browser
   end
 
   def current_url
-    last_request.url
+    URI.decode(last_request.url)
   rescue Rack::Test::Error
     ""
   end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -123,7 +123,7 @@ module Capybara
     # @return [String] Path of the current page, without any domain information
     #
     def current_path
-      path = URI.parse(current_url).path
+      path = URI.parse(URI.encode(current_url)).path
       path if path and not path.empty?
     end
 

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -31,6 +31,13 @@ describe Capybara::Session do
       end
     end
 
+    describe "#current_path" do
+      it "should handle spaces if the driver provides them in the current_url" do
+        @session.visit(URI.encode("/path with a space/with_html"))
+        lambda { @session.current_path }.should_not raise_error
+      end
+    end
+
     describe '#click_link' do
       it "should use data-method if option is true" do
         @session.driver.options[:respect_data_method] = true
@@ -66,6 +73,25 @@ describe Capybara::Session do
           @session.html.should include('Successfully ignored empty file field.')
         end
       end
+    end
+  end
+end
+
+
+describe Capybara::RackTest::Browser do
+  before do
+    @browser = Capybara::RackTest::Browser.new(TestSessions::RackTest.driver)
+  end
+
+  describe ':current_url' do
+    it 'should return the last requested url' do
+      @browser.visit('/with_simple_html')
+      @browser.current_url.should include('/with_simple_html')
+    end
+
+    it "should behave like firefox's window.location, presenting a decoded url" do
+      @browser.visit(URI.encode('/path with spaces and/simple_html'))
+      @browser.current_url.should include('/path with spaces and/simple_html')
     end
   end
 end


### PR DESCRIPTION
The 'current_path' method on the session object, uses 'current_url', which uses the javascript 'window.location.toString()' (with capybara-webkit at least) to determine the current url. That string may or may not encode special characters like spaces, it seems to depend on the browser. Eg, 'http://www.example.com/path with spaces/index.html'. But firefox doesn't encode spaces, and neither does webkit, and passing a string with spaces to URI.decode raises an error.

This patch makes the RackTest browser behave like firefox, and then introduces a test & fix for the problem.
