### PR TITLE
Make process method safer by coercing path into a string

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -42,11 +42,10 @@ class Capybara::RackTest::Browser
   end
 
   def process(method, path, attributes = {}, env = {})
-    path = path.to_s
-    new_uri = URI.parse(path)
+    new_uri = URI.parse(path.to_s)
     method.downcase! unless method.is_a? Symbol
 
-    new_uri.path = request_path if path.start_with?("?")
+    new_uri.path = request_path if path.to_s.start_with?("?")
     new_uri.path = "/" if new_uri.path.empty?
     new_uri.path = request_path.sub(%r(/[^/]*$), '/') + new_uri.path unless new_uri.path.start_with?('/')
     new_uri.scheme ||= @current_scheme


### PR DESCRIPTION
Currently the `process` method in `Capybara::RackTest::Browser` takes an argument called `path` and assumes it is a string as it treats it as such by using it as an argument to `URI.parse` and sending it methods like `start_with?`.

This patch coerces the path argument with `to_s`.

@twalpole I thought this a more appropriate near term fix for my desired long term fix by tackling the issue at the driver level.
