### PR TITLE
Replace hardcoded `localhost` in spec helper

### DIFF
--- a/lib/capybara/spec/session/visit_spec.rb
+++ b/lib/capybara/spec/session/visit_spec.rb
@@ -22,7 +22,7 @@ Capybara::SpecHelper.spec '#visit' do
     @session.visit('/foo/bar')
     root_uri = URI.parse(@session.current_url)
 
-    @session.visit("http://localhost:#{root_uri.port}")
+    @session.visit("http://#{root_uri.host}:#{root_uri.port}")
     expect(@session).to have_content('Hello world!')
   end
 


### PR DESCRIPTION
Hi, one of the maintainers of capybara-mechanize here. This test had a hardcoded values for the URI to visit which varies for different test cases. When these specs are integrated in custom driver's test suite like capybara-mechanize, it leads to failures. In addition, the remainder of the tests in this file also use `root_uri.host` rather than `localhost`.

This replaces #1227, which was rejected for changing the original purpose of the test. However, this patch only changes the hardcoding. It will allow https://github.com/jeroenvandijk/capybara-mechanize/issues/55 to proceed and bump it's compatibility to beyond capybara 2.1.

Thanks!
