### PR TITLE
Handle onbeforeunload dialog during session reset

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -98,6 +98,12 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         # instead.
       end
       @browser.navigate.to("about:blank")
+      # Navigating away might cause an onbeforeunload alert which we need to handle
+      begin
+        @browser.switch_to.alert.accept
+      rescue Selenium::WebDriver::Error::NoAlertPresentError
+        # There was no alert so we don't need to do anything
+      end
     end
   end
 


### PR DESCRIPTION
During session reset in the Selenium driver if the page being tested had an onbeforeunload dialog, navigating to about:blank would cause this dialog to display. There was no way to handle this so a Selenium::WebDriver::Error::UnhandledAlertError would occur. This patch switches to the alert (if it is present) and accepts it so that the error doesn't occur.
