### PR TITLE
Force url parameter in visit method with to_s

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -205,12 +205,14 @@ module Capybara
 
       @touched = true
 
+      url = url.to_s
+
       if url !~ /^http/ and Capybara.app_host
-        url = Capybara.app_host + url.to_s
+        url = Capybara.app_host + url
       end
 
       if @server
-        url = "http://#{@server.host}:#{@server.port}" + url.to_s unless url =~ /^http/
+        url = "http://#{@server.host}:#{@server.port}" + url unless url =~ /^http/
 
         if Capybara.always_include_port
           uri = URI.parse(url)


### PR DESCRIPTION
The `visit` method takes a `url` as a parameter and in checking for special cases it performs `url.to_s`. However if no special cases apply, it does not perform `to_s`.

As someone who would like to send an arbitrary object capable of producing a url from `to_s` I feel adding consistency to the treatment of the parameter is beneficial.
