### PR TITLE
Chromedriver unable to fill time fields after navigating to "about:blank"

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -98,7 +98,9 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
           # to about:blank, so we rescue this error and do nothing
           # instead.
         end
-        @browser.navigate.to("about:blank")
+        @browser.execute_script %Q{
+          window.location = "about:blank";
+        }
       rescue Selenium::WebDriver::Error::UnhandledAlertError
         # This error is thrown if an unhandled alert is on the page
         # Firefox appears to automatically dismiss this alert, chrome does not


### PR DESCRIPTION
I don't fully understand this issue, so this PR is more about putting eyeballs on the problem than proposing a good solution. /disclaimer

Capybara has an issue when filling time fields in Chrome. When using Chromedriver only, calling `navigate.to("about:blank")` causes _all_ subsequent attempts to fill inputs with `type=time` to silently fail.

I've set up a [Rails repo](https://github.com/chronophasiac/capybara_test) that illustrates the problem. Clone, `bundle`, and run `bundle exec rspec spec/features`. I would have added a test to Capybara, but I couldn't figure out how to execute the test suite in Chrome instead of FF.

The quick fix that I've implemented for my project is the subject of this PR. For reasons I cannot discern, calling JavaScript to load "about:blank" appears not to trigger the bug. Hopefully someone else can dig around and discover the real cause for this issue so a proper solution can be implemented.
