### PR TITLE
Use Rack::Lock to prevent concurrency when eager_load is false

### DIFF
--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -2,6 +2,12 @@ require 'capybara'
 require 'capybara/dsl'
 
 Capybara.app = Rack::Builder.new do
+  # Work around an issue where rails allows concurrency in test mode even though eager_load
+  # is false which can cause an issue with constant loading
+  if Gem::Version.new(Rails.version) >= Gem::Version.new("4.0")
+    use Rack::Lock unless Rails.application.config.eager_load || Rails.application.middleware.include?(Rack::Lock)
+  end
+  
   map "/" do
     if Gem::Version.new(Rails.version) >= Gem::Version.new("3.0")
       run Rails.application


### PR DESCRIPTION
Rails doesn't insert Rack::Lock into the middleware when config.cache_classes is true, even if config.eager_load is false (the default Rails test environment settings).   This causes an issue since it allows WEBrick to handle multiple requests at once which can cause concurrency issues around constant loading. See - https://github.com/rails/rails/issues/15089
