### PR TITLE
Always convert visit's URL to a String before manipulation

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -199,7 +199,7 @@ module Capybara
     #
     # Will actually navigate to `http://google.com:4567/test`.
     #
-    # @param [String] url     The URL to navigate to
+    # @param [#to_s] url     The URL to navigate to. The parameter will be cast to a String.
     #
     def visit(url)
       raise_server_error!


### PR DESCRIPTION
It is convenient to be able to pass in URI objects to `visit`, but
these need to be coerced to a string before actual usage. Most of
visit's code paths would convert the incoming url to a string
as-needed. However, the path used when `always_include_port` is
enabled did not, causing an error where `URI.parse` would try to parse
an existing URI object.

This change consolidates the coercion to string at the entrypoint of
the method.
