### PR TITLE
Integer Unification for Ruby 2.4.0+

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -244,7 +244,7 @@ module Capybara
     # manually.
     #
     # @param [Rack Application] app    The rack application to run
-    # @param [Fixnum] port              The port to run the application on
+    # @param [Integer] port              The port to run the application on
     #
     def run_default_server(app, port)
       servers[:webrick].call(app, port, server_host)

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -108,7 +108,7 @@ Capybara::SpecHelper.spec '#find' do
     it "should use the selector when it matches the :for option" do
       Capybara.add_selector(:beatle) do
         xpath { |num| ".//*[contains(@class, 'beatle')][#{num}]" }
-        match { |value| value.is_a?(Fixnum) }
+        match { |value| value.is_a?(Integer) }
       end
       expect(@session.find(:beatle, '2').text).to eq('Paul')
       expect(@session.find(1).text).to eq('John')

--- a/lib/capybara/window.rb
+++ b/lib/capybara/window.rb
@@ -71,7 +71,7 @@ module Capybara
     # Get window size.
     #
     # @macro about_current
-    # @return [Array<(Fixnum, Fixnum)>] an array with width and height
+    # @return [Array<(Integer, Integer)>] an array with width and height
     #
     def size
       @driver.window_size(handle)

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -372,7 +372,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
           end.to raise_error('expected to find text matching /No such Text/ in "Text"')
         end
 
-        it "casts Fixnum to string" do
+        it "casts Integer to string" do
           expect do
             expect("<h1>Text</h1>").to have_text(3)
           end.to raise_error(/expected to find text "3" in "Text"/)


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Just modified `Fixnum` to `Integer`. As a result of that will fix `warning: constant ::Fixnum is deprecated` warning in Ruby 2.4.0+.

Thanks.