### PR TITLE
Use Ruby 2.x compatible rescue clauses

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -87,7 +87,7 @@ module Capybara
 
       def inspect
         %(#<#{self.class} tag="#{tag_name}" path="#{path}">)
-      rescue NotSupportedByDriverError, 'Capybara::Driver::Node#inspect'
+      rescue NotSupportedByDriverError
         %(#<#{self.class} tag="#{tag_name}">)
       end
 

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -240,7 +240,7 @@ module Capybara
 
       def inspect
         %(#<Capybara::Element tag="#{tag_name}" path="#{path}">)
-      rescue NotSupportedByDriverError, 'Capybara::Node::Element#inspect'
+      rescue NotSupportedByDriverError
         %(#<Capybara::Element tag="#{tag_name}">)
       end
     end


### PR DESCRIPTION
Ruby 2.x doesn't support non-class/module arguments to rescue clauses.
Ruby 1.9 only supported it due to what is now considered a regression:

https://bugs.ruby-lang.org/issues/4438

Remove string arguments from rescue clauses to prevent TypeErrors from
being raised during rescue attempts.
