### PR TITLE
Add missing bracket to a selector's description when a class is specified

### DIFF
--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -47,7 +47,7 @@ module Capybara
         @description << " with#{" exact" if exact_text == true} text #{options[:text].inspect}" if options[:text]
         @description << " with exact text #{options[:exact_text]}" if options[:exact_text].is_a?(String)
         @description << " with id #{options[:id]}" if options[:id]
-        @description << " with classes #{Array(options[:class]).join(',')}]" if options[:class]
+        @description << " with classes [#{Array(options[:class]).join(',')}]" if options[:class]
         @description << selector.description(options)
         @description << " that also matches the custom filter block" if @filter_block
         @description


### PR DESCRIPTION
There is a missing square bracket at the beginning of the description message for any selector if a class is specified, this pull request adds it.

### Example
```ruby
find('.item', text: 'content', class: 'css')
```
results in:
```
expected to find ".item" with text "content" with classes css] but there were no matches
```
and after the fix:
```
expected to find ".item" with text "content" with classes [css] but there were no matches
```