### PR TITLE
Workaround JRuby lazy enumerators bug below version 9.2.0.0

### DIFF
--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -28,11 +28,11 @@ module Capybara
       @result_cache = []
       @results_enum = lazy_select_elements { |node| query.matches_filters?(node) }
       @query = query
-      # JRuby < 9.1.6.0 has an issue with eagerly finding next in lazy enumerators which
+      # JRuby < 9.2.0.0 has an issue with eagerly finding next in lazy enumerators which
       # causes a concurrency issue with network requests here
       # https://github.com/jruby/jruby/issues/4212
       # Just force all the results to be evaluated
-      full_results if RUBY_PLATFORM == 'java' && (Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('9.1.6.0'))
+      full_results if RUBY_PLATFORM == 'java' && (Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('9.2.0.0'))
     end
 
     def_delegators :full_results, :size, :length, :last, :values_at, :inspect, :sample

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
+JRUBY_LAZY_ENUMERATORS_FIX_VERSION = '9.2.0.0'
+
 RSpec.describe Capybara::Result do
   let :string do
     Capybara.string <<-STRING
@@ -73,7 +75,8 @@ RSpec.describe Capybara::Result do
 
   #Not a great test but it indirectly tests what is needed
   it "should evaluate filters lazily" do
-    skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java' && (Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('9.1.6.0'))
+    skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java' &&
+      Gem::Version.new(JRUBY_VERSION) < Gem::Version.new(JRUBY_LAZY_ENUMERATORS_FIX_VERSION)
     #Not processed until accessed
     expect(result.instance_variable_get('@result_cache').size).to be 0
 
@@ -95,7 +98,8 @@ RSpec.describe Capybara::Result do
 
   context '#each' do
     it 'lazily evaluates' do
-      skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java' && (Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('9.1.6.0'))
+      skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java' &&
+        Gem::Version.new(JRUBY_VERSION) < Gem::Version.new(JRUBY_LAZY_ENUMERATORS_FIX_VERSION)
       results=[]
       result.each do |el|
         results << el
@@ -111,7 +115,8 @@ RSpec.describe Capybara::Result do
       end
 
       it 'lazily evaluates' do
-        skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java' && (Gem::Version.new(JRUBY_VERSION) < Gem::Version.new('9.1.6.0'))
+        skip 'JRuby has an issue with lazy enumerator next evaluation' if RUBY_PLATFORM == 'java' &&
+          Gem::Version.new(JRUBY_VERSION) < Gem::Version.new(JRUBY_LAZY_ENUMERATORS_FIX_VERSION)
         result.each.with_index do |el, idx|
           expect(result.instance_variable_get('@result_cache').size).to eq(idx+1)  # 0 indexing
         end


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/4212 - this bug is still unfixed and they've suggested a fix will be in 9.2.0.0. Because of that, https://github.com/teamcapybara/capybara/commit/f7e537006af5cf882bc3df4317d2974bf392c974 breaks Capybara 2.12.0 for JRuby above 9.1.5.0. This is our case - we use JRuby 9.1.7.0 and Capybara 2.12.0 doesn't work.