### PR TITLE
Fix incorrect password in RSpec example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can now write your specs like so:
 ```ruby
 describe "the signin process", :type => :feature do
   before :each do
-    User.make(:email => 'user@example.com', :password => 'caplin')
+    User.make(:email => 'user@example.com', :password => 'password')
   end
 
   it "signs me in" do


### PR DESCRIPTION
The example given for a successful sign in test was incorrect as the password for the created user and the password to sign in did not match. Thanks to @amelialaundy for the catch while going over the docs.
