### PR TITLE
Increase wait times for window_opened_by spec due to slow Travis CI

### DIFF
--- a/lib/capybara/spec/session/window/window_opened_by_spec.rb
+++ b/lib/capybara/spec/session/window/window_opened_by_spec.rb
@@ -16,10 +16,11 @@ Capybara::SpecHelper.spec '#window_opened_by', requires: [:windows] do
 
   context 'with :wait option' do
     it 'should raise error if value of :wait is less than timeout' do
-      Capybara.using_wait_time 1 do
+      # So large value is used as `driver.window_handles` takes up to 800 ms on Travis
+      Capybara.using_wait_time 2 do
         expect do
-          @session.window_opened_by(wait: 0.4) do
-            @session.find(:css, '#openWindowWithTimeout').click
+          @session.window_opened_by(wait: 0.8) do
+            @session.find(:css, '#openWindowWithLongerTimeout').click
           end
         end.to raise_error(Capybara::WindowError, zero_windows_message)
       end

--- a/lib/capybara/spec/views/with_windows.erb
+++ b/lib/capybara/spec/views/with_windows.erb
@@ -16,6 +16,13 @@
         return false;
       });
 
+      $('#openWindowWithLongerTimeout').click(function(){
+        setTimeout(function(){
+          window.open('/popup_one', 'firstPopup');
+        }, 1400);
+        return false;
+      });
+
       $('#openTwoWindows').click(function() {
         window.open('/popup_one', 'firstPopup');
         window.open('/popup_two', 'secondPopup');
@@ -28,6 +35,8 @@
     <button id="openWindow">Open new window</button>
 
     <button id="openWindowWithTimeout">Open new window with timeout</button>
+
+    <button id="openWindowWithLongerTimeout">Open new window with longer timeout</button>
 
     <button id="openTwoWindows">Open two windows</button>
 


### PR DESCRIPTION
To debug Travis failures I added once the following to `window_opened_by` method when running tests on Travis:

``` ruby
require 'benchmark'
time = Benchmark.realtime do
  driver.window_handles
end
puts time * 1000
```

On my machine it executes from 3 to 140 ms. On Travis it took ~760 ms once - https://travis-ci.org/jnicklas/capybara/jobs/33410167#L492 so spec failed.

So I changed that failing spec so it won't fail if takes so long. Probably it would be needed to increase it even more.
