### PR TITLE
Add ability to save and open screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,12 @@ Finally, in drivers that support it, you can save a screenshot:
 page.save_screenshot('screenshot.png')
 ```
 
+Or have it save and automatically open:
+
+```ruby
+save_and_open_screenshot
+```
+
 ## Matching
 
 It is possible to customize how Capybara finds elements. At your disposal

--- a/lib/capybara/spec/session/save_and_open_screenshot_spec.rb
+++ b/lib/capybara/spec/session/save_and_open_screenshot_spec.rb
@@ -1,0 +1,46 @@
+require 'launchy'
+
+Capybara::SpecHelper.spec '#save_and_open_screenshot' do
+  before do
+    @session.visit '/'
+  end
+
+  it 'opens file from the default directory', :requires => [:screenshot] do
+    expected_file_regex = %r{capybara/capybara-\d+\.png}
+    @session.driver.stub(:save_screenshot)
+    Launchy.stub(:open)
+
+    @session.save_and_open_screenshot
+
+    expect(@session.driver).to have_received(:save_screenshot).
+      with(expected_file_regex, {})
+    expect(Launchy).to have_received(:open).with(expected_file_regex)
+  end
+
+  it 'opens file from the provided directory', :requires => [:screenshot] do
+    custom_path = 'screenshots/1.png'
+    @session.driver.stub(:save_screenshot)
+    Launchy.stub(:open)
+
+    @session.save_and_open_screenshot(custom_path)
+
+    expect(@session.driver).to have_received(:save_screenshot).
+      with(custom_path, {})
+    expect(Launchy).to have_received(:open).with(custom_path)
+  end
+
+  context 'when launchy cannot be required' do
+    it 'prints out a correct warning message', :requires => [:screenshot] do
+      file_path = File.join(Dir.tmpdir, 'test.png')
+      @session.stub(:require).with('launchy').and_raise(LoadError)
+      @session.stub(:warn)
+
+      @session.save_and_open_screenshot(file_path)
+
+      expect(@session).to have_received(:warn).
+        with("File saved to #{file_path}.")
+      expect(@session).to have_received(:warn).
+        with('Please install the launchy gem to open the file automatically.')
+    end
+  end
+end

--- a/lib/capybara/spec/session/screenshot_spec.rb
+++ b/lib/capybara/spec/session/screenshot_spec.rb
@@ -4,11 +4,13 @@ Capybara::SpecHelper.spec "#save_screenshot" do
 
   before do
     @session.visit '/'
-    @session.save_screenshot image_path
   end
 
   it "should generate PNG file", :requires => [:screenshot] do
+    path = @session.save_screenshot image_path
+
     magic = File.read(image_path, 4)
     expect(magic).to eq "\x89PNG"
+    expect(path).to eq image_path
   end
 end


### PR DESCRIPTION
This adds a new method `save_and_open_screenshot` that saves the screenshot then
opens it for inspection.

Refactor duplicate logic for `save_and_open_page` and `save_and_open_screenshot`
