### PR TITLE
fix warning about metadata filtering under RSpec 3

### DIFF
--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'capybara/rspec'
 
-RSpec.configuration.before(:each, :example_group => {:file_path => "./spec/rspec/features_spec.rb"}) do
+RSpec.configuration.before(:each, { file_path: "./spec/rspec/features_spec.rb" } ) do
   @in_filtered_hook = true
 end
 


### PR DESCRIPTION
In RSpec 2 :file_path appears to be delegated to :example_group metadata so the same format works for both
