### PR TITLE
Update documentation for RSpec 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tags set up for you.
 ## Using Capybara with RSpec
 
 Load RSpec 2.x support by adding the following line (typically to your
-`spec_helper.rb` file):
+`rails_helper.rb` file):
 
 ```ruby
 require 'capybara/rspec'


### PR DESCRIPTION
Would it be helpful to update the instructions for the placement of require 'capybara/rspec'? It might even be helpful just to specify that for RSpec 3.x the new location is rails_helper.rb.

==Edit==
The location can be inferred from the initial setup. Closed issue to refrain from redundancy. 
