### PR TITLE
Change :style option for attach_file to :make_visible

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -230,7 +230,7 @@ module Capybara
       # @option options [String] id             Match fields that match the id attribute
       # @option options [String] name           Match fields that match the name attribute
       # @option options [String, Array<String>] :class    Match links that match the class(es) provided
-      # @option options [Hash] style   A Hash of CSS styles to change before attempting to attach the file (may not be supported by all driver)
+      # @option options [true, Hash] make_visible   A Hash of CSS styles to change before attempting to attach the file, if `true` { opacity: 1, display: 'block', visibility: 'visible' } is used (may not be supported by all drivers)
       #
       # @return [Capybara::Node::Element]  The file field element
       def attach_file(locator, path, options={})
@@ -239,11 +239,18 @@ module Capybara
           raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s)
         end
         # Allow user to update the CSS style of the file input since they are so often hidden on a page
-        if style = options.delete(:style)
+        if style = options.delete(:make_visible)
+          style = { opacity: 1, display: 'block', visibility: 'visible' } if style == true
           ff = find(:file_field, locator, options.merge({visible: :all}))
           _update_style(ff, style)
+          if ff.visible?
+            ff.set(path)
+          else
+            raise ExpectationNotMet, "The style changes in :make_visible did not make the file input visible"
+          end
+        else
+          find(:file_field, locator, options).set(path)
         end
-        find(:file_field, locator, options).set(path)
       end
 
     private

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -108,11 +108,27 @@ Capybara::SpecHelper.spec "#attach_file" do
     end
   end
 
-  context "with :style option", requires: [:js, :es_args] do
-    it "can change the CSS style of the file input field" do
+  context "with :make_visible option", requires: [:js, :es_args] do
+    it "applies a default style change when true" do
       @session.visit('/with_js')
       expect { @session.attach_file("hidden_file", __FILE__) }.to raise_error Capybara::ElementNotFound
-      @session.attach_file("hidden_file", __FILE__, style: { opacity: 1, display: 'block' })
+      expect {
+        @session.attach_file("hidden_file", __FILE__, make_visible: true)
+      }.not_to raise_error
+    end
+
+    it "accepts a hash of styles to be applied" do
+      @session.visit('/with_js')
+      expect {
+        @session.attach_file("hidden_file", __FILE__, make_visible: { opacity: 1, display: 'block' })
+      }.not_to raise_error
+    end
+
+    it "raises an error when the file input is not made visible" do
+      @session.visit('/with_js')
+      expect {
+        @session.attach_file("hidden_file", __FILE__, make_visible: { color: 'red' })
+      }.to raise_error(Capybara::ExpectationNotMet)
     end
   end
 end


### PR DESCRIPTION
This changes the :style option for `attach_file` to :make_visible which takes true or a hash of style options to change.  If `true` is specified it currently applies opacity:1, display: 'block'.   Still considering how to handle errors/the changes not making the field visible, currently it warns and then raises an error about not finding the element -- probably should just raise an error about the style changes not making the element visible.