### PR TITLE
Fixed a bug that if you reset your session with open session, test suite crashes.

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -98,6 +98,9 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         # instead.
       end
       @browser.navigate.to("about:blank")
+      # If browser has alerts while navigating, then the entire test suite crashes. There is no
+      # way to check for alert without expecting for exception
+      browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoAlertOpenError
     end
   end
 


### PR DESCRIPTION
Related to:
https://github.com/jnicklas/capybara/issues/1253

Capybara #reset! should handle quite an ordinary case, where an alert might open up on the page.

Currently, if you try to use reset! and an alert opens on the page, then the capybara fails to handle it and crashes this and every other test that uses that same session
