### PR TITLE
Add currently_with option to #fill_in

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -75,6 +75,7 @@ module Capybara
       #   @macro waiting_behavior
       #   @option options [String] :with          The value to fill in - required
       #   @option options [Hash] :fill_options    Driver specific options regarding how to fill fields
+      #   @option options [String] :currently_with The current value property of the field to fill in
       #   @option options [Boolean] :multiple      Match fields that can have multiple values?
       #   @option options [String] :id             Match fields that match the id attribute
       #   @option options [String] :name           Match fields that match the name attribute
@@ -87,6 +88,7 @@ module Capybara
         raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
         with = options.delete(:with)
         fill_options = options.delete(:fill_options)
+        options[:with] = options.delete(:currently_with) if options.has_key?(:currently_with)
         find(:fillable_field, locator, options).set(with, fill_options)
       end
 

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -100,6 +100,12 @@ Capybara::SpecHelper.spec "#fill_in" do
     expect(extract_results(@session)['password']).to eq('supasikrit')
   end
 
+  it "should fill in a field based on current value", twtw: true do
+    @session.fill_in(currently_with: 'John', with: 'Thomas')
+    @session.click_button('awesome')
+    expect(extract_results(@session)['first_name']).to eq('Thomas')
+  end
+
   it "should throw an exception if a hash containing 'with' is not provided" do
     expect {@session.fill_in 'Name', 'ignu'}.to raise_error(RuntimeError, /with/)
   end


### PR DESCRIPTION
The required `with` option to Node#fill_in masks the ability to pass a `with` option through to the fillable_field finder used to locate the field.  This allows that with a `currently_with` option.