### PR TITLE
Provide RSpec expect syntax for specs in spec

### DIFF
--- a/spec/basic_node_spec.rb
+++ b/spec/basic_node_spec.rb
@@ -44,96 +44,94 @@ describe Capybara do
     end
 
     it "allows using matchers" do
-      string.should have_css('#page')
-      string.should_not have_css('#does-not-exist')
+      expect(string).to have_css('#page')
+      expect(string).not_to have_css('#does-not-exist')
     end
 
-    it "allows using custom matchers" do
+    it "allows using custom matchers using xpath" do
       Capybara.add_selector :lifeform do
         xpath { |name| "//option[contains(.,'#{name}')]" }
       end
-      string.should have_selector(:id, "page")
-      string.should_not have_selector(:id, 'does-not-exist')
-      string.should have_selector(:lifeform, "Monkey")
-      string.should_not have_selector(:lifeform, "Gorilla")
+      expect(string).to have_selector(:lifeform, "Monkey")
+      expect(string).not_to have_selector(:lifeform, "Gorilla")
     end
 
     it 'allows custom matcher using css' do
       Capybara.add_selector :section do
         css { |css_class| "section .#{css_class}" }
       end
-      string.should     have_selector(:section, 'subsection')
-      string.should_not have_selector(:section, 'section_8')
+      expect(string).to have_selector(:section, 'subsection')
+      expect(string).not_to have_selector(:section, 'section_8')
     end
 
     it "allows using matchers with text option" do
-      string.should have_css('h1', :text => 'Totally awesome')
-      string.should_not have_css('h1', :text => 'Not so awesome')
+      expect(string).to have_css('h1', :text => 'Totally awesome')
+      expect(string).not_to have_css('h1', :text => 'Not so awesome')
     end
 
     it "allows finding only visible nodes" do
-      string.all(:css, '#secret', :visible => true).should be_empty
-      string.all(:css, '#secret', :visible => false).should have(1).element
+      expect(string.all(:css, '#secret', :visible => true)).to be_empty
+      expect(string.all(:css, '#secret', :visible => false)).to have(1).element
     end
 
     it "allows finding elements and extracting text from them" do
-      string.find('//h1').text.should == 'Totally awesome'
+      expect(string.find('//h1').text).to be_eql('Totally awesome')
     end
 
     it "allows finding elements and extracting attributes from them" do
-      string.find('//h1')[:data].should == 'fantastic'
+      expect(string.find('//h1')[:data]).to be_eql('fantastic')
     end
 
     it "allows finding elements and extracting the tag name from them" do
-      string.find('//h1').tag_name.should == 'h1'
+      expect(string.find('//h1').tag_name).to be_eql('h1')
     end
 
     it "allows finding elements and extracting the path" do
-      string.find('//h1').path.should == '/html/body/div/div[1]/h1'
+      expect(string.find('//h1').path).to be_eql('/html/body/div/div[1]/h1')
     end
 
     it "allows finding elements and extracting the path" do
-      string.find('//div/input').value.should == 'bar'
-      string.find('//select').value.should == 'Capybara'
+      expect(string.find('//div/input').value).to be_eql('bar')
+      expect(string.find('//select').value).to be_eql('Capybara')
     end
 
     it "allows finding elements and checking if they are visible" do
-      string.find('//h1').should be_visible
-      string.find(:css, "#secret", :visible => false).should_not be_visible
+      expect(string.find('//h1')).to be_visible
+      expect(string.find(:css, "#secret", :visible => false)).not_to be_visible
     end
 
     it "allows finding elements and checking if they are disabled" do
-      string.find('//form/input[@name="bleh"]').should be_disabled
-      string.find('//form/input[@name="meh"]').should_not be_disabled
+      expect(string.find('//form/input[@name="bleh"]')).to be_disabled
+      expect(string.find('//form/input[@name="meh"]')).not_to be_disabled
     end
 
     describe "#title" do
       it "returns the page title" do
-        string.title.should == "simple_node"
+        expect(string.title).to be_eql("simple_node")
       end
     end
 
     describe "#has_title?" do
       it "returns whether the page has the given title" do
-        string.has_title?('simple_node').should be_true
-        string.has_title?('monkey').should be_false
+        expect(string.has_title?('simple_node')).to be_true
+        expect(string.has_title?('monkey')).to be_false
       end
 
       it "allows regexp matches" do
-        string.has_title?(/s[a-z]+_node/).should be_true
-        string.has_title?(/monkey/).should be_false
+        expect(string.has_title?(/s[a-z]+_node/)).to be_true
+        expect(string.has_title?(/monkey/)).to be_false
       end
     end
 
     describe '#has_no_title?' do
       it "returns whether the page does not have the given title" do
-        string.has_no_title?('simple_node').should be_false
-        string.has_no_title?('monkey').should be_true
+        expect(string.has_no_title?('simple_node')).to be_false
+        expect(string.has_no_title?('monkey')).to be_true
       end
 
       it "allows regexp matches" do
-        string.has_no_title?(/s[a-z]+_node/).should be_false
-        string.has_no_title?(/monkey/).should be_true
+        expect(string.has_no_title?(/s[a-z]+_node/)).to be_false
+        expect(string.has_no_title?(/monkey/)).to be_true
       end
     end
   end

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -10,7 +10,7 @@ describe Capybara do
     it "should be changeable" do
       @previous_default_time = Capybara.default_wait_time
       Capybara.default_wait_time = 5
-      Capybara.default_wait_time.should == 5
+      expect(Capybara.default_wait_time).to be_eql(5)
     end
   end
 
@@ -21,7 +21,7 @@ describe Capybara do
       end
       session = Capybara::Session.new(:schmoo, TestApp)
       session.visit('/')
-      session.body.should include("Hello world!")
+      expect(session.body).to include("Hello world!")
     end
   end
 
@@ -32,14 +32,14 @@ describe Capybara do
 
     it "should default to a proc that calls run_default_server" do
       mock_app = double('app')
-      Capybara.should_receive(:run_default_server).with(mock_app, 8000)
+      expect(Capybara).to receive(:run_default_server).with(mock_app, 8000)
       Capybara.server.call(mock_app, 8000)
     end
 
     it "should return a custom server proc" do
       server = lambda {|app, port|}
       Capybara.server(&server)
-      Capybara.server.should == server
+      expect(Capybara.server).to be_eql(server)
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -25,36 +25,36 @@ describe Capybara::DSL do
 
   describe '#default_driver' do
     it "should default to rack_test" do
-      Capybara.default_driver.should == :rack_test
+      expect(Capybara.default_driver).to be_eql :rack_test
     end
 
     it "should be changeable" do
       Capybara.default_driver = :culerity
-      Capybara.default_driver.should == :culerity
+      expect(Capybara.default_driver).to be_eql :culerity
     end
   end
 
   describe '#current_driver' do
     it "should default to the default driver" do
-      Capybara.current_driver.should == :rack_test
+      expect(Capybara.current_driver).to be_eql :rack_test
       Capybara.default_driver = :culerity
-      Capybara.current_driver.should == :culerity
+      expect(Capybara.current_driver).to be_eql :culerity
     end
 
     it "should be changeable" do
       Capybara.current_driver = :culerity
-      Capybara.current_driver.should == :culerity
+      expect(Capybara.current_driver).to be_eql :culerity
     end
   end
 
   describe '#javascript_driver' do
     it "should default to selenium" do
-      Capybara.javascript_driver.should == :selenium
+      expect(Capybara.javascript_driver).to be_eql :selenium
     end
 
     it "should be changeable" do
       Capybara.javascript_driver = :culerity
-      Capybara.javascript_driver.should == :culerity
+      expect(Capybara.javascript_driver).to be_eql :culerity
     end
   end
 
@@ -62,26 +62,26 @@ describe Capybara::DSL do
     it "should restore the default driver" do
       Capybara.current_driver = :culerity
       Capybara.use_default_driver
-      Capybara.current_driver.should == :rack_test
+      expect(Capybara.current_driver).to be_eql :rack_test
     end
   end
 
   describe '#using_driver' do
     before do
-      Capybara.current_driver.should_not == :selenium
+      expect(Capybara.current_driver).not_to be_eql :selenium
     end
 
     it 'should set the driver using Capybara.current_driver=' do
       driver = nil
       Capybara.using_driver(:selenium) { driver = Capybara.current_driver }
-      driver.should == :selenium
+      expect(driver).to be_eql :selenium
     end
 
     it 'should return the driver to default if it has not been changed' do
       Capybara.using_driver(:selenium) do
-        Capybara.current_driver.should == :selenium
+        expect(Capybara.current_driver).to be_eql :selenium
       end
-      Capybara.current_driver.should == Capybara.default_driver
+      expect(Capybara.current_driver).to be_eql Capybara.default_driver
     end
 
     it 'should reset the driver even if an exception occurs' do
@@ -90,24 +90,24 @@ describe Capybara::DSL do
         Capybara.using_driver(:selenium) { raise "ohnoes!" }
       rescue Exception
       end
-      Capybara.current_driver.should == driver_before_block
+      expect(Capybara.current_driver).to be_eql driver_before_block
     end
 
     it 'should return the driver to what it was previously' do
       Capybara.current_driver = :selenium
       Capybara.using_driver(:culerity) do
         Capybara.using_driver(:rack_test) do
-          Capybara.current_driver.should == :rack_test
+          expect(Capybara.current_driver).to be_eql :rack_test
         end
-        Capybara.current_driver.should == :culerity
+        expect(Capybara.current_driver).to be_eql :culerity
       end
-      Capybara.current_driver.should == :selenium
+      expect(Capybara.current_driver).to be_eql :selenium
     end
 
     it 'should yield the passed block' do
       called = false
       Capybara.using_driver(:selenium) { called = true }
-      called.should == true
+      expect(called).to be true
     end
   end
 
@@ -126,7 +126,7 @@ describe Capybara::DSL do
         in_block = Capybara.default_wait_time
       end
       in_block.should == 6
-      Capybara.default_wait_time.should == @previous_wait_time
+      expect(Capybara.default_wait_time).to be_eql @previous_wait_time
     end
 
     it "should ensure wait time is reset" do
@@ -135,70 +135,70 @@ describe Capybara::DSL do
           raise "hell"
         end
       end.to raise_error
-      Capybara.default_wait_time.should == @previous_wait_time
+      expect(Capybara.default_wait_time).to be_eql @previous_wait_time
     end
   end
 
   describe '#app' do
     it "should be changeable" do
       Capybara.app = "foobar"
-      Capybara.app.should == 'foobar'
+      expect(Capybara.app).to be_eql 'foobar'
     end
   end
 
   describe '#current_session' do
     it "should choose a session object of the current driver type" do
-      Capybara.current_session.should be_a(Capybara::Session)
+      expect(Capybara.current_session).to be_a(Capybara::Session)
     end
 
     it "should use #app as the application" do
       Capybara.app = proc {}
-      Capybara.current_session.app.should == Capybara.app
+      expect(Capybara.current_session.app).to be_eql Capybara.app
     end
 
     it "should change with the current driver" do
       Capybara.current_session.mode.should == :rack_test
       Capybara.current_driver = :selenium
-      Capybara.current_session.mode.should == :selenium
+      expect(Capybara.current_session.mode).to be_eql :selenium
     end
 
     it "should be persistent even across driver changes" do
       object_id = Capybara.current_session.object_id
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.current_session.object_id).to be_eql object_id
       Capybara.current_driver = :selenium
-      Capybara.current_session.mode.should == :selenium
-      Capybara.current_session.object_id.should_not == object_id
+      expect(Capybara.current_session.mode).to be_eql :selenium
+      expect(Capybara.current_session.object_id).not_to be_eql object_id
 
       Capybara.current_driver = :rack_test
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.current_session.object_id).to be_eql object_id
     end
 
     it "should change when changing application" do
       object_id = Capybara.current_session.object_id
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.current_session.object_id).to be_eql object_id
       Capybara.app = proc {}
-      Capybara.current_session.object_id.should_not == object_id
-      Capybara.current_session.app.should == Capybara.app
+      expect(Capybara.current_session.object_id).not_to be_eql object_id
+      expect(Capybara.current_session.app).to be_eql Capybara.app
     end
 
     it "should change when the session name changes" do
       object_id = Capybara.current_session.object_id
       Capybara.session_name = :administrator
-      Capybara.session_name.should == :administrator
-      Capybara.current_session.object_id.should_not == object_id
+      expect(Capybara.session_name).to be_eql :administrator
+      expect(Capybara.current_session.object_id).not_to be_eql object_id
       Capybara.session_name = :default
-      Capybara.session_name.should == :default
-      Capybara.current_session.object_id.should == object_id
+      expect(Capybara.session_name).to be_eql :default
+      expect(Capybara.current_session.object_id).to be_eql object_id
     end
   end
 
   describe "#using_session" do
     it "should change the session name for the duration of the block" do
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to be_eql :default
       Capybara.using_session(:administrator) do
-        Capybara.session_name.should == :administrator
+        expect(Capybara.session_name).to be_eql :administrator
       end
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to be_eql :default
     end
 
     it "should reset the session to the default, even if an exception occurs" do
@@ -208,19 +208,19 @@ describe Capybara::DSL do
         end
       rescue Exception
       end
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to be_eql :default
     end
 
     it "should yield the passed block" do
       called = false
       Capybara.using_session(:administrator) { called = true }
-      called.should == true
+      expect(called).to be true
     end
   end
 
   describe "#session_name" do
     it "should default to :default" do
-      Capybara.session_name.should == :default
+      expect(Capybara.session_name).to be_eql :default
     end
   end
 
@@ -232,22 +232,22 @@ describe Capybara::DSL do
     it "should be possible to include it in another class" do
       @session.visit('/with_html')
       @session.click_link('ullamco')
-      @session.body.should include('Another World')
+      expect(@session.body).to include('Another World')
     end
 
     it "should provide a 'page' shortcut for more expressive tests" do
       @session.page.visit('/with_html')
       @session.page.click_link('ullamco')
-      @session.page.body.should include('Another World')
+      expect(@session.page.body).to include('Another World')
     end
 
     it "should provide an 'using_session' shortcut" do
-      Capybara.should_receive(:using_session).with(:name)
+      expect(Capybara).to receive(:using_session).with(:name)
       @session.using_session(:name)
     end
 
     it "should provide a 'using_wait_time' shortcut" do
-      Capybara.should_receive(:using_wait_time).with(6)
+      expect(Capybara).to receive(:using_wait_time).with(6)
       @session.using_wait_time(6)
     end
   end

--- a/spec/fixtures/selenium_driver_rspec_failure.rb
+++ b/spec/fixtures/selenium_driver_rspec_failure.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Capybara::Selenium::Driver do
   it "should exit with a non-zero exit status" do
     browser = Capybara::Selenium::Driver.new(TestApp).browser
-    true.should == false
+    expect(true).to be false
   end
 end

--- a/spec/fixtures/selenium_driver_rspec_success.rb
+++ b/spec/fixtures/selenium_driver_rspec_success.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe Capybara::Selenium::Driver do
   it "should exit with a zero exit status" do
     browser = Capybara::Selenium::Driver.new(TestApp).browser
-    true.should == true
+    expect(true).to be true
   end
 end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -21,13 +21,13 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a rack test driver" do
-        @session.driver.should be_an_instance_of(Capybara::RackTest::Driver)
+        expect(@session.driver).to be_an_instance_of(Capybara::RackTest::Driver)
       end
     end
 
     describe '#mode' do
       it "should remember the mode" do
-        @session.mode.should == :rack_test
+        expect(@session.mode).to be_eql :rack_test
       end
     end
 
@@ -36,21 +36,21 @@ describe Capybara::Session do
         @session.driver.options[:respect_data_method] = true
         @session.visit "/with_html"
         @session.click_link "A link with data-method"
-        @session.html.should include('The requested object was deleted')
+        expect(@session.html).to include('The requested object was deleted')
       end
 
       it "should not use data-method if option is false" do
         @session.driver.options[:respect_data_method] = false
         @session.visit "/with_html"
         @session.click_link "A link with data-method"
-        @session.html.should include('Not deleted')
+        expect(@session.html).to include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         @session.driver.options[:respect_data_method] = true
         @session.visit "/with_html"
         @session.click_link "A link with capitalized data-method"
-        @session.html.should include('The requested object was deleted')
+        expect(@session.html).to include('The requested object was deleted')
       end
 
       after do
@@ -63,7 +63,7 @@ describe Capybara::Session do
         it "should submit an empty form-data section if no file is submitted" do
           @session.visit("/form")
           @session.click_button("Upload Empty")
-          @session.html.should include('Successfully ignored empty file field.')
+          expect(@session.html).to include('Successfully ignored empty file field.')
         end
       end
     end
@@ -79,45 +79,43 @@ describe Capybara::RackTest::Driver do
     it 'should always set headers' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header')
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
 
     it 'should keep headers on link clicks' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find_xpath('.//a').first.click
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
 
     it 'should keep headers on form submit' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/header_links')
       @driver.find_xpath('.//input').first.click
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
 
     it 'should keep headers on redirects' do
       @driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       @driver.visit('/get_header_via_redirect')
-      @driver.html.should include('foobar')
+      expect(@driver.html).to include('foobar')
     end
   end
 
   describe ':follow_redirects option' do
     it "defaults to following redirects" do
       @driver = Capybara::RackTest::Driver.new(TestApp)
-
       @driver.visit('/redirect')
       @driver.response.header['Location'].should be_nil
-      @driver.browser.current_url.should match %r{/landed$}
+      expect(@driver.browser.current_url).to match %r{/landed$}
     end
 
     it "is possible to not follow redirects" do
       @driver = Capybara::RackTest::Driver.new(TestApp, :follow_redirects => false)
-
       @driver.visit('/redirect')
-      @driver.response.header['Location'].should match %r{/redirect_again$}
-      @driver.browser.current_url.should match %r{/redirect$}
+      expect(@driver.response.header['Location']).to match %r{/redirect_again$}
+      expect(@driver.browser.current_url).to match %r{/redirect$}
     end
   end
 
@@ -129,7 +127,7 @@ describe Capybara::RackTest::Driver do
 
       it "should follow 5 redirects" do
         @driver.visit("/redirect/5/times")
-        @driver.html.should include('redirection complete')
+        expect(@driver.html).to include('redirection complete')
       end
 
       it "should not follow more than 6 redirects" do
@@ -146,7 +144,7 @@ describe Capybara::RackTest::Driver do
 
       it "should follow 21 redirects" do
         @driver.visit("/redirect/21/times")
-        @driver.html.should include('redirection complete')
+        expect(@driver.html).to include('redirection complete')
       end
 
       it "should not follow more than 21 redirects" do

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -17,49 +17,43 @@ describe Capybara::Result do
   end
 
   it "has a length" do
-    result.length.should == 4
+    expect(result.length).to be_eql 4
   end
 
   it "has a first element" do
-    result.first.text == 'Alpha'
+    expect(result.first.text).to be_eql 'Alpha'
   end
 
   it "has a last element" do
-    result.last.text == 'Delta'
+    expect(result.last.text).to be_eql 'Delta'
   end
 
   it 'can supports values_at method' do
-    result.values_at(0, 2).map(&:text).should == %w(Alpha Gamma)
+    expect(result.values_at(0, 2).map(&:text)).to be_eql %w(Alpha Gamma)
   end
 
   it "can return an element by its index" do
-    result.at(1).text.should == 'Beta'
-    result[2].text.should == 'Gamma'
+    expect(result.at(1).text).to be_eql 'Beta'
+    expect(result[2].text).to be_eql 'Gamma'
   end
 
   it "can be mapped" do
-    result.map(&:text).should == %w(Alpha Beta Gamma Delta)
+    expect(result.map(&:text)).to be_eql %w(Alpha Beta Gamma Delta)
   end
 
   it "can be selected" do
-    result.select do |element|
-      element.text.include? 't'
-    end.length.should == 2
+    expect(result.select { |element| element.text.include? 't'}.length).to be_eql 2
   end
 
   it "can be reduced" do
-    result.reduce('') do |memo, element|
-      memo += element.text[0]
-    end.should == 'ABGD'
+    expect(result.reduce('') { |memo, element| memo += element.text[0] }).to be_eql 'ABGD'
   end
 
   it 'can be sampled' do
-    result.should include(result.sample)
+    expect(result).to include(result.sample)
   end
 
   it 'can be indexed' do
-    result.index do |el|
-      el.text == 'Gamma'
-    end.should == 2
+    expect(result.index { |el| el.text == 'Gamma' }).to be_eql 2
   end
 end

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -12,41 +12,41 @@ feature "Capybara's feature DSL" do
 
   scenario "includes Capybara" do
     visit('/')
-    page.should have_content('Hello world!')
+    expect(page).to have_content('Hello world!')
   end
 
   scenario "preserves description" do
-    example.metadata[:full_description].should == "Capybara's feature DSL preserves description"
+    expect(example.metadata[:full_description]).to be_eql "Capybara's feature DSL preserves description"
   end
 
   scenario "allows driver switching", :driver => :selenium do
-    Capybara.current_driver.should == :selenium
+    expect(Capybara.current_driver).to be_eql :selenium
   end
 
   scenario "runs background" do
-    @in_background.should be_true
+    expect(@in_background).to be_true
   end
 
   scenario "runs hooks filtered by file path" do
-    @in_filtered_hook.should be_true
+    expect(@in_filtered_hook).to be_true
   end
 
   scenario "doesn't pollute the Object namespace" do
-    Object.new.respond_to?(:feature, true).should be_false
+    expect(Object.new.respond_to?(:feature, true)).to be_false
   end
 
   feature 'nested features' do
     scenario 'work as expected' do
       visit '/'
-      page.should have_content 'Hello world!'
+      expect(page).to have_content 'Hello world!'
     end
 
     scenario 'are marked in the metadata as capybara_feature' do
-      example.metadata[:capybara_feature].should be_true
+      expect(example.metadata[:capybara_feature]).to be_true
     end
 
     scenario 'have a type of :feature' do
-      example.metadata[:type].should eq :feature
+      expect(example.metadata[:type]).to be_eql :feature
     end
   end
 end
@@ -56,12 +56,12 @@ feature "given and given! aliases to let and let!" do
   given!(:value_in_background) { :available }
 
   background do
-    value_in_background.should be(:available)
+    expect(value_in_background).to be(:available)
   end
 
   scenario "given and given! work as intended" do
-    value.should be(:available)
-    value_in_background.should be(:available)
+    expect(value).to be(:available)
+    expect(value_in_background).to be(:available)
   end
 end
 
@@ -72,6 +72,6 @@ end
 
 feature "Capybara's feature DSL with driver", :driver => :culerity do
   scenario "switches driver" do
-    Capybara.current_driver.should == :culerity
+    expect(Capybara.current_driver).to be_eql :culerity
   end
 end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -8,70 +8,70 @@ describe Capybara::RSpecMatchers do
 
   describe "have_css matcher" do
     it "gives proper description" do
-      have_css('h1').description.should == "have css \"h1\""
+      expect(have_css('h1').description).to be_eql "have css \"h1\""
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_css? returns true" do
-          "<h1>Text</h1>".should have_css('h1')
+          expect("<h1>Text</h1>").to have_css('h1')
         end
 
         it "fails if has_css? returns false" do
-          expect do
-            "<h1>Text</h1>".should have_css('h2')
-          end.to raise_error(/expected to find css "h2" but there were no matches/)
+          expect {
+            expect("<h1>Text</h1>").to have_css('h2')
+          }.to raise_error(/expected to find css "h2" but there were no matches/)
         end
 
         it "passes if matched node count equals expected count" do
-          "<h1>Text</h1>".should have_css('h1', :count => 1)
+          expect("<h1>Text</h1>").to have_css('h1', :count => 1)
         end
 
         it "fails if matched node count does not equal expected count" do
-          expect do
-            "<h1>Text</h1>".should have_css('h1', count: 2)
-          end.to raise_error("expected to find css \"h1\" 2 times, found 1 match: \"Text\"")
+          expect {
+            expect("<h1>Text</h1>").to have_css('h1', count: 2)
+          }.to raise_error("expected to find css \"h1\" 2 times, found 1 match: \"Text\"")
         end
 
         it "fails if matched node count is less than expected minimum count" do
-          expect do
-            "<h1>Text</h1>".should have_css('p', minimum: 1)
-          end.to raise_error("expected to find css \"p\" at least 1 time but there were no matches")
+          expect {
+            expect("<h1>Text</h1>").to have_css('p', minimum: 1)
+          }.to raise_error("expected to find css \"p\" at least 1 time but there were no matches")
         end
 
         it "fails if matched node count is more than expected maximum count" do
-          expect do
-            "<h1>Text</h1><h1>Text</h1><h1>Text</h1>".should have_css('h1', maximum: 2)
-          end.to raise_error('expected to find css "h1" at most 2 times, found 3 matches: "Text", "Text", "Text"')
+          expect {
+            expect("<h1>Text</h1><h1>Text</h1><h1>Text</h1>").to have_css('h1', maximum: 2)
+          }.to raise_error('expected to find css "h1" at most 2 times, found 3 matches: "Text", "Text", "Text"')
         end
 
         it "fails if matched node count does not belong to expected range" do
-          expect do
-            "<h1>Text</h1>".should have_css('h1', between: 2..3)
-          end.to raise_error("expected to find css \"h1\" between 2 and 3 times, found 1 match: \"Text\"")
+          expect {
+            expect("<h1>Text</h1>").to have_css('h1', between: 2..3)
+          }.to raise_error("expected to find css \"h1\" between 2 and 3 times, found 1 match: \"Text\"")
         end
 
       end
 
       context "with should_not" do
         it "passes if has_no_css? returns true" do
-          "<h1>Text</h1>".should_not have_css('h2')
+          expect("<h1>Text</h1>").not_to have_css('h2')
         end
 
         it "fails if has_no_css? returns false" do
-          expect do
-            "<h1>Text</h1>".should_not have_css('h1')
-          end.to raise_error(/expected not to find css "h1"/)
+          expect {
+            expect("<h1>Text</h1>").not_to have_css('h1')
+          }.to raise_error(/expected not to find css "h1"/)
         end
 
         it "passes if matched node count does not equal expected count" do
-          "<h1>Text</h1>".should_not have_css('h1', :count => 2)
+          expect("<h1>Text</h1>").not_to have_css('h1', :count => 2)
         end
 
         it "fails if matched node count equals expected count" do
-          expect do
-            "<h1>Text</h1>".should_not have_css('h1', :count => 1)
-          end.to raise_error(/expected not to find css "h1"/)
+          expect {
+            expect("<h1>Text</h1>").not_to have_css('h1', :count => 1)
+          }.to raise_error(/expected not to find css "h1"/)
         end
       end
     end
@@ -83,25 +83,25 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_css? returns true" do
-          page.should have_css('h1')
+          expect(page).to have_css('h1')
         end
 
         it "fails if has_css? returns false" do
-          expect do
-            page.should have_css('h1#doesnotexist')
-          end.to raise_error(/expected to find css "h1#doesnotexist" but there were no matches/)
+          expect {
+            expect(page).to have_css('h1#doesnotexist')
+          }.to raise_error(/expected to find css "h1#doesnotexist" but there were no matches/)
         end
       end
 
       context "with should_not" do
         it "passes if has_no_css? returns true" do
-          page.should_not have_css('h1#doesnotexist')
+          expect(page).not_to have_css('h1#doesnotexist')
         end
 
         it "fails if has_no_css? returns false" do
-          expect do
-            page.should_not have_css('h1')
-          end.to raise_error(/expected not to find css "h1"/)
+          expect {
+            expect(page).not_to have_css('h1')
+          }.to raise_error(/expected not to find css "h1"/)
         end
       end
     end
@@ -109,31 +109,31 @@ describe Capybara::RSpecMatchers do
 
   describe "have_xpath matcher" do
     it "gives proper description" do
-      have_xpath('//h1').description.should == "have xpath \"\/\/h1\""
+      expect(have_xpath('//h1').description).to be_eql "have xpath \"\/\/h1\""
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_xpath? returns true" do
-          "<h1>Text</h1>".should have_xpath('//h1')
+          expect("<h1>Text</h1>").to have_xpath('//h1')
         end
 
         it "fails if has_xpath? returns false" do
-          expect do
-            "<h1>Text</h1>".should have_xpath('//h2')
-          end.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
+          expect {
+            expect("<h1>Text</h1>").to have_xpath('//h2')
+          }.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_xpath? returns true" do
-          "<h1>Text</h1>".should_not have_xpath('//h2')
+          expect("<h1>Text</h1>").not_to have_xpath('//h2')
         end
 
         it "fails if has_no_xpath? returns false" do
-          expect do
-            "<h1>Text</h1>".should_not have_xpath('//h1')
-          end.to raise_error(%r(expected not to find xpath "//h1"))
+          expect {
+            expect("<h1>Text</h1>").not_to have_xpath('//h1')
+          }.to raise_error(%r(expected not to find xpath "//h1"))
         end
       end
     end
@@ -145,25 +145,25 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_xpath? returns true" do
-          page.should have_xpath('//h1')
+          expect(page).to have_xpath('//h1')
         end
 
         it "fails if has_xpath? returns false" do
-          expect do
-            page.should have_xpath("//h1[@id='doesnotexist']")
-          end.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
+          expect {
+            expect(page).to have_xpath("//h1[@id='doesnotexist']")
+          }.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_xpath? returns true" do
-          page.should_not have_xpath('//h1[@id="doesnotexist"]')
+          expect(page).not_to have_xpath('//h1[@id="doesnotexist"]')
         end
 
         it "fails if has_no_xpath? returns false" do
-          expect do
-            page.should_not have_xpath('//h1')
-          end.to raise_error(%r(expected not to find xpath "//h1"))
+          expect {
+            expect(page).not_to have_xpath('//h1')
+          }.to raise_error(%r(expected not to find xpath "//h1"))
         end
       end
     end
@@ -172,32 +172,32 @@ describe Capybara::RSpecMatchers do
   describe "have_selector matcher" do
     it "gives proper description" do
       matcher = have_selector('//h1')
-      "<h1>Text</h1>".should matcher
-      matcher.description.should == "have xpath \"//h1\""
+      expect("<h1>Text</h1>").to matcher
+      expect(matcher.description).to be_eql "have xpath \"//h1\""
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_selector? returns true" do
-          "<h1>Text</h1>".should have_selector('//h1')
+          expect("<h1>Text</h1>").to have_selector('//h1')
         end
 
         it "fails if has_selector? returns false" do
-          expect do
-            "<h1>Text</h1>".should have_selector('//h2')
-          end.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
+          expect {
+            expect("<h1>Text</h1>").to have_selector('//h2')
+          }.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_selector? returns true" do
-          "<h1>Text</h1>".should_not have_selector(:css, 'h2')
+          expect("<h1>Text</h1>").not_to have_selector(:css, 'h2')
         end
 
         it "fails if has_no_selector? returns false" do
-          expect do
-            "<h1>Text</h1>".should_not have_selector(:css, 'h1')
-          end.to raise_error(%r(expected not to find css "h1"))
+          expect {
+            expect("<h1>Text</h1>").not_to have_selector(:css, 'h1')
+          }.to raise_error(%r(expected not to find css "h1"))
         end
       end
     end
@@ -209,31 +209,31 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_selector? returns true" do
-          page.should have_selector('//h1', :text => 'test')
+          expect(page).to have_selector('//h1', :text => 'test')
         end
 
         it "fails if has_selector? returns false" do
-          expect do
-            page.should have_selector("//h1[@id='doesnotexist']")
-          end.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
+          expect {
+            expect(page).to have_selector("//h1[@id='doesnotexist']")
+          }.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
         end
 
         it "includes text in error message" do
-          expect do
-            page.should have_selector("//h1", :text => 'wrong text')
-          end.to raise_error(%r(expected to find xpath "//h1" with text "wrong text" but there were no matches))
+          expect {
+            expect(page).to have_selector("//h1", :text => 'wrong text')
+          }.to raise_error(%r(expected to find xpath "//h1" with text "wrong text" but there were no matches))
         end
       end
 
       context "with should_not" do
         it "passes if has_no_css? returns true" do
-          page.should_not have_selector(:css, 'h1#doesnotexist')
+          expect(page).not_to have_selector(:css, 'h1#doesnotexist')
         end
 
         it "fails if has_no_selector? returns false" do
-          expect do
-            page.should_not have_selector(:css, 'h1', :text => 'test')
-          end.to raise_error(%r(expected not to find css "h1" with text "test"))
+          expect {
+            expect(page).not_to have_selector(:css, 'h1', :text => 'test')
+          }.to raise_error(%r(expected not to find css "h1" with text "test"))
         end
       end
     end
@@ -241,39 +241,39 @@ describe Capybara::RSpecMatchers do
 
   describe "have_content matcher" do
     it "gives proper description" do
-      have_content('Text').description.should == "text \"Text\""
+      expect(have_content('Text').description).to be_eql "text \"Text\""
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_content? returns true" do
-          "<h1>Text</h1>".should have_content('Text')
+          expect("<h1>Text</h1>").to have_content('Text')
         end
 
         it "passes if has_content? returns true using regexp" do
-          "<h1>Text</h1>".should have_content(/ext/)
+          expect("<h1>Text</h1>").to have_content(/ext/)
         end
 
         it "fails if has_content? returns false" do
-          expect do
-            "<h1>Text</h1>".should have_content('No such Text')
-          end.to raise_error(/expected to find text "No such Text" in "Text"/)
+          expect {
+            expect("<h1>Text</h1>").to have_content('No such Text')
+          }.to raise_error(/expected to find text "No such Text" in "Text"/)
         end
       end
 
       context "with should_not" do
         it "passes if has_no_content? returns true" do
-          "<h1>Text</h1>".should_not have_content('No such Text')
+          expect("<h1>Text</h1>").not_to have_content('No such Text')
         end
 
         it "passes because escapes any characters that would have special meaning in a regexp" do
-          "<h1>Text</h1>".should_not have_content('.')
+          expect("<h1>Text</h1>").not_to have_content('.')
         end
 
         it "fails if has_no_content? returns false" do
-          expect do
-            "<h1>Text</h1>".should_not have_content('Text')
-          end.to raise_error(/expected not to find text "Text" in "Text"/)
+          expect {
+            expect("<h1>Text</h1>").not_to have_content('Text')
+          }.to raise_error(/expected not to find text "Text" in "Text"/)
         end
       end
     end
@@ -285,25 +285,24 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_content? returns true" do
-          page.should have_content('This is a test')
+          expect(page).to have_content('This is a test')
         end
 
         it "passes if has_content? returns true using regexp" do
-          page.should have_content(/test/)
+          expect(page).to have_content(/test/)
         end
 
         it "fails if has_content? returns false" do
-          expect do
-            page.should have_content('No such Text')
-          end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
+          expect { expect(page).to have_content('No such Text')
+          }.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
         end
 
         context "with default selector CSS" do
           before { Capybara.default_selector = :css }
           it "fails if has_content? returns false" do
-            expect do
-              page.should have_content('No such Text')
-            end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
+            expect {
+              expect(page).to have_content('No such Text')
+            }.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
           end
           after { Capybara.default_selector = :xpath }
         end
@@ -311,13 +310,13 @@ describe Capybara::RSpecMatchers do
 
       context "with should_not" do
         it "passes if has_no_content? returns true" do
-          page.should_not have_content('No such Text')
+          expect(page).not_to have_content('No such Text')
         end
 
         it "fails if has_no_content? returns false" do
-          expect do
-            page.should_not have_content('This is a test')
-          end.to raise_error(/expected not to find text "This is a test"/)
+          expect {
+            expect(page).not_to have_content('This is a test')
+          }.to raise_error(/expected not to find text "This is a test"/)
         end
       end
     end
@@ -325,69 +324,69 @@ describe Capybara::RSpecMatchers do
 
   describe "have_text matcher" do
     it "gives proper description" do
-      have_text('Text').description.should == "text \"Text\""
+      expect(have_text('Text').description).to be_eql "text \"Text\""
     end
 
     context "on a string" do
       context "with should" do
         it "passes if has_text? returns true" do
-          "<h1>Text</h1>".should have_text('Text')
+          expect("<h1>Text</h1>").to have_text('Text')
         end
 
         it "passes if has_text? returns true using regexp" do
-          "<h1>Text</h1>".should have_text(/ext/)
+          expect("<h1>Text</h1>").to have_text(/ext/)
         end
 
         it "fails if has_text? returns false" do
-          expect do
-            "<h1>Text</h1>".should have_text('No such Text')
-          end.to raise_error(/expected to find text "No such Text" in "Text"/)
+          expect {
+            expect("<h1>Text</h1>").to have_text('No such Text')
+          }.to raise_error(/expected to find text "No such Text" in "Text"/)
         end
 
         it "casts Fixnum to string" do
-          expect do
-            "<h1>Text</h1>".should have_text(3)
-          end.to raise_error(/expected to find text "3" in "Text"/)
+          expect { 
+            expect("<h1>Text</h1>").to have_text(3)
+          }.to raise_error(/expected to find text "3" in "Text"/)
         end
 
         it "fails if matched text count does not equal to expected count" do
-          expect do
-            "<h1>Text</h1>".should have_text('Text', count: 2)
-          end.to raise_error(/expected to find text "Text" 2 times in "Text"/)
+          expect {
+            expect("<h1>Text</h1>").to have_text('Text', count: 2)
+          }.to raise_error(/expected to find text "Text" 2 times in "Text"/)
         end
 
         it "fails if matched text count is less than expected minimum count" do
-          expect do
-            "<h1>Text</h1>".should have_text('Lorem', minimum: 1)
-          end.to raise_error(/expected to find text "Lorem" at least 1 time in "Text"/)
+          expect {
+            expect("<h1>Text</h1>").to have_text('Lorem', minimum: 1)
+          }.to raise_error(/expected to find text "Lorem" at least 1 time in "Text"/)
         end
 
         it "fails if matched text count is more than expected maximum count" do
-          expect do
-            "<h1>Text TextText</h1>".should have_text('Text', maximum: 2)
-          end.to raise_error(/expected to find text "Text" at most 2 times in "Text TextText"/)
+          expect { 
+            expect("<h1>Text TextText</h1>").to have_text('Text', maximum: 2)
+          }.to raise_error(/expected to find text "Text" at most 2 times in "Text TextText"/)
         end
 
         it "fails if matched text count does not belong to expected range" do
-          expect do
-            "<h1>Text</h1>".should have_text('Text', between: 2..3)
-          end.to raise_error(/expected to find text "Text" between 2 and 3 times in "Text"/)
+          expect { 
+            expect("<h1>Text</h1>").to have_text('Text', between: 2..3)
+          }.to raise_error(/expected to find text "Text" between 2 and 3 times in "Text"/)
         end
       end
 
       context "with should_not" do
         it "passes if has_no_text? returns true" do
-          "<h1>Text</h1>".should_not have_text('No such Text')
+          expect("<h1>Text</h1>").not_to have_text('No such Text')
         end
 
         it "passes because escapes any characters that would have special meaning in a regexp" do
-          "<h1>Text</h1>".should_not have_text('.')
+          expect("<h1>Text</h1>").not_to have_text('.')
         end
 
         it "fails if has_no_text? returns false" do
-          expect do
-            "<h1>Text</h1>".should_not have_text('Text')
-          end.to raise_error(/expected not to find text "Text" in "Text"/)
+          expect {
+            expect("<h1>Text</h1>").not_to have_text('Text')
+          }.to raise_error(/expected not to find text "Text" in "Text"/)
         end
       end
     end
@@ -399,34 +398,34 @@ describe Capybara::RSpecMatchers do
 
       context "with should" do
         it "passes if has_text? returns true" do
-          page.should have_text('This is a test')
+          expect(page).to have_text('This is a test')
         end
 
         it "passes if has_text? returns true using regexp" do
-          page.should have_text(/test/)
+          expect(page).to have_text(/test/)
         end
 
         it "can check for all text" do
-          page.should have_text(:all, 'Some of this text is hidden!')
+          expect(page).to have_text(:all, 'Some of this text is hidden!')
         end
 
         it "can check for visible text" do
-          page.should have_text(:visible, 'Some of this text is')
-          page.should_not have_text(:visible, 'Some of this text is hidden!')
+          expect(page).to have_text(:visible, 'Some of this text is')
+          expect(page).not_to have_text(:visible, 'Some of this text is hidden!')
         end
 
         it "fails if has_text? returns false" do
-          expect do
-            page.should have_text('No such Text')
-          end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
+          expect {
+            expect(page).to have_text('No such Text')
+          }.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
         end
 
         context "with default selector CSS" do
           before { Capybara.default_selector = :css }
           it "fails if has_text? returns false" do
-            expect do
-              page.should have_text('No such Text')
-            end.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
+            expect {
+              expect(page).to have_text('No such Text')
+            }.to raise_error(/expected to find text "No such Text" in "(.*)This is a test(.*)"/)
           end
           after { Capybara.default_selector = :xpath }
         end
@@ -434,13 +433,13 @@ describe Capybara::RSpecMatchers do
 
       context "with should_not" do
         it "passes if has_no_text? returns true" do
-          page.should_not have_text('No such Text')
+          expect(page).not_to have_text('No such Text')
         end
 
         it "fails if has_no_text? returns false" do
-          expect do
-            page.should_not have_text('This is a test')
-          end.to raise_error(/expected not to find text "This is a test"/)
+          expect {
+            expect(page).not_to have_text('This is a test')
+          }.to raise_error(/expected not to find text "This is a test"/)
         end
       end
     end
@@ -450,36 +449,36 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<a href="#">Just a link</a>' }
 
     it "gives proper description" do
-      have_link('Just a link').description.should == "have link \"Just a link\""
+      expect(have_link('Just a link').description).to be_eql "have link \"Just a link\""
     end
 
     it "passes if there is such a button" do
-      html.should have_link('Just a link')
+      expect(html).to have_link('Just a link')
     end
 
     it "fails if there is no such button" do
-      expect do
-        html.should have_link('No such Link')
-      end.to raise_error(/expected to find link "No such Link"/)
+      expect {
+        expect(html).to have_link('No such Link')
+      }.to raise_error(/expected to find link "No such Link"/)
     end
   end
 
   describe "have_title matcher" do
     it "gives proper description" do
-      have_title('Just a title').description.should == "have title \"Just a title\""
+      expect(have_title('Just a title').description).to be_eql "have title \"Just a title\""
     end
 
     context "on a string" do
       let(:html) { '<title>Just a title</title>' }
 
       it "passes if there is such a title" do
-        html.should have_title('Just a title')
+        expect(html).to have_title('Just a title')
       end
 
       it "fails if there is no such title" do
-        expect do
-          html.should have_title('No such title')
-        end.to raise_error(/expected there to be title "No such title"/)
+        expect {
+          expect(html).to have_title('No such title')
+        }.to raise_error(/expected there to be title "No such title"/)
       end
     end
 
@@ -489,13 +488,13 @@ describe Capybara::RSpecMatchers do
       end
 
       it "passes if there is such a title" do
-        page.should have_title('with_js')
+        expect(page).to have_title('with_js')
       end
 
       it "fails if there is no such title" do
-        expect do
-          page.should have_title('No such title')
-        end.to raise_error(/expected there to be title "No such title"/)
+        expect {
+          expect(page).to have_title('No such title')
+        }.to raise_error(/expected there to be title "No such title"/)
       end
     end
   end
@@ -504,17 +503,17 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<button>A button</button><input type="submit" value="Another button"/>' }
 
     it "gives proper description" do
-      have_button('A button').description.should == "have button \"A button\""
+      expect(have_button('A button').description).to be_eql "have button \"A button\""
     end
 
     it "passes if there is such a button" do
-      html.should have_button('A button')
+      expect(html).to have_button('A button')
     end
 
     it "fails if there is no such button" do
-      expect do
-        html.should have_button('No such Button')
-      end.to raise_error(/expected to find button "No such Button"/)
+      expect {
+        expect(html).to have_button('No such Button')
+      }.to raise_error(/expected to find button "No such Button"/)
     end
   end
 
@@ -522,31 +521,31 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<p><label>Text field<input type="text" value="some value"/></label></p>' }
 
     it "gives proper description" do
-      have_field('Text field').description.should == "have field \"Text field\""
+      expect(have_field('Text field').description).to be_eql "have field \"Text field\""
     end
 
     it "gives proper description for a given value" do
-      have_field('Text field', with: 'some value').description.should == "have field \"Text field\" with value \"some value\""
+      expect(have_field('Text field', with: 'some value').description).to be_eql "have field \"Text field\" with value \"some value\""
     end
 
     it "passes if there is such a field" do
-      html.should have_field('Text field')
+      expect(html).to have_field('Text field')
     end
 
     it "passes if there is such a field with value" do
-      html.should have_field('Text field', with: 'some value')
+      expect(html).to have_field('Text field', with: 'some value')
     end
 
     it "fails if there is no such field" do
-      expect do
-        html.should have_field('No such Field')
-      end.to raise_error(/expected to find field "No such Field"/)
+      expect {
+        expect(html).to have_field('No such Field')
+      }.to raise_error(/expected to find field "No such Field"/)
     end
 
     it "fails if there is such field but with false value" do
-      expect do
-        html.should have_field('Text field', with: 'false value')
-      end.to raise_error(/expected to find field "Text field"/)
+      expect {
+        expect(html).to have_field('Text field', with: 'false value')
+      }.to raise_error(/expected to find field "Text field"/)
     end
 
     it "treats a given value as a string" do
@@ -555,7 +554,7 @@ describe Capybara::RSpecMatchers do
           "some value"
         end
       end
-      html.should have_field('Text field', with: Foo.new)
+      expect(html).to have_field('Text field', with: Foo.new)
     end
   end
 
@@ -566,40 +565,40 @@ describe Capybara::RSpecMatchers do
     end
 
     it "gives proper description" do
-      have_checked_field('it is checked').description.should == "have field \"it is checked\""
+      expect(have_checked_field('it is checked').description).to be_eql "have field \"it is checked\""
     end
 
     context "with should" do
       it "passes if there is such a field and it is checked" do
-        html.should have_checked_field('it is checked')
+        expect(html).to have_checked_field('it is checked')
       end
 
       it "fails if there is such a field but it is not checked" do
-        expect do
-          html.should have_checked_field('unchecked field')
-        end.to raise_error(/expected to find field "unchecked field"/)
+        expect {
+          expect(html).to have_checked_field('unchecked field')
+        }.to raise_error(/expected to find field "unchecked field"/)
       end
 
       it "fails if there is no such field" do
-        expect do
-          html.should have_checked_field('no such field')
-        end.to raise_error(/expected to find field "no such field"/)
+        expect {
+          expect(html).to have_checked_field('no such field')
+        }.to raise_error(/expected to find field "no such field"/)
       end
     end
 
     context "with should not" do
       it "fails if there is such a field and it is checked" do
-        expect do
-          html.should_not have_checked_field('it is checked')
-        end.to raise_error(/expected not to find field "it is checked"/)
+        expect {
+          expect(html).not_to have_checked_field('it is checked')
+        }.to raise_error(/expected not to find field "it is checked"/)
       end
 
       it "passes if there is such a field but it is not checked" do
-        html.should_not have_checked_field('unchecked field')
+        expect(html).not_to have_checked_field('unchecked field')
       end
 
       it "passes if there is no such field" do
-        html.should_not have_checked_field('no such field')
+        expect(html).not_to have_checked_field('no such field')
       end
     end
   end
@@ -611,40 +610,40 @@ describe Capybara::RSpecMatchers do
     end
 
     it "gives proper description" do
-      have_unchecked_field('unchecked field').description.should == "have field \"unchecked field\""
+      expect(have_unchecked_field('unchecked field').description).to be_eql "have field \"unchecked field\""
     end
 
     context "with should" do
       it "passes if there is such a field and it is not checked" do
-        html.should have_unchecked_field('unchecked field')
+        expect(html).to have_unchecked_field('unchecked field')
       end
 
       it "fails if there is such a field but it is checked" do
-        expect do
-          html.should have_unchecked_field('it is checked')
-        end.to raise_error(/expected to find field "it is checked"/)
+        expect {
+          expect(html).to have_unchecked_field('it is checked')
+        }.to raise_error(/expected to find field "it is checked"/)
       end
 
       it "fails if there is no such field" do
-        expect do
-          html.should have_unchecked_field('no such field')
-        end.to raise_error(/expected to find field "no such field"/)
+        expect {
+          expect(html).to have_unchecked_field('no such field')
+        }.to raise_error(/expected to find field "no such field"/)
       end
     end
 
     context "with should not" do
       it "fails if there is such a field and it is not checked" do
-        expect do
-          html.should_not have_unchecked_field('unchecked field')
-        end.to raise_error(/expected not to find field "unchecked field"/)
+        expect {
+          expect(html).not_to have_unchecked_field('unchecked field')
+        }.to raise_error(/expected not to find field "unchecked field"/)
       end
 
       it "passes if there is such a field but it is checked" do
-        html.should_not have_unchecked_field('it is checked')
+        expect(html).not_to have_unchecked_field('it is checked')
       end
 
       it "passes if there is no such field" do
-        html.should_not have_unchecked_field('no such field')
+        expect(html).not_to have_unchecked_field('no such field')
       end
     end
   end
@@ -653,17 +652,17 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<label>Select Box<select></select></label>' }
 
     it "gives proper description" do
-      have_select('Select Box').description.should == "have select box \"Select Box\""
+      expect(have_select('Select Box').description).to be_eql "have select box \"Select Box\""
     end
 
     it "passes if there is such a select" do
-      html.should have_select('Select Box')
+      expect(html).to have_select('Select Box')
     end
 
     it "fails if there is no such select" do
-      expect do
-        html.should have_select('No such Select box')
-      end.to raise_error(/expected to find select box "No such Select box"/)
+      expect {
+        expect(html).to have_select('No such Select box')
+      }.to raise_error(/expected to find select box "No such Select box"/)
     end
   end
 
@@ -671,17 +670,17 @@ describe Capybara::RSpecMatchers do
     let(:html) { '<table><caption>Lovely table</caption></table>' }
 
     it "gives proper description" do
-      have_table('Lovely table').description.should == "have table \"Lovely table\""
+      expect(have_table('Lovely table').description).to be_eql "have table \"Lovely table\""
     end
 
     it "passes if there is such a select" do
-      html.should have_table('Lovely table')
+      expect(html).to have_table('Lovely table')
     end
 
     it "fails if there is no such select" do
-      expect do
-        html.should have_table('No such Table')
-      end.to raise_error(/expected to find table "No such Table"/)
+      expect {
+        expect(html).to have_table('No such Table')
+      }.to raise_error(/expected to find table "No such Table"/)
     end
   end
 end

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 describe 'capybara/rspec', :type => :feature do
   it "should include Capybara in rspec" do
     visit('/foo')
-    page.body.should include('Another World')
+    expect(page.body).to include('Another World')
   end
 
   context "resetting session" do
     it "sets a cookie in one example..." do
       visit('/set_cookie')
-      page.body.should include('Cookie set to test_cookie')
+      expect(page.body).to include('Cookie set to test_cookie')
     end
 
     it "...then it is not availbable in the next" do
       visit('/get_cookie')
-      page.body.should_not include('test_cookie')
+      expect(page.body).not_to include('test_cookie')
     end
   end
 
@@ -24,16 +24,16 @@ describe 'capybara/rspec', :type => :feature do
     end
 
     it "...then it has returned to the default in the next example" do
-      Capybara.current_driver.should == :rack_test
+      expect(Capybara.current_driver).to be_eql :rack_test
     end
   end
 
   it "switches to the javascript driver when giving it as metadata", :js => true do
-    Capybara.current_driver.should == Capybara.javascript_driver
+    expect(Capybara.current_driver).to be_eql Capybara.javascript_driver
   end
 
   it "switches to the given driver when giving it as metadata", :driver => :culerity do
-    Capybara.current_driver.should == :culerity
+    expect(Capybara.current_driver).to be_eql :culerity
   end
 end
 
@@ -46,6 +46,6 @@ end
 feature "Feature DSL" do
   scenario "is pulled in" do
     visit('/foo')
-    page.body.should include('Another World')
+    expect(page.body).to include('Another World')
   end
 end

--- a/spec/selenium_spec.rb
+++ b/spec/selenium_spec.rb
@@ -25,13 +25,13 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a selenium driver" do
-        @session.driver.should be_an_instance_of(Capybara::Selenium::Driver)
+        expect(@session.driver).to be_an_instance_of(Capybara::Selenium::Driver)
       end
     end
 
     describe '#mode' do
       it "should remember the mode" do
-        @session.mode.should == :selenium_focus
+        expect(@session.mode).to be_eql :selenium_focus
       end
     end
 
@@ -39,7 +39,7 @@ describe Capybara::Session do
       it "freshly reset session should not be touched" do
         @session.instance_variable_set(:@touched, true)
         @session.reset!
-        @session.instance_variable_get(:@touched).should be_false
+        expect(@session.instance_variable_get(:@touched)).to be_false
       end
     end
 
@@ -55,12 +55,12 @@ describe Capybara::Session do
 
       it "should have return code 1 when running selenium_driver_rspec_failure.rb" do
         `rspec spec/fixtures/selenium_driver_rspec_failure.rb`
-        $?.exitstatus.should be 1
+        expect($?.exitstatus).to be 1
       end
 
       it "should have return code 0 when running selenium_driver_rspec_success.rb" do
         `rspec spec/fixtures/selenium_driver_rspec_success.rb`
-        $?.exitstatus.should be 0
+        expect($?.exitstatus).to be 0
       end
     end
   end
@@ -73,10 +73,10 @@ describe Capybara::Selenium::Driver do
   
   describe '#quit' do
     it "should reset browser when quit" do
-      @driver.browser.should be
+      expect(@driver.browser).to be
       @driver.quit
       #access instance variable directly so we don't create a new browser instance
-      @driver.instance_variable_get(:@browser).should be_nil
+      expect(@driver.instance_variable_get(:@browser)).to be_nil
     end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -8,13 +8,11 @@ describe Capybara::Server do
 
     @res = Net::HTTP.start(@server.host, @server.port) { |http| http.get('/') }
 
-    @res.body.should include('Hello Server')
+    expect(@res.body).to include('Hello Server')
   end
 
   it "should do nothing when no server given" do
-    expect do
-      @server = Capybara::Server.new(nil).boot
-    end.not_to raise_error
+    expect {@server = Capybara::Server.new(nil).boot}.not_to raise_error
   end
 
   it "should bind to the specified host" do
@@ -42,7 +40,7 @@ describe Capybara::Server do
     @server = Capybara::Server.new(@app).boot
 
     @res = Net::HTTP.start(@server.host, 22789) { |http| http.get('/') }
-    @res.body.should include('Hello Server')
+    expect(@res.body).to include('Hello Server')
 
     Capybara.server_port = nil
   end
@@ -52,7 +50,7 @@ describe Capybara::Server do
     @server = Capybara::Server.new(@app, 22790).boot
 
     @res = Net::HTTP.start(@server.host, 22790) { |http| http.get('/') }
-    @res.body.should include('Hello Server')
+    expect(@res.body).to include('Hello Server')
 
     Capybara.server_port = nil
   end
@@ -65,10 +63,10 @@ describe Capybara::Server do
     @server2 = Capybara::Server.new(@app2).boot
 
     @res1 = Net::HTTP.start(@server1.host, @server1.port) { |http| http.get('/') }
-    @res1.body.should include('Hello Server')
+    expect(@res1.body).to include('Hello Server')
 
     @res2 = Net::HTTP.start(@server2.host, @server2.port) { |http| http.get('/') }
-    @res2.body.should include('Hello Second Server')
+    expect(@res2.body).to include('Hello Second Server')
   end
 
   it "should use the server if it already running" do
@@ -81,13 +79,13 @@ describe Capybara::Server do
     @server2b = Capybara::Server.new(@app2).boot
 
     @res1 = Net::HTTP.start(@server1b.host, @server1b.port) { |http| http.get('/') }
-    @res1.body.should include('Hello Server')
+    expect(@res1.body).to include('Hello Server')
 
     @res2 = Net::HTTP.start(@server2b.host, @server2b.port) { |http| http.get('/') }
-    @res2.body.should include('Hello Second Server')
+    expect(@res2.body).to include('Hello Second Server')
 
-    @server1a.port.should == @server1b.port
-    @server2a.port.should == @server2b.port
+    expect(@server1a.port).to be_eql @server1b.port
+    expect(@server2a.port).to be_eql @server2b.port
   end
 
   it "should raise server errors when the server errors before the timeout" do
@@ -97,9 +95,7 @@ describe Capybara::Server do
         raise 'kaboom'
       end
 
-      proc do
-        Capybara::Server.new(proc {|e|}).boot
-      end.should raise_error(RuntimeError, 'kaboom')
+      expect(proc {Capybara::Server.new(proc {|e|}).boot}).to raise_error(RuntimeError, 'kaboom')
     ensure
       # TODO refactor out the defaults so it's reliant on unset state instead of
       # a one-time call in capybara.rb
@@ -110,7 +106,7 @@ describe Capybara::Server do
   it "is not #responsive? when Net::HTTP raises a SystemCallError" do
     app = lambda { [200, {}, ['Hello, world']] }
     server = Capybara::Server.new(app)
-    Net::HTTP.should_receive(:start).and_raise(SystemCallError.allocate)
+    expect(Net::HTTP).to receive(:start).and_raise(SystemCallError.allocate)
     expect(server.responsive?).to eq false
   end
 end


### PR DESCRIPTION
Deprecated should RSpec syntax updated to new expect variant (in folder spec/).

All specs I have updated are working the same way as before (passing or pending). 
