### PR TITLE
Make racktest driver #text behave more like real browser drivers for …

### DIFF
--- a/History.md
+++ b/History.md
@@ -20,6 +20,7 @@ Release date: unreleased
 *  Lazy Capybara::Results evaluation enabled for JRuby 9.1.6.0+
 *  A driver returning nil for #current_url won't raise an exception when calling #current_path [Dylan Reichstadt]
 *  Support Ruby 2.4.0 unified Integer [Koichi ITO]
+*  RackTest driver no longer modifies the text content of textarea elements to behave more like a real browser [Thomas Walpole]
 
 #Version 2.11.0
 Release date: 2016-12-05

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -369,7 +369,7 @@ module Capybara
     def HTML(html)
       Nokogiri::HTML(html).tap do |document|
         document.xpath('//textarea').each do |textarea|
-          textarea.content=textarea.content.sub(/\A\n/,'')
+          textarea['_capybara_raw_value'] = textarea.content.sub(/\A\n/,'')
         end
       end
     end

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -76,7 +76,7 @@ module Capybara
       #
       def value
         if tag_name == 'textarea'
-          native.content
+          native['_capybara_raw_value']
         elsif tag_name == 'select'
           if native['multiple'] == 'multiple'
             native.xpath(".//option[@selected='selected']").map { |option| option[:value] || option.content  }

--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -65,7 +65,7 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
           merge_param!(params, field['name'].to_s, (option['value'] || option.text).to_s) if option
         end
       when 'textarea'
-        merge_param!(params, field['name'].to_s, field.text.to_s.gsub(/\n/, "\r\n"))
+        merge_param!(params, field['name'].to_s, field['_capybara_raw_value'].to_s.gsub(/\n/, "\r\n"))
       end
     end
     merge_param!(params, button[:name], button[:value] || "") if button[:name]

--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -31,7 +31,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
       if self[:readonly]
         warn "Attempt to set readonly element with value: #{value} \n * This will raise an exception in a future version of Capybara"
       else
-        native.content = value.to_s
+        native['_capybara_raw_value'] = value.to_s
       end
     end
   end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -112,6 +112,16 @@ RSpec.describe Capybara::Session do
         end
       end
     end
+
+    describe '#text' do
+      it "should return original text content for textareas", :focus_ do
+        @session.visit('/with_html')
+        @session.find_field('normal', type: 'textarea', with: 'banana').set('hello')
+        normal = @session.find(:css, '#normal')
+        expect(normal.value).to eq 'hello'
+        expect(normal.text).to eq 'banana'
+      end
+    end
   end
 end
 


### PR DESCRIPTION
…textarea elements -  This makes Noed#text return the original text from textarea elements like selenium does, rather than a new value that is set to the element.  Technically, according to the spec, I think `#text` should return nothing on a textarea since the text content isn't actually shown - and innerText returns blank.  Currently though all drivers return the initial page content of textarea elements.  We should look at changing this to be more spec compliant in a future release or v3.0