### PR TITLE
Allow specification of expression filters outside the main selector expression

### DIFF
--- a/lib/capybara/selector/expression_filter.rb
+++ b/lib/capybara/selector/expression_filter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'capybara/selector/filter'
+
+module Capybara
+  class Selector
+    class ExpressionFilter < Filter
+      undef_method :matches?
+
+      def apply_filter(expr, value)
+        return expr if skip?(value)
+
+        if !valid_value?(value)
+          msg = "Invalid value #{value.inspect} passed to expression filter #{@name} - "
+          if default?
+            warn msg + "defaulting to #{default}"
+            value = default
+          else
+            warn msg + "skipping"
+            return expr
+          end
+        end
+
+        @block.call(expr, value)
+      end
+    end
+
+    class IdentityExpressionFilter < ExpressionFilter
+      def initialize
+      end
+
+      def default?
+        false
+      end
+
+      def apply_filter(expr, _value)
+        return expr
+      end
+    end
+  end
+end

--- a/spec/filter_set_spec.rb
+++ b/spec/filter_set_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Capybara::Selector::FilterSet do
+  after do
+    Capybara::Selector::FilterSet.remove(:test)
+  end
+
+  it "allows node filters" do
+    fs = Capybara::Selector::FilterSet.add(:test) do
+      filter(:node_test, :boolean) { |node, value| true }
+      expression_filter(:expression_test, :boolean) { |expr, value| true }
+    end
+
+    expect(fs.node_filters.keys).to include(:node_test)
+    expect(fs.node_filters.keys).not_to include(:expression_test)
+  end
+
+  it "allows expression filters" do
+    fs = Capybara::Selector::FilterSet.add(:test) do
+      filter(:node_test, :boolean) { |node, value| true }
+      expression_filter(:expression_test, :boolean) { |expr, value| true }
+    end
+
+    expect(fs.expression_filters.keys).to include(:expression_test)
+    expect(fs.expression_filters.keys).not_to include(:node_test)
+  end
+end

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Capybara do
             <input type="hidden" id="hidden_field" value="this is hidden"/>
             <a href="#">link</a>
             <fieldset></fieldset>
-            <select>
+            <select id="select">
               <option value="a">A</option>
               <option value="b" disabled>B</option>
               <option value="c" selected>C</option>
@@ -177,6 +177,7 @@ RSpec.describe Capybara do
 
         it "finds by type" do
           expect(string.find(:field, type: 'file')[:id]).to eq 'file'
+          expect(string.find(:field, type: 'select')[:id]).to eq 'select'
         end
       end
 


### PR DESCRIPTION
Allow to keep expression filter definitions more modular by allowing declaration outside of the main selector expression - work in progress
