### PR TITLE
move include method from ActionDispatch::MiddlewareStack to array of middlewares

### DIFF
--- a/lib/capybara/rails.rb
+++ b/lib/capybara/rails.rb
@@ -5,7 +5,7 @@ Capybara.app = Rack::Builder.new do
   # Work around an issue where rails allows concurrency in test mode even though eager_load
   # is false which can cause an issue with constant loading
   if Gem::Version.new(Rails.version) >= Gem::Version.new("4.0")
-    use Rack::Lock unless Rails.application.config.allow_concurrency || Rails.application.config.eager_load || Rails.application.middleware.include?(Rack::Lock)
+    use Rack::Lock unless Rails.application.config.allow_concurrency || Rails.application.config.eager_load || Rails.application.middleware.middlewares.include?(Rack::Lock)
   end
   
   map "/" do


### PR DESCRIPTION
I have a rails 4.1.1 application and integration tests.
And now i decide to update my capybara version to last at this moment (2.4.3)
My tests failed with 
NoMethodError: undefined method `include?' for #Rails::Configuration::MiddlewareStackProxy:0x00000003218128
This PR fixes this.
