### PR TITLE
Fix save_and_open_screenshot for 3rd drivers

### DIFF
--- a/lib/capybara/spec/session/save_and_open_screenshot_spec.rb
+++ b/lib/capybara/spec/session/save_and_open_screenshot_spec.rb
@@ -6,7 +6,7 @@ Capybara::SpecHelper.spec '#save_and_open_screenshot' do
   end
 
   it 'opens file from the default directory', :requires => [:screenshot] do
-    expected_file_regex = %r{capybara/capybara-\d+\.png}
+    expected_file_regex = %r{capybara-\d+\.png}
     allow(@session.driver).to receive(:save_screenshot)
     allow(Launchy).to receive(:open)
 


### PR DESCRIPTION
The screenshot path will not start with `capybara/` for 3rd drivers like
poltergeist since they aren't on capybara itself.

See https://travis-ci.org/teampoltergeist/poltergeist/jobs/28737963#L534
