### PR TITLE
save_page saves the CSS and images

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -34,6 +34,21 @@ module Capybara
 
     ##
     #
+    # Updates the HTML before writing it to the temp file.
+    #
+    # @param [String] html                HTML code to inject into
+    # @param [Capybara::Session] session  current Capybara session
+    # @return [String]                    The modified HTML code
+    #
+    def finalise_html(html, session)
+      html = inject_asset_host(html)
+      html = inject_css_as_internal(html, session)
+      html = inject_html_images_as_base64(html, session)
+      inject_css_images_as_base64(html, session)
+    end
+
+    ##
+    #
     # Injects a `<base>` tag into the given HTML code, pointing to
     # `Capybara.asset_host`.
     #
@@ -45,6 +60,79 @@ module Capybara
         match = html.match(/<head[^<]*?>/)
         if match
           return html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
+        end
+      end
+
+      html
+    end
+
+    ##
+    #
+    # Injects the CSS fetched from the <link rel="stylesheet" ... /> as internal
+    # CSS in the HTML
+    #
+    # @param [String] html                HTML code to inject into
+    # @param [Capybara::Session] session  current Capybara session
+    # @return [String]                    The modified HTML code
+    #
+    def inject_css_as_internal(html, session)
+      rel_stylesheet = Nokogiri::HTML(html).css('link[rel="stylesheet"]')
+                                           .attr('href').value
+      session.visit(rel_stylesheet)
+      css = session.driver.html
+
+      html.gsub(%r{</head>}, "<style>#{css}</style></style>")
+    end
+
+    ##
+    #
+    #
+    # Injects a Base64 version of the images in the <img> src attribute in the
+    # HTML.
+    # @param [String] html                HTML code to inject into
+    # @param [Capybara::Session] session  current Capybara session
+    # @return [String]                    The modified HTML code
+    #
+    def inject_html_images_as_base64(html, session)
+      image_sources = Nokogiri::HTML(html).css('img').map do |img|
+                        img.attr('src')
+                      end
+      image_sources.each do |img_src|
+        begin
+          session.visit(img_src)
+          regex = %r{#{img_src}}
+          image_base64 = Base64.encode64(session.driver.html)
+          image_data = "data:image/gif;base64,#{image_base64}"
+          html.gsub!(regex, image_data)
+        rescue ActionController::RoutingError
+          # Image cannot be downloaded, just ignore it.
+        end
+      end
+
+      html
+    end
+
+    ##
+    #
+    # Injects a Base64 version of the images in the background:url() CSS rule
+    # in the internal CSS.
+    # @see #inject_css_as_internal
+    #
+    # @param [String] html                HTML code to inject into
+    # @param [Capybara::Session] session  current Capybara session
+    # @return [String]                    The modified HTML code
+    #
+    def inject_css_images_as_base64(html, session)
+      image_urls = html.scan(/background(?:-image)?:\s?url\(([\/A-z\.\-0-9]+)\)/)
+      image_urls.flatten.each do |img_url|
+        begin
+          session.visit(img_url)
+          regex = %r{#{img_url}}
+          image_base64 = Base64.encode64(session.driver.html).gsub(%r{\n}, '')
+          image_data = "data:image/gif;base64,#{image_base64}"
+          html.gsub!(regex, image_data)
+        rescue ActionController::RoutingError
+          # Image cannot be downloaded, just ignore it.
         end
       end
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -695,7 +695,7 @@ module Capybara
     #
     def save_page(path = nil)
       path = prepare_path(path, 'html')
-      File.write(path, Capybara::Helpers.inject_asset_host(body), mode: 'wb')
+      File.write(path, Capybara::Helpers.finalise_html(body, self), mode: 'wb')
       path
     end
 


### PR DESCRIPTION
This commit injects the CSS as internal, and the images as Base64 allowing to have an HTML screenshot looking much better.

Regarding the code, I don't like to pass the session as parameter to the helper methods, but it was even worst to me to have those methods in the `Capybara::Session` class. I was tempted to create a `Capybara::HtmlTransformer` class which would embed this code and called from the `Capybara::Session`.

Can someone (@twalpole maybe?) tells me the way I should implement this better (if needed)?