### PR TITLE
Fix loss of whitespace btwn inline tags

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -107,7 +107,7 @@ protected
     elsif native.element?
       native.children.map do |child|
         Capybara::RackTest::Node.new(driver, child).unnormalized_text
-      end.join
+      end.join(' ')
     else
       ''
     end

--- a/lib/capybara/spec/session/has_text_spec.rb
+++ b/lib/capybara/spec/session/has_text_spec.rb
@@ -37,6 +37,11 @@ Capybara::SpecHelper.spec '#has_text?' do
     @session.should have_text("text     with \n\n whitespace")
   end
 
+  it "should not collapse whitespace between tags" do
+    @session.visit('/with_html')
+    @session.should have_text('Label span')
+  end
+
   it "should be false if the given text is not on the page" do
     @session.visit('/with_html')
     @session.should_not have_text('xxxxyzzz')

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -107,3 +107,5 @@ banana</textarea>
 </div>
 
 <input type="text" disabled="disabled" name="disabled_text" value="This is disabled"/>
+
+<div><label>Label</label><input type="text"/> <span>span</span></div>


### PR DESCRIPTION
Discovered in https://github.com/bootstrap-ruby/rails-bootstrap-forms. This fix is required by 832cf8752ab2d8ae52aa208131a2309f029e9e22.

Previously, the following

```
<div><label>Label</label><input type="text"/> <span>span</span></div>
```

would result in `Labelspan` instead of `Label span`
