### PR TITLE
support elements in evaluate_script result structures

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -637,8 +637,7 @@ module Capybara
       else
         driver.evaluate_script(script, *args.map { |arg| arg.is_a?(Capybara::Node::Element) ?  arg.base : arg} )
       end
-      result = Capybara::Node::Element.new(self, result, nil, nil) if result.is_a?(Capybara::Driver::Node)
-      result
+      element_script_result(result)
     end
 
     ##
@@ -843,6 +842,19 @@ module Capybara
 
     def scopes
       @scopes ||= [nil]
+    end
+
+    def element_script_result(arg)
+      case arg
+      when Array
+        arg.map { |e| element_script_result(e) }
+      when Hash
+        arg.each { |k, v| arg[k] = element_script_result(v) }
+      when Capybara::Driver::Node
+        Capybara::Node::Element.new(self, arg, nil, nil)
+      else
+        arg
+      end
     end
   end
 end

--- a/lib/capybara/spec/session/evaluate_script_spec.rb
+++ b/lib/capybara/spec/session/evaluate_script_spec.rb
@@ -18,4 +18,11 @@ Capybara::SpecHelper.spec "#evaluate_script", requires: [:js] do
     expect(@session).to have_css('#change', text: 'Doodle Funk')
   end
 
+  it "should support returning elements", requires: [:js, :es_args] do
+    @session.visit('/with_js')
+    el = @session.find(:css, '#change')
+    el = @session.evaluate_script("document.getElementById('change')")
+    expect(el).to be_instance_of(Capybara::Node::Element)
+    expect(el).to eq(@session.find(:css, '#change'))
+  end
 end

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -121,10 +121,30 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
     end
 
     describe "#evaluate_script" do
-      it "can return elements" do
+      it "can return an element" do
         @session.visit('/form')
         element = @session.evaluate_script("document.getElementById('form_title')")
         expect(element).to eq @session.find(:id, 'form_title')
+      end
+
+      it "can return arrays of nested elements" do
+        @session.visit('/form')
+        elements = @session.evaluate_script('document.querySelectorAll("#form_city option")')
+        elements.each do |el|
+          expect(el).to be_instance_of Capybara::Node::Element
+        end
+        expect(elements).to eq @session.find(:css, '#form_city').all(:css, 'option').to_a
+      end
+
+      it "can return hashes with elements" do
+        @session.visit('/form')
+        result = @session.evaluate_script("{ a: document.getElementById('form_title'), b: {c: document.querySelectorAll('#form_city option')}}")
+        expect(result).to eq({
+          'a' => @session.find(:id, 'form_title'),
+          'b' => {
+            'c' => @session.find(:css, '#form_city').all(:css, 'option').to_a
+          }
+        })
       end
     end
   end


### PR DESCRIPTION
Support the return of elements in nested structures (Arrays, Hashes) from evaluate_script