### PR TITLE
Prevent bad uri errors

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -168,7 +168,8 @@ module Capybara
     # @return [String] Path of the current page, without any domain information
     #
     def current_path
-      path = URI.parse(current_url).path
+      encoded_url = URI.encode(current_url)
+      path = URI.parse(encoded_url).path
       path if path and not path.empty?
     end
 


### PR DESCRIPTION
When using the gem [capybara-screenshot](https://github.com/mattheworiordan/capybara-screenshot), sometimes I get a BadURI error, because the current URL of the application has the following form:

`http://someNormalUrl/some_normal_path/some_id##other_stuff` (Note the two hashes)

When there is this type of url capybara throws the error and the screenshot is not saved, which is bad because we want the screenshot to understand what is going on. It still shows the cause of the error and everything else runs normally, but with no screenshot.

This fix prevents the badURI error and allows to save the screenshot. All tests are passing as well, but I am honestly not sure wether this can have more impact on the execution of capybara.