### PR TITLE
Fix build on rbx (it failed consistently previously)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
   - 2.1.1
   - jruby-19mode
-  - rbx
+  - rbx-2
 gemfile:
   - Gemfile
 matrix:


### PR DESCRIPTION
Here is the reason - https://github.com/wayneeseguin/rvm/issues/2847

The build also started to fail on Chrome (maybe because of Chromedriver update to 2.10, maybe because of something else) but I haven't investigated it yet.
