### PR TITLE
Optimize become_closed matcher

### DIFF
--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -132,10 +132,11 @@ module Capybara
       def matches?(window)
         @window = window
         start_time = Time.now
-        while window.exists? && (Time.now - start_time) < @wait_time
+        while window.exists?
+          return false if (Time.now - start_time) > @wait_time
           sleep 0.05
         end
-        window.closed?
+        true
       end
 
       def failure_message


### PR DESCRIPTION
Previous behavior didn't match behavior of other methods: there should not be additional check for `window.closed?` after wait time had elapsed.
