### PR TITLE
Add an option for attach_file to allow modifying the elements style s…

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -230,7 +230,7 @@ module Capybara
       # @option options [String] id             Match fields that match the id attribute
       # @option options [String] name           Match fields that match the name attribute
       # @option options [String, Array<String>] :class    Match links that match the class(es) provided
-      # @option options [Hash] style   A Hash of CSS styles to change before attempting to attach the file
+      # @option options [Hash] style   A Hash of CSS styles to change before attempting to attach the file (may not be supported by all driver)
       #
       # @return [Capybara::Node::Element]  The file field element
       def attach_file(locator, path, options={})

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -230,6 +230,7 @@ module Capybara
       # @option options [String] id             Match fields that match the id attribute
       # @option options [String] name           Match fields that match the name attribute
       # @option options [String, Array<String>] :class    Match links that match the class(es) provided
+      # @option options [Hash] style   A Hash of CSS styles to change before attempting to attach the file
       #
       # @return [Capybara::Node::Element]  The file field element
       def attach_file(locator, path, options={})
@@ -237,10 +238,31 @@ module Capybara
         Array(path).each do |p|
           raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s)
         end
+        # Allow user to update the CSS style of the file input since they are so often hidden on a page
+        if style = options.delete(:style)
+          ff = find(:file_field, locator, options.merge({visible: :all}))
+          _update_style(ff, style)
+        end
         find(:file_field, locator, options).set(path)
       end
 
     private
+      def _update_style(element, style)
+        script = <<-JS
+          var el = arguments[0];
+          var css = arguments[1];
+          for (var prop in css){
+            if (css.hasOwnProperty(prop)) {
+              el.style[prop] = css[prop]
+            }
+          }
+        JS
+        begin
+          session.execute_script(script, element, style)
+        rescue Capybara::NotSupportedByDriverError
+          warn "The :style option is not supported by the current driver - ignoring"
+        end
+      end
 
       def _check_with_label(selector, checked, locator, options)
         locator, options = nil, locator if locator.is_a? Hash

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -107,4 +107,12 @@ Capybara::SpecHelper.spec "#attach_file" do
       end.to raise_error(Capybara::ElementNotFound)
     end
   end
+
+  context "with :style option", requires: [:js, :es_args] do
+    it "can change the CSS style of the file input field" do
+      @session.visit('/with_js')
+      expect { @session.attach_file("hidden_file", __FILE__) }.to raise_error Capybara::ElementNotFound
+      @session.attach_file("hidden_file", __FILE__, style: { opacity: 1, display: 'block' })
+    end
+  end
 end

--- a/lib/capybara/spec/session/evaluate_script_spec.rb
+++ b/lib/capybara/spec/session/evaluate_script_spec.rb
@@ -5,13 +5,13 @@ Capybara::SpecHelper.spec "#evaluate_script", requires: [:js] do
     expect(@session.evaluate_script("1+3")).to eq(4)
   end
 
-  it "should pass arguments to the script" do
+  it "should pass arguments to the script", requires: [:js, :es_args] do
     @session.visit('/with_js')
     @session.evaluate_script("document.getElementById('change').textContent = arguments[0]", "Doodle Funk")
     expect(@session).to have_css('#change', text: 'Doodle Funk')
   end
 
-  it "should support passing elements as arguments to the script" do
+  it "should support passing elements as arguments to the script", requires: [:js, :es_args] do
     @session.visit('/with_js')
     el = @session.find(:css, '#change')
     @session.evaluate_script("arguments[0].textContent = arguments[1]", el, "Doodle Funk")

--- a/lib/capybara/spec/session/execute_script_spec.rb
+++ b/lib/capybara/spec/session/execute_script_spec.rb
@@ -11,13 +11,13 @@ Capybara::SpecHelper.spec "#execute_script", requires: [:js] do
     expect{ @session.execute_script("$('#change').text('Funky Doodle')") }.not_to raise_error
   end
 
-  it "should pass arguments to the script" do
+  it "should pass arguments to the script", requires: [:js, :es_args] do
     @session.visit('/with_js')
     @session.execute_script("document.getElementById('change').textContent = arguments[0]", "Doodle Funk")
     expect(@session).to have_css('#change', text: 'Doodle Funk')
   end
 
-  it "should support passing elements as arguments to the script" do
+  it "should support passing elements as arguments to the script", requires: [:js, :es_args] do
     @session.visit('/with_js')
     el = @session.find(:css, '#change')
     @session.execute_script("arguments[1].textContent = arguments[0]", "Doodle Funk", el)

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -110,6 +110,11 @@
       <input type="test" name="with-key-events" id="with-key-events">
       <p id="key-events-output"></p>
     </p>
+
+    <p>
+      <input type="file" id="hidden_file" style="opacity:0; display: none;">
+    </p>
+
     <script type="text/javascript">
       // a javascript comment
       var aVar = 123;


### PR DESCRIPTION
…ince they are so often hidden on the page  -  This adds a :style option to the attach_file method which allows for modifying the file inputs CSS before attempting to attach the file.  This is because it's pretty standard for a file input to be hidden in some way for styling reasons, and attach_file requires the input to be visible to attach the file with no other way of interacting with it.  This just prevents people from having to add their own code that modifies style before every attach_file call.  It requires driver support for argument passing of elements to execute_script.