### PR TITLE
Allow for per-session configuration of relevant global options for "thread safety"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can read more about the missing features [here](https://github.com/teamcapyb
 - [Beware the XPath // trap](#beware-the-xpath--trap)
 - [Configuring and adding drivers](#configuring-and-adding-drivers)
 - [Gotchas:](#gotchas)
+- ["Threadsafe" mode](#threadsafe)
 - [Development](#development)
 
 ## <a name="key-benefits"></a>Key benefits
@@ -1047,6 +1048,31 @@ additional info about how the underlying driver can be configured.
 * Server errors will only be raised in the session that initiates the server thread. If you
   are testing for specific server errors and using multiple sessions make sure to test for the
   errors using the initial session (usually :default)
+
+## <a name="threadsafe"></a>"Threadsafe" mode - BETA - may change
+
+In normal mode most of Capybara's configuration options are global settings which can cause issues
+if using multiple sessions and wanting to change a setting for only one of the sessions.  To provide
+support for this type of usage Capybara now provides a "threadsafe" mode which can be enabled by setting
+
+    Capybara.threadsafe = true
+
+This setting can only be changed before any sessions have been created.  In "threadsafe" mode the following
+behaviors of Capybara change
+
+* Most options can now be set on a session.  These can either be set at session creation time or after, and
+  default to the global options at the time of session creation.  Options which are NOT session specific are
+  `app`, `reuse_server`, `default_driver`, `javascript_driver`, and (obviously) `threadsafe`.  Any drivers and servers
+  registered through `register_driver` and `register_server` are also global.
+
+      my_session = Capybara::Session.new(:driver, some_app) do |config|
+        config.automatic_label_click = true # only set for my_session
+      end
+      my_session.config.default_max_wait_time = 10 # only set for my_session
+      Capybara.default_max_wait_time = 2 # will not change the default_max_wait in my_session
+
+* `current_driver` and `session_name` are thread specific.  This means that `using_session' and
+  `using_driver` also only affect the current thread.
 
 ## <a name="development"></a>Development
 

--- a/lib/capybara/config.rb
+++ b/lib/capybara/config.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+require 'forwardable'
+require 'capybara/session/config'
+
+module Capybara
+  class Config
+    extend Forwardable
+
+    OPTIONS = [:app, :reuse_server, :threadsafe, :default_wait_time, :server, :default_driver, :javascript_driver]
+
+    attr_accessor :app
+    attr_reader :reuse_server, :threadsafe
+    attr_reader :session_options
+    attr_writer :default_driver, :javascript_driver
+
+    SessionConfig::OPTIONS.each do |method|
+      def_delegators :session_options, method, "#{method}="
+    end
+
+    def initialize
+      @session_options = Capybara::SessionConfig.new
+    end
+
+    def reuse_server=(bool)
+      @reuse_server = bool
+    end
+
+    def threadsafe=(bool)
+      warn "Capybara.threadsafe == true is a BETA feature and may change in future minor versions" if bool
+      raise "Threadsafe setting cannot be changed once a session is created" if (bool != threadsafe) && Session.instance_created?
+      @threadsafe = bool
+    end
+
+    ##
+    #
+    # Return the proc that Capybara will call to run the Rack application.
+    # The block returned receives a rack app, port, and host/ip and should run a Rack handler
+    # By default, Capybara will try to run webrick.
+    #
+    def server(&block)
+      if block_given?
+        warn "DEPRECATED: Passing a block to Capybara::server is deprecated, please use Capybara::register_server instead"
+        @server = block
+      else
+        @server
+      end
+    end
+
+    ##
+    #
+    # Set the server to use.
+    #
+    #     Capybara.server = :webrick
+    #
+    # @param [Symbol] name     Name of the server type to use
+    # @see register_server
+    #
+    def server=(name)
+      @server = if name.respond_to? :call
+        name
+      else
+        Capybara.servers[name.to_sym]
+      end
+    end
+
+    ##
+    #
+    # @return [Symbol]    The name of the driver to use by default
+    #
+    def default_driver
+      @default_driver || :rack_test
+    end
+
+    ##
+    #
+    # @return [Symbol]    The name of the driver used when JavaScript is needed
+    #
+    def javascript_driver
+      @javascript_driver || :selenium
+    end
+
+    # @deprecated Use default_max_wait_time instead
+    def default_wait_time
+      deprecate('default_wait_time', 'default_max_wait_time', true)
+      default_max_wait_time
+    end
+
+    # @deprecated Use default_max_wait_time= instead
+    def default_wait_time=(t)
+      deprecate('default_wait_time=', 'default_max_wait_time=')
+      self.default_max_wait_time = t
+    end
+
+    def deprecate(method, alternate_method, once=false)
+      @deprecation_notified ||= {}
+      warn "DEPRECATED: ##{method} is deprecated, please use ##{alternate_method} instead" unless once and @deprecation_notified[method]
+      @deprecation_notified[method]=true
+    end
+  end
+
+  class ConfigureDeprecator
+    def initialize(config)
+      @config = config
+    end
+
+    def method_missing(m, *args, &block)
+      if @config.respond_to?(m)
+        @config.public_send(m, *args, &block)
+      elsif Capybara.respond_to?(m)
+        warn "Calling #{m} from Capybara.configure is deprecated - please call it on Capybara directly ( Capybara.#{m}(...) )"
+        Capybara.public_send(m, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(m, include_private = false)
+      @config.respond_to_missing?(m, include_private) || Capybara.respond_to_missing?(m, include_private)
+    end
+  end
+end

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Capybara::Driver::Base
+  attr_writer :session_options
+
   def current_url
     raise NotImplementedError
   end
@@ -137,6 +139,10 @@ class Capybara::Driver::Base
 
   def needs_server?
     false
+  end
+
+  def session_options
+    @session_options || Capybara.session_options
   end
 
   # @deprecated This method is being removed

--- a/lib/capybara/dsl.rb
+++ b/lib/capybara/dsl.rb
@@ -21,12 +21,10 @@ module Capybara
       Capybara.using_session(name, &block)
     end
 
-    ##
-    #
     # Shortcut to using a different wait time.
     #
     def using_wait_time(seconds, &block)
-      Capybara.using_wait_time(seconds, &block)
+      page.using_wait_time(seconds, &block)
     end
 
     ##

--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -46,11 +46,11 @@ module Capybara
     # @param [String] html     HTML code to inject into
     # @return [String]         The modified HTML code
     #
-    def inject_asset_host(html)
-      if Capybara.asset_host && Nokogiri::HTML(html).css("base").empty?
+    def inject_asset_host(html, asset_host = Capybara.asset_host)
+      if asset_host && Nokogiri::HTML(html).css("base").empty?
         match = html.match(/<head[^<]*?>/)
         if match
-          return html.clone.insert match.end(0), "<base href='#{Capybara.asset_host}' />"
+          return html.clone.insert match.end(0), "<base href='#{asset_host}' />"
         end
       end
 

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -293,9 +293,9 @@ module Capybara
 
       def _check_with_label(selector, checked, locator, options)
         locator, options = nil, locator if locator.is_a? Hash
-        allow_label_click = options.delete(:allow_label_click) { Capybara.automatic_label_click }
+        allow_label_click = options.delete(:allow_label_click) { session_options.automatic_label_click }
 
-        synchronize(Capybara::Queries::BaseQuery::wait(options)) do
+        synchronize(Capybara::Queries::BaseQuery.wait(options, session_options.default_max_wait_time)) do
           begin
             el = find(selector, locator, options)
             el.set(checked)

--- a/lib/capybara/node/base.rb
+++ b/lib/capybara/node/base.rb
@@ -74,7 +74,7 @@ module Capybara
       # @return [Object]                  The result of the given block
       # @raise  [Capybara::FrozenInTime]  If the return value of `Time.now` appears stuck
       #
-      def synchronize(seconds=Capybara.default_max_wait_time, options = {})
+      def synchronize(seconds=session_options.default_max_wait_time, options = {})
         start_time = Capybara::Helpers.monotonic_time
 
         if session.synchronized
@@ -90,7 +90,7 @@ module Capybara
             raise e if (Capybara::Helpers.monotonic_time - start_time) >= seconds
             sleep(0.05)
             raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if Capybara::Helpers.monotonic_time == start_time
-            reload if Capybara.automatic_reload
+            reload if session_options.automatic_reload
             retry
           ensure
             session.synchronized = false
@@ -112,6 +112,11 @@ module Capybara
       def parent
         warn "DEPRECATED: #parent is deprecated in favor of #query_scope - Note: #parent was not the elements parent in the document so it's most likely not what you wanted anyway"
         query_scope
+      end
+
+      # @api private
+      def session_options
+        session.config
       end
 
     protected

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -55,7 +55,7 @@ module Capybara
       # @return [String]              The text of the element
       #
       def text(type=nil)
-        type ||= :all unless Capybara.ignore_hidden_elements or Capybara.visible_text_only
+        type ||= :all unless session_options.ignore_hidden_elements or session_options.visible_text_only
         synchronize do
           if type == :all
             base.all_text

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -114,8 +114,8 @@ module Capybara
       #
       def assert_all_of_selectors(*args, &optional_filter_block)
         options = if args.last.is_a?(Hash) then args.pop.dup else {} end
-        selector = if args.first.is_a?(Symbol) then args.shift else Capybara.default_selector end
-        wait = options.fetch(:wait, Capybara.default_max_wait_time)
+        selector = if args.first.is_a?(Symbol) then args.shift else session_options.default_selector end
+        wait = options.fetch(:wait, session_options.default_max_wait_time)
         synchronize(wait) do
           args.each do |locator|
             assert_selector(selector, locator, options, &optional_filter_block)
@@ -140,8 +140,8 @@ module Capybara
       #
       def assert_none_of_selectors(*args, &optional_filter_block)
         options = if args.last.is_a?(Hash) then args.pop.dup else {} end
-        selector = if args.first.is_a?(Symbol) then args.shift else Capybara.default_selector end
-        wait = options.fetch(:wait, Capybara.default_max_wait_time)
+        selector = if args.first.is_a?(Symbol) then args.shift else session_options.default_selector end
+        wait = options.fetch(:wait, session_options.default_max_wait_time)
         synchronize(wait) do
           args.each do |locator|
             assert_no_selector(selector, locator, options, &optional_filter_block)
@@ -680,6 +680,7 @@ module Capybara
     private
 
       def _verify_selector_result(query_args, optional_filter_block, &result_block)
+        _set_query_session_options(query_args)
         query = Capybara::Queries::SelectorQuery.new(*query_args, &optional_filter_block)
         synchronize(query.wait) do
           result = query.resolve_for(self)
@@ -689,6 +690,7 @@ module Capybara
       end
 
       def _verify_match_result(query_args, optional_filter_block, &result_block)
+        _set_query_session_options(query_args)
         query = Capybara::Queries::MatchQuery.new(*query_args, &optional_filter_block)
         synchronize(query.wait) do
           result = query.resolve_for(self.query_scope)
@@ -698,6 +700,7 @@ module Capybara
       end
 
       def _verify_text(query_args)
+        _set_query_session_options(query_args)
         query = Capybara::Queries::TextQuery.new(*query_args)
         synchronize(query.wait) do
           count = query.resolve_for(self)
@@ -706,6 +709,14 @@ module Capybara
         return true
       end
 
+      def _set_query_session_options(query_args)
+        if query_args.last.is_a? Hash
+          query_args.last[:session_options] = session_options
+        else
+          query_args.push(session_options: session_options)
+        end
+        query_args
+      end
     end
   end
 end

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -173,6 +173,11 @@ module Capybara
       def find_xpath(xpath)
         native.xpath(xpath)
       end
+
+      # @api private
+      def session_options
+        Capybara.session_options
+      end
     end
   end
 end

--- a/lib/capybara/queries/base_query.rb
+++ b/lib/capybara/queries/base_query.rb
@@ -6,13 +6,18 @@ module Capybara
       COUNT_KEYS = [:count, :minimum, :maximum, :between]
 
       attr_reader :options
+      attr_writer :session_options
 
-      def wait
-        self.class.wait(options)
+      def session_options
+        @session_options || Capybara.session_options
       end
 
-      def self.wait(options)
-        options.fetch(:wait, Capybara.default_max_wait_time) || 0
+      def wait
+        self.class.wait(options, session_options.default_max_wait_time)
+      end
+
+      def self.wait(options, default=Capybara.default_max_wait_time)
+        options.fetch(:wait, default) || 0
       end
 
       ##

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -5,13 +5,18 @@ module Capybara
     class TextQuery < BaseQuery
       def initialize(*args)
         @type = (args.first.is_a?(Symbol) || args.first.nil?) ? args.shift : nil
-        @type = (Capybara.ignore_hidden_elements or Capybara.visible_text_only) ? :visible : :all if @type.nil?
-        @expected_text, @options = args
+        # @type = (Capybara.ignore_hidden_elements or Capybara.visible_text_only) ? :visible : :all if @type.nil?
+        @options = if args.last.is_a?(Hash) then args.pop.dup else {} end
+        self.session_options = @options.delete(:session_options)
+
+        @type = (session_options.ignore_hidden_elements or session_options.visible_text_only) ? :visible : :all if @type.nil?
+
+        @expected_text = args.shift
         unless @expected_text.is_a?(Regexp)
           @expected_text = Capybara::Helpers.normalize_whitespace(@expected_text)
         end
-        @options ||= {}
         @search_regexp = Capybara::Helpers.to_regexp(@expected_text, nil, exact?)
+        warn "Unused parameters passed to #{self.class.name} : #{args.to_s}" unless args.empty?
         assert_valid_keys
       end
 
@@ -40,7 +45,7 @@ module Capybara
       private
 
       def exact?
-        options.fetch(:exact, Capybara.exact_text)
+        options.fetch(:exact, session_options.exact_text)
       end
 
       def build_message(report_on_invisible)

--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -71,7 +71,7 @@ class Capybara::RackTest::Browser
   end
 
   def reset_host!
-    uri = URI.parse(Capybara.app_host || Capybara.default_host)
+    uri = URI.parse(driver.session_options.app_host || driver.session_options.default_host)
     @current_scheme = uri.scheme
     @current_host = uri.host
     @current_port = uri.port

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -139,7 +139,7 @@ Capybara.add_selector(:link) do
                  XPath.string.n.is(locator) |
                  XPath.attr(:title).is(locator) |
                  XPath.descendant(:img)[XPath.attr(:alt).is(locator)]
-      matchers |= XPath.attr(:'aria-label').is(locator) if Capybara.enable_aria_label
+      matchers |= XPath.attr(:'aria-label').is(locator) if options[:enable_aria_label]
       xpath = xpath[matchers]
     end
     xpath = [:title].inject(xpath) { |memo, ef| memo[find_by_attr(ef, options[ef])] }
@@ -185,14 +185,14 @@ Capybara.add_selector(:button) do
     unless locator.nil?
       locator = locator.to_s
       locator_matches = XPath.attr(:id).equals(locator) | XPath.attr(:value).is(locator) | XPath.attr(:title).is(locator)
-      locator_matches |= XPath.attr(:'aria-label').is(locator) if Capybara.enable_aria_label
+      locator_matches |= XPath.attr(:'aria-label').is(locator) if options[:enable_aria_label]
 
       input_btn_xpath = input_btn_xpath[locator_matches]
 
       btn_xpath = btn_xpath[locator_matches | XPath.string.n.is(locator) | XPath.descendant(:img)[XPath.attr(:alt).is(locator)]]
 
       alt_matches = XPath.attr(:alt).is(locator)
-      alt_matches |= XPath.attr(:'aria-label').is(locator) if Capybara.enable_aria_label
+      alt_matches |= XPath.attr(:'aria-label').is(locator) if options[:enable_aria_label]
       image_btn_xpath = image_btn_xpath[alt_matches]
     end
 

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -201,9 +201,9 @@ module Capybara
       @default_visibility = default_visibility
     end
 
-    def default_visibility
+    def default_visibility(fallback = Capybara.ignore_hidden_elements)
       if @default_visibility.nil?
-        Capybara.ignore_hidden_elements
+        fallback
       else
         @default_visibility
       end
@@ -219,7 +219,7 @@ module Capybara
                          XPath.attr(:name).equals(locator) |
                          XPath.attr(:placeholder).equals(locator) |
                          XPath.attr(:id).equals(XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))
-        attr_matchers |= XPath.attr(:'aria-label').is(locator) if Capybara.enable_aria_label
+        attr_matchers |= XPath.attr(:'aria-label').is(locator) if options[:enable_aria_label]
 
         locate_xpath = locate_xpath[attr_matchers]
         locate_xpath += XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(xpath)

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -320,7 +320,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     # Selenium has its own built in wait (2 seconds)for a modal to show up, so this wait is really the minimum time
     # Actual wait time may be longer than specified
     wait = Selenium::WebDriver::Wait.new(
-      timeout: (options[:wait] || Capybara.default_max_wait_time),
+      timeout: options.fetch(:wait, session_options.default_max_wait_time) || 0 ,
       ignore: Selenium::WebDriver::Error::NoAlertPresentError)
     begin
       wait.until do

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -17,6 +17,14 @@ module Capybara
   #     session = Capybara::Session.new(:culerity)
   #     session.visit('http://www.google.com')
   #
+  # When Capybara.threadsafe == true the sessions options will be initially set to the
+  # current values of the global options and a configuration block can be passed to the session initializer.
+  # For available options see {Capybara::SessionConfig::OPTIONS}
+  #
+  #     session = Capybara::Session.new(:driver, MyRackApp) do |config|
+  #       config.app_host = "http://my_host.dev"
+  #     end
+  #
   # Session provides a number of methods for controlling the navigation of the page, such as +visit+,
   # +current_path, and so on. It also delegate a number of methods to a Capybara::Document, representing
   # the current HTML document. This allows interaction:
@@ -69,10 +77,15 @@ module Capybara
 
     def initialize(mode, app=nil)
       raise TypeError, "The second parameter to Session::new should be a rack app if passed." if app && !app.respond_to?(:call)
+      @@instance_created = true
       @mode = mode
       @app = app
-      if Capybara.run_server and @app and driver.needs_server?
-        @server = Capybara::Server.new(@app).boot
+      if block_given?
+        raise "A configuration block is only accepted when Capybara.threadsafe == true" unless Capybara.threadsafe
+        yield config if block_given?
+      end
+      if config.run_server and @app and driver.needs_server?
+        @server = Capybara::Server.new(@app, config.server_port, config.server_host, config.server_errors).boot
       else
         @server = nil
       end
@@ -85,7 +98,9 @@ module Capybara
           other_drivers = Capybara.drivers.keys.map { |key| key.inspect }
           raise Capybara::DriverNotFoundError, "no driver called #{mode.inspect} was found, available drivers: #{other_drivers.join(', ')}"
         end
-        Capybara.drivers[mode].call(app)
+        driver = Capybara.drivers[mode].call(app)
+        driver.session_options = config
+        driver
       end
     end
 
@@ -126,7 +141,7 @@ module Capybara
       if @server and @server.error
         # Force an explanation for the error being raised as the exception cause
         begin
-          if Capybara.raise_server_errors
+          if config.raise_server_errors
             raise CapybaraError, "Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true"
           end
         rescue CapybaraError
@@ -235,10 +250,10 @@ module Capybara
       visit_uri = URI.parse(visit_uri.to_s)
 
       uri_base = if @server
-        visit_uri.port = @server.port if Capybara.always_include_port && (visit_uri.port == visit_uri.default_port)
-        URI.parse(Capybara.app_host || "http://#{@server.host}:#{@server.port}")
+        visit_uri.port = @server.port if config.always_include_port && (visit_uri.port == visit_uri.default_port)
+        URI.parse(config.app_host || "http://#{@server.host}:#{@server.port}")
       else
-        Capybara.app_host && URI.parse(Capybara.app_host)
+        config.app_host && URI.parse(config.app_host)
       end
 
       # TODO - this is only for compatability with previous 2.x behavior that concatenated
@@ -481,7 +496,7 @@ module Capybara
         driver.switch_to_window(window.handle)
         window
       else
-        wait_time = Capybara::Queries::BaseQuery.wait(options)
+        wait_time = Capybara::Queries::BaseQuery.wait(options, config.default_max_wait_time)
         document.synchronize(wait_time, errors: [Capybara::WindowError]) do
           original_window_handle = driver.current_window_handle
           begin
@@ -578,7 +593,7 @@ module Capybara
       old_handles = driver.window_handles
       block.call
 
-      wait_time = Capybara::Queries::BaseQuery.wait(options)
+      wait_time = Capybara::Queries::BaseQuery.wait(options, config.default_max_wait_time)
       document.synchronize(wait_time, errors: [Capybara::WindowError]) do
         opened_handles = (driver.window_handles - old_handles)
         if opened_handles.size != 1
@@ -701,7 +716,7 @@ module Capybara
     #
     def save_page(path = nil)
       path = prepare_path(path, 'html')
-      File.write(path, Capybara::Helpers.inject_asset_host(body), mode: 'wb')
+      File.write(path, Capybara::Helpers.inject_asset_host(body, config.asset_host), mode: 'wb')
       path
     end
 
@@ -786,7 +801,49 @@ module Capybara
       scope
     end
 
+    ##
+    #
+    # Yield a block using a specific wait time
+    #
+    def using_wait_time(seconds)
+      if Capybara.threadsafe
+        begin
+          previous_wait_time = config.default_max_wait_time
+          config.default_max_wait_time = seconds
+          yield
+        ensure
+          config.default_max_wait_time = previous_wait_time
+        end
+      else
+        Capybara.using_wait_time(seconds) { yield }
+      end
+    end
+
+    ##
+    #
+    #  Accepts a block to set the configuration options if Capybara.threadsafe == true. Note that some options only have an effect
+    #  if set at initialization time, so look at the configuration block that can be passed to the initializer too
+    #
+    def configure
+      raise "Session configuration is only supported when Capybara.threadsafe == true" unless Capybara.threadsafe
+      yield config
+    end
+
+    def self.instance_created?
+      @@instance_created
+    end
+
+    def config
+      @config ||= if Capybara.threadsafe
+        Capybara.session_options.dup
+      else
+        Capybara::ReadOnlySessionConfig.new(Capybara.session_options)
+      end
+    end
   private
+
+    @@instance_created = false
+
     def accept_modal(type, text_or_options, options, &blk)
       driver.accept_modal(type, modal_options(text_or_options, options), &blk)
     end
@@ -798,7 +855,7 @@ module Capybara
     def modal_options(text_or_options, options)
       text_or_options, options = nil, text_or_options if text_or_options.is_a?(Hash)
       options[:text] ||= text_or_options unless text_or_options.nil?
-      options[:wait] ||= Capybara.default_max_wait_time
+      options[:wait] ||= config.default_max_wait_time
       options
     end
 
@@ -814,10 +871,10 @@ module Capybara
     end
 
     def prepare_path(path, extension)
-      if Capybara.save_path || Capybara.save_and_open_page_path.nil?
-        path = File.expand_path(path || default_fn(extension), Capybara.save_path)
+      if config.save_path || config.save_and_open_page_path.nil?
+        path = File.expand_path(path || default_fn(extension), config.save_path)
       else
-        path = File.expand_path(default_fn(extension), Capybara.save_and_open_page_path) if path.nil?
+        path = File.expand_path(default_fn(extension), config.save_and_open_page_path) if path.nil?
       end
       FileUtils.mkdir_p(File.dirname(path))
       path

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require 'delegate'
+
+module Capybara
+  class SessionConfig
+    OPTIONS = [:always_include_port, :run_server, :default_selector, :default_max_wait_time, :ignore_hidden_elements,
+               :automatic_reload, :match, :exact, :exact_text, :raise_server_errors, :visible_text_only, :wait_on_first_by_default,
+               :automatic_label_click, :enable_aria_label, :save_path, :exact_options, :asset_host, :default_host, :app_host,
+               :save_and_open_page_path, :server_host, :server_port, :server_errors]
+
+    attr_accessor *OPTIONS
+
+    ##
+    #@!method always_include_port
+    #  See {Capybara#configure}
+    #@!method run_server
+    #  See {Capybara#configure}
+    #@!method default_selector
+    #  See {Capybara#configure}
+    #@!method default_max_wait_time
+    #  See {Capybara#configure}
+    #@!method ignore_hidden_elements
+    #  See {Capybara#configure}
+    #@!method automatic_reload
+    #  See {Capybara#configure}
+    #@!method match
+    #  See {Capybara#configure}
+    #@!method exact
+    #  See {Capybara#configure}
+    #@!method raise_server_errors
+    #  See {Capybara#configure}
+    #@!method visible_text_only
+    #  See {Capybara#configure}
+    #@!method wait_on_first_by_default
+    #  See {Capybara#configure}
+    #@!method automatic_label_click
+    #  See {Capybara#configure}
+    #@!method enable_aria_label
+    #  See {Capybara#configure}
+    #@!method save_path
+    #  See {Capybara#configure}
+    #@!method exact_options
+    #  See {Capybara#configure}
+    #@!method asset_host
+    #  See {Capybara#configure}
+    #@!method default_host
+    #  See {Capybara#configure}
+    #@!method app_host
+    #  See {Capybara#configure}
+    #@!method save_and_open_page_path
+    #  See {Capybara#configure}
+    #@!method server_host
+    #  See {Capybara#configure}
+    #@!method server_port
+    #  See {Capybara#configure}
+    #@!method server_errors
+    #  See {Capybara#configure}
+
+    ##
+    #
+    # @return [String]    The IP address bound by default server
+    #
+    def server_host
+      @server_host || '127.0.0.1'
+    end
+
+    def server_errors=(errors)
+      (@server_errors ||= []).replace(errors.dup)
+    end
+
+    def app_host=(url)
+      raise ArgumentError.new("Capybara.app_host should be set to a url (http://www.example.com)") unless url.nil? || (url =~ URI::Parser.new.make_regexp)
+      @app_host = url
+    end
+
+    def default_host=(url)
+      raise ArgumentError.new("Capybara.default_host should be set to a url (http://www.example.com)") unless url.nil? || (url =~ URI::Parser.new.make_regexp)
+      @default_host = url
+    end
+
+    def save_and_open_page_path=(path)
+      warn "DEPRECATED: #save_and_open_page_path is deprecated, please use #save_path instead. \n"\
+           "Note: Behavior is slightly different with relative paths - see documentation" unless path.nil?
+      @save_and_open_page_path = path
+    end
+
+    def initialize_copy(other)
+      super
+      @server_errors = @server_errors.dup
+    end
+  end
+
+  class ReadOnlySessionConfig < SimpleDelegator
+    SessionConfig::OPTIONS.each do |m|
+      define_method "#{m}=" do |val|
+        raise "Per session settings are only supported when Capybara.threadsafe == true"
+      end
+    end
+  end
+end

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -58,7 +58,7 @@ $(function() {
   $('#change-title').click(function() {
     setTimeout(function() {
       $('title').text('changed title')
-    }, 250)
+    }, 400)
   });
   $('#click-test').on({
     dblclick: function() {

--- a/lib/capybara/spec/session/all_spec.rb
+++ b/lib/capybara/spec/session/all_spec.rb
@@ -66,6 +66,17 @@ Capybara::SpecHelper.spec "#all" do
       Capybara.ignore_hidden_elements = false
       expect(@session.all(:css, "a.simple").size).to eq(2)
     end
+
+    context "with per session config", requires: [:psc] do
+      it "should use the sessions ignore_hidden_elements", psc: true do
+        Capybara.ignore_hidden_elements = true
+        @session.config.ignore_hidden_elements = false
+        expect(Capybara.ignore_hidden_elements).to eq(true)
+        expect(@session.all(:css, "a.simple").size).to eq(2)
+        @session.config.ignore_hidden_elements = true
+        expect(@session.all(:css, "a.simple").size).to eq(1)
+      end
+    end
   end
 
   context 'with element count filters' do

--- a/lib/capybara/spec/session/assert_all_of_selectors_spec.rb
+++ b/lib/capybara/spec/session/assert_all_of_selectors_spec.rb
@@ -18,10 +18,18 @@ Capybara::SpecHelper.spec '#assert_all_of_selectors' do
     @session.assert_all_of_selectors("p a#foo", "h2#h2two", "h2#h2one" )
   end
 
-  it "should respect scopes" do
-    @session.within "//p[@id='first']" do
-      @session.assert_all_of_selectors(".//a[@id='foo']")
-      expect { @session.assert_all_of_selectors(".//a[@id='red']") }.to raise_error(Capybara::ElementNotFound)
+  context "should respect scopes" do
+    it "when used with `within`" do
+      @session.within "//p[@id='first']" do
+        @session.assert_all_of_selectors(".//a[@id='foo']")
+        expect { @session.assert_all_of_selectors(".//a[@id='red']") }.to raise_error(Capybara::ElementNotFound)
+      end
+    end
+
+    it "when called on elements" do
+      el = @session.find "//p[@id='first']"
+      el.assert_all_of_selectors(".//a[@id='foo']")
+      expect { el.assert_all_of_selectors(".//a[@id='red']") }.to raise_error(Capybara::ElementNotFound)
     end
   end
 
@@ -65,10 +73,18 @@ Capybara::SpecHelper.spec '#assert_none_of_selectors' do
     expect { @session.assert_none_of_selectors("abbr", "p a#foo") }.to raise_error(Capybara::ElementNotFound)
   end
 
-  it "should respect scopes" do
-    @session.within "//p[@id='first']" do
-      expect { @session.assert_none_of_selectors(".//a[@id='foo']") }.to raise_error(Capybara::ElementNotFound)
-      @session.assert_none_of_selectors(".//a[@id='red']")
+  context "should respect scopes" do
+    it "when used with `within`" do
+      @session.within "//p[@id='first']" do
+        expect { @session.assert_none_of_selectors(".//a[@id='foo']") }.to raise_error(Capybara::ElementNotFound)
+        @session.assert_none_of_selectors(".//a[@id='red']")
+      end
+    end
+
+    it "when called on an element" do
+      el = @session.find "//p[@id='first']"
+      expect { el.assert_none_of_selectors(".//a[@id='foo']") }.to raise_error(Capybara::ElementNotFound)
+      el.assert_none_of_selectors(".//a[@id='red']")
     end
   end
 

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -421,8 +421,9 @@ Capybara::SpecHelper.spec '#find' do
     end
   end
 
-  it "should warn if selector type is unknown" do
-    expect_any_instance_of(Kernel).to receive(:warn).with(/^Unknown selector type/)
-    @session.find(:unknown, '//h1')
+  it "should raise if selector type is unknown" do
+    expect do
+      @session.find(:unknown, '//h1')
+    end.to raise_error(ArgumentError)
   end
 end

--- a/lib/capybara/spec/session/reset_session_spec.rb
+++ b/lib/capybara/spec/session/reset_session_spec.rb
@@ -88,7 +88,7 @@ Capybara::SpecHelper.spec '#reset_session!' do
   end
 
   it "raises configured errors caught inside the server", requires: [:server] do
-    prev_errors = Capybara.server_errors
+    prev_errors = Capybara.server_errors.dup
 
     Capybara.server_errors = [LoadError]
     quietly { @session.visit("/error") }

--- a/lib/capybara/spec/session/window/become_closed_spec.rb
+++ b/lib/capybara/spec/session/window/become_closed_spec.rb
@@ -60,18 +60,18 @@ Capybara::SpecHelper.spec '#become_closed', requires: [:windows, :js] do
   end
 
   context 'with not_to' do
-    it 'should raise error if default_max_wait_time is more than timeout' do
+    it "should not raise error if window doesn't close before default_max_wait_time" do
       @session.within_window @other_window do
-        @session.execute_script('setTimeout(function(){ window.close(); }, 700);')
+        @session.execute_script('setTimeout(function(){ window.close(); }, 1000);')
       end
-      Capybara.using_wait_time 0.4 do
+      Capybara.using_wait_time 0.3 do
         expect do
           expect(@other_window).not_to become_closed
         end
       end
     end
 
-    it 'should raise error if default_max_wait_time is more than timeout' do
+    it 'should raise error if window closes before default_max_wait_time' do
       @session.within_window @other_window do
         @session.execute_script('setTimeout(function(){ window.close(); }, 700);')
       end

--- a/lib/capybara/window.rb
+++ b/lib/capybara/window.rb
@@ -115,7 +115,7 @@ module Capybara
 
     private
 
-    def wait_for_stable_size(seconds=Capybara.default_max_wait_time)
+    def wait_for_stable_size(seconds=session.config.default_max_wait_time)
       res = yield if block_given?
       prev_size = size
       start_time = Capybara::Helpers.monotonic_time

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Capybara do
     end
 
     it "should be accesible as the deprecated default_wait_time" do
-      expect(Capybara).to receive(:warn).ordered.with('DEPRECATED: #default_wait_time= is deprecated, please use #default_max_wait_time= instead')
-      expect(Capybara).to receive(:warn).ordered.with('DEPRECATED: #default_wait_time is deprecated, please use #default_max_wait_time instead')
+      expect(Capybara.send(:config)).to receive(:warn).ordered.with('DEPRECATED: #default_wait_time= is deprecated, please use #default_max_wait_time= instead')
+      expect(Capybara.send(:config)).to receive(:warn).ordered.with('DEPRECATED: #default_wait_time is deprecated, please use #default_max_wait_time instead')
       @previous_default_time = Capybara.default_max_wait_time
       Capybara.default_wait_time = 5
       expect(Capybara.default_wait_time).to eq(5)
@@ -112,6 +112,18 @@ RSpec.describe Capybara do
 
     it "should not warn if a valid URL" do
       expect { Capybara.default_host = "http://www.example.com" }.not_to raise_error
+    end
+  end
+
+  describe "configure" do
+    it 'deprecates calling non configuration option methods in configure' do
+      expect_any_instance_of(Kernel).to receive(:warn).
+        with('Calling register_driver from Capybara.configure is deprecated - please call it on Capybara directly ( Capybara.register_driver(...) )')
+      Capybara.configure do |config|
+        config.register_driver(:random_name) do
+          #just a random block
+        end
+      end
     end
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -16,6 +16,7 @@ Capybara::SpecHelper.run_specs TestClass.new, "DSL", capybara_skip: [
   :server,
   :hover,
   :about_scheme,
+  :psc
 ]
 
 RSpec.describe Capybara::DSL do

--- a/spec/per_session_config_spec.rb
+++ b/spec/per_session_config_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'capybara/dsl'
+
+RSpec.describe Capybara::SessionConfig do
+  describe "threadsafe" do
+    it "defaults to global session options" do
+      Capybara.threadsafe = true
+      session = Capybara::Session.new(:rack_test, TestApp)
+      [:default_host, :app_host, :save_and_open_page_path,
+       :always_include_port, :run_server, :default_selector, :default_max_wait_time, :ignore_hidden_elements,
+       :automatic_reload, :match, :exact, :raise_server_errors, :visible_text_only, :wait_on_first_by_default,
+       :automatic_label_click, :enable_aria_label,
+       :save_path, :exact_options, :asset_host].each do |m|
+         expect(session.config.public_send(m)).to eq Capybara.public_send(m)
+       end
+    end
+
+    it "doesn't change global session when changed" do
+      Capybara.threadsafe = true
+      host = "http://my.example.com"
+      session = Capybara::Session.new(:rack_test, TestApp) do |config|
+        config.default_host = host
+        config.automatic_label_click = !config.automatic_label_click
+        config.server_errors << ArgumentError
+      end
+      expect(Capybara.default_host).not_to eq host
+      expect(session.config.default_host).to eq host
+      expect(Capybara.automatic_label_click).not_to eq session.config.automatic_label_click
+      expect(Capybara.server_errors).not_to eq session.config.server_errors
+    end
+
+    it "doesn't allow session configuration block when false" do
+      Capybara.threadsafe = false
+      expect do
+        Capybara::Session.new(:rack_test, TestApp) { |config| }
+      end.to raise_error "A configuration block is only accepted when Capybara.threadsafe == true"
+    end
+
+    it "doesn't allow session config when false" do
+      Capybara.threadsafe = false
+      session = Capybara::Session.new(:rack_test, TestApp)
+      expect { session.config.default_selector = :title }.to raise_error /Per session settings are only supported when Capybara.threadsafe == true/
+      expect do
+        session.configure do |config|
+          config.exact = true
+        end
+      end.to raise_error /Session configuration is only supported when Capybara.threadsafe == true/
+    end
+
+    it "uses the config from the session" do
+      Capybara.threadsafe = true
+      session = Capybara::Session.new(:rack_test, TestApp) do |config|
+        config.default_selector = :link
+      end
+      session.visit('/with_html')
+      expect(session.find('foo').tag_name).to eq 'a'
+    end
+
+    it "won't change threadsafe once a session is created" do
+      Capybara.threadsafe = true
+      Capybara.threadsafe = false
+      session = Capybara::Session.new(:rack_test, TestApp)
+      expect { Capybara.threadsafe = true }.to raise_error /Threadsafe setting cannot be changed once a session is created/
+    end
+  end
+end

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -555,8 +555,8 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
 
         it "doesn't wait if wait time is less than timeout" do
           @session.click_link("Change title")
-          using_wait_time 0 do
-            expect(@session).not_to have_title('changed title')
+          using_wait_time 3 do
+            expect(@session).not_to have_title('changed title', wait: 0)
           end
         end
       end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -7,4 +7,48 @@ RSpec.describe Capybara::Session do
       Capybara::Session.new(:unknown, { random: "hash"})
     end.to raise_error TypeError, "The second parameter to Session::new should be a rack app if passed."
   end
+
+  context "current_driver" do
+    it "is global when threadsafe false" do
+      Capybara.threadsafe = false
+      Capybara.current_driver = :selenium
+      thread = Thread.new do
+        Capybara.current_driver = :random
+      end
+      thread.join
+      expect(Capybara.current_driver).to eq :random
+    end
+
+    it "is thread specific threadsafe true" do
+      Capybara.threadsafe = true
+      Capybara.current_driver = :selenium
+      thread = Thread.new do
+        Capybara.current_driver = :random
+      end
+      thread.join
+      expect(Capybara.current_driver).to eq :selenium
+    end
+  end
+
+  context "session_name" do
+    it "is global when threadsafe false" do
+      Capybara.threadsafe = false
+      Capybara.session_name = "sess1"
+      thread = Thread.new do
+        Capybara.session_name = "sess2"
+      end
+      thread.join
+      expect(Capybara.session_name).to eq "sess2"
+    end
+
+    it "is thread specific when threadsafe true" do
+      Capybara.threadsafe = true
+      Capybara.session_name = "sess1"
+      thread = Thread.new do
+        Capybara.session_name = "sess2"
+      end
+      thread.join
+      expect(Capybara.session_name).to eq "sess1"
+    end
+  end
 end


### PR DESCRIPTION
As the largest part of Issue #1248 this allows for per session configuration of the relevant global options.  The feature is hidden behind the `Capybara.per_session_configuration` swtich. 