### PR TITLE
Support easier full text matching

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,9 @@ Release date: unreleased
 * Session#switch_to_frame for manually handling frame switching - Issue #1365 [Thomas Walpole]
 * Session#execute_script and Session#evaluate_script now accept optional arguments that will be based to the JS function.  This may not be supported
   by all drivers, and the types of arguments that may be passed is limited.  If drivers opt to support this feature they should support passing page elements.
+* :exact option for text and title matchers
+* :exact_text option for selector finders/minders
+* Capybara.exact_text setting that affects the text matchers and :text options passed to selector finders/matchers.
 
 #Version 2.11.0
 Release date: 2016-12-05

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -29,6 +29,7 @@ module Capybara
     attr_accessor :raise_server_errors, :server_errors
     attr_writer :default_driver, :current_driver, :javascript_driver, :session_name, :server_host
     attr_reader :save_and_open_page_path
+    attr_accessor :exact_text
     attr_accessor :app
 
     ##
@@ -495,6 +496,7 @@ Capybara.configure do |config|
   config.automatic_reload = true
   config.match = :smart
   config.exact = false
+  config.exact_text = false
   config.raise_server_errors = true
   config.server_errors = [StandardError]
   config.visible_text_only = false

--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -28,8 +28,14 @@ module Capybara
     # @param [String] text Text to escape
     # @return [String]     Escaped text
     #
-    def to_regexp(text, options=nil)
-      text.is_a?(Regexp) ? text : Regexp.new(Regexp.escape(normalize_whitespace(text)), options)
+    def to_regexp(text, regexp_options=nil, exact=false)
+      if text.is_a?(Regexp)
+        text
+      else
+        escaped = Regexp.escape(normalize_whitespace(text))
+        escaped = "\\A#{escaped}\\z" if exact
+        Regexp.new(escaped, regexp_options)
+      end
     end
 
     ##

--- a/lib/capybara/node/document_matchers.rb
+++ b/lib/capybara/node/document_matchers.rb
@@ -7,10 +7,11 @@ module Capybara
       #
       # @!macro title_query_params
       #   @overload $0(string, options = {})
-      #     @param string [String]           The string that title should include
+      #     @param string [String]           The string that title should include      #
       #   @overload $0(regexp, options = {})
       #     @param regexp [Regexp]           The regexp that title should match to
       #   @option options [Numeric] :wait (Capybara.default_max_wait_time) Maximum time that Capybara will wait for title to eq/match given string/regexp argument
+      #   @option options [Boolean] :exact (false) When passed a string should the match be exact or just substring
       # @raise [Capybara::ExpectationNotMet] if the assertion hasn't succeeded during wait time
       # @return [true]
       #

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -188,6 +188,7 @@ module Capybara
       # @param [Symbol] kind                       Optional selector type (:css, :xpath, :field, etc.) - Defaults to Capybara.default_selector
       # @param [String] locator                    The selector
       # @option options [String, Regexp] text      Only find elements which contain this text or match this regexp
+      # @option options [String, Boolean] exact_text (Capybara.exact_text) When String the string the elements contained text must match exactly, when Boolean controls whether the :text option must match exactly
       # @option options [Boolean, Symbol] visible  Only find elements with the specified visibility:
       #                                              * true - only finds visible elements.
       #                                              * false - finds invisible _and_ visible elements.

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -546,6 +546,7 @@ module Capybara
       #     @option options [Integer] :maximum (nil)   Maximum number of times the text is expected to occur
       #     @option options [Range]   :between (nil)   Range of times that is expected to contain number of times text occurs
       #     @option options [Numeric] :wait (Capybara.default_max_wait_time)      Maximum time that Capybara will wait for text to eq/match given string/regexp argument
+      #     @option options [Boolean] :exact (Capybara.exact_text) Whether text must be an exact match or just substring
       #   @overload $0(text, options = {})
       #     @param [String, Regexp] text               The string/regexp to check for. If it's a string, text is expected to include it. If it's a regexp, text is expected to match it.
       #     @option options [Integer] :count (nil)     Number of times the text is expected to occur
@@ -553,6 +554,7 @@ module Capybara
       #     @option options [Integer] :maximum (nil)   Maximum number of times the text is expected to occur
       #     @option options [Range]   :between (nil)   Range of times that is expected to contain number of times text occurs
       #     @option options [Numeric] :wait (Capybara.default_max_wait_time)      Maximum time that Capybara will wait for text to eq/match given string/regexp argument
+      #     @option options [Boolean] :exact (Capybara.exact_text) Whether text must be an exact match or just substring
       # @raise [Capybara::ExpectationNotMet] if the assertion hasn't succeeded during wait time
       # @return [true]
       #

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -10,8 +10,8 @@ module Capybara
         unless @expected_text.is_a?(Regexp)
           @expected_text = Capybara::Helpers.normalize_whitespace(@expected_text)
         end
-        @search_regexp = Capybara::Helpers.to_regexp(@expected_text)
         @options ||= {}
+        @search_regexp = Capybara::Helpers.to_regexp(@expected_text, nil, exact?)
         assert_valid_keys
       end
 
@@ -33,11 +33,15 @@ module Capybara
         if @expected_text.is_a?(Regexp)
           "text matching #{@expected_text.inspect}"
         else
-          "text #{@expected_text.inspect}"
+          "#{"exact " if exact?}text #{@expected_text.inspect}"
         end
       end
 
       private
+
+      def exact?
+        options.fetch(:exact, Capybara.exact_text)
+      end
 
       def build_message(report_on_invisible)
         message = String.new()
@@ -70,7 +74,7 @@ module Capybara
       end
 
       def valid_keys
-        COUNT_KEYS + [:wait]
+        COUNT_KEYS + [:wait, :exact]
       end
 
       def check_visible_text?

--- a/lib/capybara/queries/title_query.rb
+++ b/lib/capybara/queries/title_query.rb
@@ -9,7 +9,7 @@ module Capybara
         unless @expected_title.is_a?(Regexp)
           @expected_title = Capybara::Helpers.normalize_whitespace(@expected_title)
         end
-        @search_regexp = Capybara::Helpers.to_regexp(@expected_title)
+        @search_regexp = Capybara::Helpers.to_regexp(@expected_title, nil, options.fetch(:exact, false))
         assert_valid_keys
       end
 
@@ -34,7 +34,7 @@ module Capybara
       end
 
       def valid_keys
-        [:wait]
+        [:wait, :exact]
       end
     end
   end

--- a/lib/capybara/spec/session/has_selector_spec.rb
+++ b/lib/capybara/spec/session/has_selector_spec.rb
@@ -77,6 +77,27 @@ Capybara::SpecHelper.spec '#has_selector?' do
       expect(@session).to have_selector(:css, "p a#foo", 'extra')
     end
   end
+
+  context "with exact_text" do
+    context "string" do
+      it "should only match elements that match exactly" do
+        expect(@session).to have_selector(:id, "h2one", exact_text: "Header Class Test One")
+        expect(@session).to have_no_selector(:id, "h2one", exact_text: "Header Class Test")
+      end
+    end
+
+    context "boolean" do
+      it "should only match elements that match exactly when true" do
+        expect(@session).to have_selector(:id, "h2one", text: "Header Class Test One", exact_text: true)
+        expect(@session).to have_no_selector(:id, "h2one", text: "Header Class Test", exact_text: true)
+      end
+
+      it "should match substrings when false" do
+        expect(@session).to have_selector(:id, "h2one", text: "Header Class Test One", exact_text: false)
+        expect(@session).to have_selector(:id, "h2one", text: "Header Class Test", exact_text: false)
+      end
+    end
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_selector?' do

--- a/lib/capybara/spec/session/has_text_spec.rb
+++ b/lib/capybara/spec/session/has_text_spec.rb
@@ -96,6 +96,18 @@ Capybara::SpecHelper.spec '#has_text?' do
     expect(@session).not_to have_text(/xxxxyzzz/)
   end
 
+  context "with exact: true option" do
+    it "should be true if text matches exactly" do
+      @session.visit('/with_html')
+      expect(@session.find(:id, "h2one")).to have_text("Header Class Test One", exact: true)
+    end
+
+    it "should be false if text doesn't match exactly" do
+      @session.visit('/with_html')
+      expect(@session.find(:id, "h2one")).not_to have_text("Header Class Test On", exact: true)
+    end
+  end
+
   it "should escape any characters that would have special meaning in a regexp" do
     @session.visit('/with_html')
     expect(@session).not_to have_text('.orem')
@@ -205,7 +217,7 @@ Capybara::SpecHelper.spec '#has_text?' do
   it "should raise an error if an invalid option is passed" do
     @session.visit('/with_html')
     expect do
-      expect(@session).to have_text('Lorem', exact: true)
+      expect(@session).to have_text('Lorem', invalid: true)
     end.to raise_error(ArgumentError)
   end
 end

--- a/lib/capybara/spec/session/has_title_spec.rb
+++ b/lib/capybara/spec/session/has_title_spec.rb
@@ -21,6 +21,21 @@ Capybara::SpecHelper.spec '#has_title?' do
   it "should be false if the page has not the given title" do
     expect(@session).not_to have_title('monkey')
   end
+
+  it "should default to exact: false matching" do
+    expect(@session).to have_title('with_js', exact: false)
+    expect(@session).to have_title('with_', exact: false)
+  end
+
+  it "should match exactly if exact: true option passed" do
+    expect(@session).to have_title('with_js', exact: true)
+    expect(@session).not_to have_title('with_', exact: true)
+  end
+
+  it "should match partial if exact: false option passed" do
+    expect(@session).to have_title('with_js', exact: false)
+    expect(@session).to have_title('with_', exact: false)
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_title?' do


### PR DESCRIPTION
This adds support for `exact_text` option on selector queries, and an 'exact' option on title and text queries.  The thought is that an `exact` option always affects the primary function of the query - so the title in title queries, text in text queries, locator in selector queries.  The `exact_text` option on selector queries can be true/false in which case it will affect the `text` option, or it can be a string which is a shortcut for passing that string as the `text` option and also passing `exact_text: true`.   

The one issue of "inconsistency" is that the text query `exact` option defaults to Capybara.exact_text, but this is documented and I don't consider it a huge issue for a user to understand - and makes more sense than it defaulting to Capybara.exact from a usability pov.

Another issue is the `exact` option for title queries currently defaults to false, but will be changed in v3 to default to Capybara.exact