### PR TITLE
Ignore extra dummy frame on page for SeleniumDriver#reset!

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,9 @@ Release date: unreleased
 ### Added
 * Session#switch_to_frame for manually handling frame switching - Issue #1365 [Thomas Walpole]
 
+### Fixed
+* SeleniumDriver#reset! allows dummy frame with chrome when JS is disabled - Issue #1809
+
 #Version 2.11.0
 Release date: 2016-12-05
 

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -133,7 +133,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         navigated = true
 
         #Ensure the page is empty and trigger an UnhandledAlertError for any modals that appear during unload
-        until find_xpath("/html/body/*").empty? do
+        until empty_browser? do
           raise Capybara::ExpectationNotMet.new('Timed out waiting for Selenium session reset') if (Capybara::Helpers.monotonic_time - start_time) >= 10
           sleep 0.05
         end
@@ -319,5 +319,11 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def silenced_unknown_error_messages
     [ /Error communicating with the remote browser/ ]
+  end
+
+  def empty_browser?
+    elements = find_xpath("/html/body/*")
+    # When using chromedriver with JS disabled there is an extra dummy frame on the about:blank page - Issue #1809
+    elements.empty? || (elements.size == 1 && (elements == find_css('iframe[name="chromedriver dummy frame"][src="about:blank"]')))
   end
 end

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -16,6 +16,19 @@ Capybara.register_driver :selenium_chrome_clear_storage do |app|
                                       clear_session_storage: true)
 end
 
+Capybara.register_driver :selenium_chrome_no_js do |app|
+  Capybara::Selenium::Driver.new(
+    app,
+    :browser => :chrome,
+    :prefs => {
+      :profile => {
+        :default_content_setting_values => { :javascript => 2 }
+      }
+    }
+  )
+end
+
+
 module TestSessions
   Chrome = Capybara::Session.new(:selenium_chrome, TestApp)
 end
@@ -48,6 +61,16 @@ RSpec.describe "Capybara::Session with chrome" do
         @session.visit('/with_js')
         expect(@session.driver.browser.local_storage.keys).to be_empty
         expect(@session.driver.browser.session_storage.keys).to be_empty
+      end
+    end
+  end
+
+  context "disabled JS" do
+    describe "#reset!" do
+      it "doesn't raise an error" do
+        @session = Capybara::Session.new(:selenium_chrome_no_js, TestApp)
+        @session.visit('/with_html')
+        expect { @session.reset! }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Attempt to fix Issue #1809.  This allows for chrome having an extra iframe on the about:blank page when JS is disabled - not sure why and long term should probably be something fixed by chrome/chromedriver 