### PR TITLE
use BasicObject so global includes don't break CSSHandlers

### DIFF
--- a/lib/capybara/rack_test/css_handlers.rb
+++ b/lib/capybara/rack_test/css_handlers.rb
@@ -1,4 +1,6 @@
-class Capybara::RackTest::CSSHandlers
+class Capybara::RackTest::CSSHandlers < BasicObject
+  include ::Kernel
+  
   def disabled list
     list.find_all { |node| node.has_attribute? 'disabled' }
   end        

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -157,3 +157,17 @@ describe Capybara::RackTest::Driver do
     end
   end
 end
+
+module CSSHandlerIncludeTester
+  def dont_extend_css_handler
+    raise 'should never be called'
+  end
+end
+include CSSHandlerIncludeTester
+
+describe  Capybara::RackTest::CSSHandlers do  
+  it "should not be extended by global includes" do
+    expect(Capybara::RackTest::CSSHandlers.new).not_to respond_to(:dont_extend_css_handler)
+  end
+end
+  


### PR DESCRIPTION
Derive CSSHandlers from BasicObject so global includes of modules with functions that collide with xpath function names (like ActionView::Helpers::TextHelper#concat) don't cause failures
