### PR TITLE
Cleanup save_* family of methods

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -41,8 +41,8 @@ module Capybara
     #
     def inject_asset_host(html)
       if Capybara.asset_host && Nokogiri::HTML(html).css("base").empty? 
-         match = html.match(/<head[^<]*?>/)
-          html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
+        match = html.match(/<head[^<]*?>/)
+        html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
       else
         html
       end

--- a/lib/capybara/spec/session/save_and_open_page_spec.rb
+++ b/lib/capybara/spec/session/save_and_open_page_spec.rb
@@ -1,0 +1,19 @@
+require 'launchy'
+
+Capybara::SpecHelper.spec '#save_and_open_page' do
+  before do
+    @session.visit '/foo'
+  end
+
+  after do
+    Dir.glob("capybara-*.html").each do |file|
+      FileUtils.rm(file)
+    end
+  end
+
+  it "sends open method to launchy" do
+    allow(Launchy).to receive(:open)
+    @session.save_and_open_page
+    expect(Launchy).to have_received(:open).with(/capybara-\d+\.html/)
+  end
+end

--- a/lib/capybara/spec/session/save_page_spec.rb
+++ b/lib/capybara/spec/session/save_page_spec.rb
@@ -20,9 +20,8 @@ Capybara::SpecHelper.spec '#save_page' do
 
   it "generates a sensible filename" do
     @session.save_page
-    path = Dir.glob("capybara-*.html").first
-    filename = path.split("/").last
-    expect(filename).to match /^capybara-\d+\.html$/
+    filename = Dir.glob("capybara-*.html").first
+    expect(filename).to match(/^capybara-\d+\.html$/)
   end
 
   it "can store files in a specified directory" do
@@ -68,6 +67,7 @@ Capybara::SpecHelper.spec '#save_page' do
       path = @session.save_page
 
       result = File.read(path)
+      expect(result).to include('<html')
       expect(result).not_to include("http://example.com")
     end
 
@@ -76,6 +76,7 @@ Capybara::SpecHelper.spec '#save_page' do
       path = @session.save_page
 
       result = File.read(path)
+      expect(result).to include('<html')
       expect(result).not_to include("http://example.com")
     end
   end

--- a/lib/capybara/spec/session/save_screenshot_spec.rb
+++ b/lib/capybara/spec/session/save_screenshot_spec.rb
@@ -1,0 +1,23 @@
+Capybara::SpecHelper.spec '#save_screenshot', requires: [:screenshot] do
+  before do
+    @session.visit '/foo'
+  end
+
+  it "generates sensible filename" do
+    allow(@session.driver).to receive(:save_screenshot)
+
+    @session.save_screenshot
+
+    regexp = Regexp.new(File.expand_path('capybara-\d+\.png'))
+    expect(@session.driver).to have_received(:save_screenshot).with(regexp, {})
+  end
+
+  it "allows to specify another path" do
+    allow(@session.driver).to receive(:save_screenshot)
+
+    custom_path = 'screenshots/1.png'
+    @session.save_screenshot(custom_path)
+
+    expect(@session.driver).to have_received(:save_screenshot).with(custom_path, {})
+  end
+end


### PR DESCRIPTION
Follow up to #1273 and #958
- Better YARD documentation
- Fix bug in `inject_asset_host` when `asset_host` is set and `base` tag is present
- Make `path` argument of `save_screenshpt` `nil` by default
- Puts generated filename to `$stdout` when `save_page` or `save_screenshot`
  are invoked without args
