### PR TITLE
Enable the #fscenario example alias

### DIFF
--- a/lib/capybara/rspec/features.rb
+++ b/lib/capybara/rspec/features.rb
@@ -11,7 +11,7 @@ if RSpec::Core::Version::STRING.to_f >= 3.0
     config.alias_example_group_to :feature, :capybara_feature => true, :type => :feature
     config.alias_example_to :scenario
     config.alias_example_to :xscenario, :skip => "Temporarily disabled with xscenario"
-    # config.alias_example_to :fscenario, :focus => true
+    config.alias_example_to :fscenario, :focus => true
   end
 else
   module Capybara


### PR DESCRIPTION
Not sure why it's disabled, but since I expected to find it working I think it would be useful to enable it

cc: @twalpole (6c0674db9bb6896d4ced8f8ab12fc0e3eec6d71e)
