### PR TITLE
Do not raise path exceptions on nil current_url

### DIFF
--- a/lib/capybara/queries/current_path_query.rb
+++ b/lib/capybara/queries/current_path_query.rb
@@ -17,10 +17,12 @@ module Capybara
         @actual_path = if options[:url]
           session.current_url
         else
+          uri = ::Addressable::URI.parse(session.current_url)
+
           if options[:only_path]
-            ::Addressable::URI.parse(session.current_url).path
+            uri.path unless uri.nil? # Ensure the parsed url isn't nil.
           else
-            ::Addressable::URI.parse(session.current_url).request_uri
+            uri.request_uri unless uri.nil? # Ensure the parsed url isn't nil.
           end
         end
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -173,6 +173,10 @@ module Capybara
     def current_path
       # Addressable parsing is more lenient than URI
       uri = Addressable::URI.parse(current_url)
+
+      # If current_url ends up being nil, won't be able to call .path on a NilClass.
+      return nil if uri.nil?
+
       # Addressable doesn't support opaque URIs - we want nil here
       return nil if uri.scheme == "about"
       path = uri.path

--- a/lib/capybara/spec/session/assert_current_path.rb
+++ b/lib/capybara/spec/session/assert_current_path.rb
@@ -34,6 +34,12 @@ Capybara::SpecHelper.spec '#assert_current_path' do
     @session.visit('/with_js?test=test')
     expect{@session.assert_current_path('/with_js', only_path: true)}.not_to raise_error
   end
+
+  it "should not cause an exception when current_url is nil" do
+    allow_any_instance_of(Capybara::Session).to receive(:current_url) { nil }
+
+    expect{@session.assert_current_path(nil)}.not_to raise_error
+  end
 end
 
 Capybara::SpecHelper.spec '#assert_no_current_path?' do
@@ -55,6 +61,12 @@ Capybara::SpecHelper.spec '#assert_no_current_path?' do
   end
 
   it "should not raise if the page has not the given current_path" do
+    expect{@session.assert_no_current_path('/with_html')}.not_to raise_error
+  end
+
+  it "should not cause an exception when current_url is nil" do
+    allow_any_instance_of(Capybara::Session).to receive(:current_url) { nil }
+
     expect{@session.assert_no_current_path('/with_html')}.not_to raise_error
   end
 end

--- a/lib/capybara/spec/session/current_url_spec.rb
+++ b/lib/capybara/spec/session/current_url_spec.rb
@@ -96,4 +96,12 @@ Capybara::SpecHelper.spec '#current_url, #current_path, #current_host' do
     @session.execute_script("window.history.replaceState({}, '', '/replaced')")
     expect(@session.current_path).to eq("/replaced")
   end
+
+  it "doesn't raise exception on a nil current_url" do
+    @session.visit("/")
+    allow_any_instance_of(Capybara::Session).to receive(:current_url) { nil }
+
+    expect { @session.current_url }.not_to raise_exception
+    expect { @session.current_path }.not_to raise_exception
+  end
 end

--- a/lib/capybara/spec/session/has_current_path_spec.rb
+++ b/lib/capybara/spec/session/has_current_path_spec.rb
@@ -52,6 +52,20 @@ Capybara::SpecHelper.spec '#has_current_path?' do
       expect(@session).to have_current_path('/with_js', url: true, only_path: true)
       }. to raise_error ArgumentError
   end
+
+  it "should not raise an exception if the current_url is nil" do
+    allow_any_instance_of(Capybara::Session).to receive(:current_url) { nil }
+
+    # Without only_path option
+    expect {
+      expect(@session).to have_current_path(nil)
+    }. not_to raise_exception
+
+    # With only_path option
+    expect {
+      expect(@session).to have_current_path(nil, only_path: true)
+    }. not_to raise_exception
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_current_path?' do
@@ -75,5 +89,19 @@ Capybara::SpecHelper.spec '#has_no_current_path?' do
 
   it "should be true if the page has not the given current_path" do
     expect(@session).to have_no_current_path('/with_html')
+  end
+
+  it "should not raise an exception if the current_url is nil" do
+    allow_any_instance_of(Capybara::Session).to receive(:current_url) { nil }
+
+    # Without only_path option
+    expect {
+      expect(@session).not_to have_current_path('/with_js')
+    }. not_to raise_exception
+
+    # With only_path option
+    expect {
+      expect(@session).not_to have_current_path('/with_js', only_path: true)
+    }. not_to raise_exception
   end
 end


### PR DESCRIPTION
When we experimented moving our suite to BrowserStack, `page.current_url` was often returning nil.

Calling `have_current_path` and `page.current_path` would raise:
`NoMethodError: undefined method 'path' for nil:NilClass`, with no intelligent waiting for BrowserStack to finally return a valid url.

This PR modified to only call those methods if the parsed URI is not nil. If it's nil, @actual_path remains nil.