### PR TITLE
Ignore connection error when quitting

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -254,12 +254,15 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     message
   end
 
+  CONNECTION_ERROR_TEXT_FIREFOX = /Error communicating with the remote browser/
+  CONNECTION_ERROR_TEXT_MARIONETTE = /Failed to decode response from marionette/
+
   def quit
     @browser.quit if @browser
   rescue Errno::ECONNREFUSED
     # Browser must have already gone
   rescue Selenium::WebDriver::Error::UnknownError => e
-    raise unless e.message =~ /Error communicating with the remote browser/
+    raise unless e.message =~ CONNECTION_ERROR_TEXT_FIREFOX || e.message =~ CONNECTION_ERROR_TEXT_MARIONETTE
     # probably already gone
   ensure
     @browser = nil

--- a/spec/selenium_spec_firefox.rb
+++ b/spec/selenium_spec_firefox.rb
@@ -62,6 +62,31 @@ RSpec.describe Capybara::Selenium::Driver do
       #access instance variable directly so we don't create a new browser instance
       expect(@driver.instance_variable_get(:@browser)).to be_nil
     end
+
+    it "ignores an error communicating with browser because it is probably already gone" do
+      allow(@driver.browser).to(
+        receive(:quit)
+        .and_raise(Selenium::WebDriver::Error::UnknownError, described_class::CONNECTION_ERROR_TEXT_FIREFOX)
+      )
+
+      expect {
+        @driver.quit
+      }.not_to raise_error
+      expect(@driver.instance_variable_get(:@browser)).to be_nil
+    end
+
+
+    it "does not ignore other errors" do
+      allow(@driver.browser).to(
+        receive(:quit)
+        .and_raise(Selenium::WebDriver::Error::UnknownError, 'alarm!')
+      )
+
+      expect {
+        @driver.quit
+      }.to raise_error(Selenium::WebDriver::Error::UnknownError, 'alarm!')
+      expect(@driver.instance_variable_get(:@browser)).to be_nil
+    end
   end
 end
 

--- a/spec/selenium_spec_marionette.rb
+++ b/spec/selenium_spec_marionette.rb
@@ -52,6 +52,30 @@ RSpec.describe Capybara::Selenium::Driver do
       #access instance variable directly so we don't create a new browser instance
       expect(@driver.instance_variable_get(:@browser)).to be_nil
     end
+
+    it "ignores an error communicating with browser because it is probably already gone" do
+      allow(@driver.browser).to(
+        receive(:quit)
+        .and_raise(Selenium::WebDriver::Error::UnknownError, described_class::CONNECTION_ERROR_TEXT_MARIONETTE)
+      )
+
+      expect {
+        @driver.quit
+      }.not_to raise_error
+      expect(@driver.instance_variable_get(:@browser)).to be_nil
+    end
+
+    it "does not ignore other errors" do
+      allow(@driver.browser).to(
+        receive(:quit)
+        .and_raise(Selenium::WebDriver::Error::UnknownError, 'alarm!')
+      )
+
+      expect {
+        @driver.quit
+      }.to raise_error(Selenium::WebDriver::Error::UnknownError, 'alarm!')
+      expect(@driver.instance_variable_get(:@browser)).to be_nil
+    end
   end
 
   context "storage" do


### PR DESCRIPTION
It looks like the message for marionette is different than for the old version. Because of this, when Firefox shuts down too quickly, the "unknown error" thrown by the driver will make the entire RSpec test suite fail.

The issue can be reproduced using:
* capybara 2.10.1
* selenium-webdriver 3.0.1
* geckodriver 0.11.1
* firefox 49.0.1
* Ubuntu 14.04 (tested on both Ubuntu and Mac OS, but the issue only appears on Ubuntu).
