### PR TITLE
Add `:last` match strategy

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ Release date: unreleased
 * Options for clearing session/local storage on reset added to the Selenium driver
 * Window size changes wait for the size to stabilize
 * Defined return value for most actions
+* Can specify `:last` to return the last matching node [Craig Buchek]
 
 ### Fixed
 * Ignore specific error when qutting selenium driver instance - Issue #1773 [Dylan Reichstadt, Thomas Walpole]

--- a/README.md
+++ b/README.md
@@ -698,16 +698,17 @@ click_link("Password", exact: false) # can be overridden
 
 Using `Capybara.match` and the equivalent `match` option, you can control how
 Capybara behaves when multiple elements all match a query. There are currently
-four different strategies built into Capybara:
+five different strategies built into Capybara:
 
 1. **first:** Just picks the first element that matches.
-2. **one:** Raises an error if more than one element matches.
-3. **smart:** If `exact` is `true`, raises an error if more than one element
+2. **last:** Just picks the last element that matches.
+3. **one:** Raises an error if more than one element matches.
+4. **smart:** If `exact` is `true`, raises an error if more than one element
    matches, just like `one`. If `exact` is `false`, it will first try to find
    an exact match. An error is raised if more than one element is found. If no
    element is found, a new search is performed which allows partial matches. If
    that search returns multiple matches, an error is raised.
-4. **prefer_exact:** If multiple matches are found, some of which are exact,
+5. **prefer_exact:** If multiple matches are found, some of which are exact,
    and some of which are not, then the first exactly matching element is
    returned.
 

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -273,7 +273,7 @@ module Capybara
       # @param [String] locator       Which field to attach the file to
       # @param [String] path          The path of the file that will be attached, or an array of paths
       #
-      # @option options [Symbol] match (Capybara.match)     The matching strategy to use (:one, :first, :prefer_exact, :smart).
+      # @option options [Symbol] match (Capybara.match)     The matching strategy to use (:one, :first, :last, :prefer_exact, :smart).
       # @option options [Boolean] exact (Capybara.exact)    Match the exact label name/contents or accept a partial match.
       # @option options [Boolean] multiple Match field which allows multiple file selection
       # @option options [String] id             Match fields that match the id attribute

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -43,7 +43,7 @@ module Capybara
           if result.empty?
             raise Capybara::ElementNotFound.new("Unable to find #{query.description}")
           end
-          result.first
+          (query.match == :last) ? result.last : result.first
         end.tap(&:allow_reload!)
       end
 

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -5,7 +5,7 @@ module Capybara
       attr_accessor :selector, :locator, :options, :expression, :find, :negative
 
       VALID_KEYS = COUNT_KEYS + [:text, :id, :class, :visible, :exact, :match, :wait, :filter_set]
-      VALID_MATCH = [:first, :smart, :prefer_exact, :one]
+      VALID_MATCH = [:first, :last, :smart, :prefer_exact, :one]
 
       def initialize(*args, &filter_block)
         @options = if args.last.is_a?(Hash) then args.pop.dup else {} end

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -276,6 +276,17 @@ Capybara::SpecHelper.spec '#find' do
       end
     end
 
+    context "when set to `last`" do
+      it "returns the last matched element" do
+        expect(@session.find(:css, ".multiple", match: :last).text).to eq("multiple two")
+      end
+      it "raises an error if there is no match" do
+        expect do
+          @session.find(:css, ".does-not-exist", match: :last)
+        end.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+
     context "when set to `smart`" do
       context "and `exact` set to `false`" do
         it "raises an error when there are multiple exact matches" do


### PR DESCRIPTION
I ran into a situation where I've got multiple matching nodes for a query, and always need to pick the last one. I added this as a patch to my tests, and figured I'd clean it up for upstream, as others might find it useful.