### PR TITLE
Work around issue in Ruby 2.4.0 

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rack/test'
+require 'capybara/rack_test/patch.rb'
 require 'rack/utils'
 require 'mime/types'
 require 'nokogiri'

--- a/lib/capybara/rack_test/patch.rb
+++ b/lib/capybara/rack_test/patch.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Workaround for issue in Ruby 2.4.0 with `def_delegators` -https://bugs.ruby-lang.org/issues/13107?next_issue_id=13106&prev_issue_id=13111
+if RUBY_ENGINE=="ruby" && RUBY_VERSION=="2.4.0"
+  class Rack::Test::Session
+    def last_response
+      @rack_mock_session.last_response
+    end
+
+    def last_request
+      @rack_mock_session.last_request
+    end
+  end
+end


### PR DESCRIPTION
Ruby 2.4.0 has an issue where using Forwardable delegators can produce random errors

https://bugs.ruby-lang.org/issues/13107?next_issue_id=13106&prev_issue_id=13111

This works around if for the methods we have seen errors on from rack-test.  The other option is to just wait for 2.4.1 to release where the issue has been fixed.