### PR TITLE
Ensure the cursor points to the end of form before sending backspaces

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -61,7 +61,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
         if options[:clear] == :backspace
           # Clear field by sending the correct number of backspace keys.
           backspaces = [:backspace] * self.value.to_s.length
-          native.send_keys(*(backspaces + [value.to_s]))
+          native.send_keys(*([:down] + backspaces + [value.to_s]))
         elsif options[:clear] == :none
           native.send_keys(value.to_s)
         elsif options[:clear].is_a? Array

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -43,7 +43,7 @@
 
   <p>
     <label for="form_last_name">Last Name</label>
-    <input type="text" name="form[last_name]" value="Smith" id="form_last_name"/>
+    <input type="text" name="form[last_name]" value="Smith" id="form_last_name" autofocus />
   </p>
 
   <p>

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -71,6 +71,13 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
         expect(@session.find(:fillable_field, 'form_first_name').value).to eq('Harry')
       end
 
+      it 'should clear an existing value even if a cursor is autofocused to a field' do
+        @session.visit('/form')
+        @session.fill_in('form_last_name', with: 'Potter',
+                          fill_options: { clear: :backspace} )
+        expect(@session.find(:fillable_field, 'form_last_name').value).to eq('Potter')
+      end
+
       it 'should only trigger onchange once' do
         @session.visit('/with_js')
         @session.fill_in('with_change_event', with: 'some value',


### PR DESCRIPTION
### Problem

In the latest stable Google Chrome (v59.0.3071.86), when an `input` element has `autofocus` attribute, the mouse cursor doesn't points its end but its *head*.

![image](https://user-images.githubusercontent.com/1131567/26965649-aef03f46-4d31-11e7-842a-e5a79b7ace62.png)

This behavior causes a problem in the backspace-based value replacement introduced in https://github.com/teamcapybara/capybara/commit/ed2071b480e3849b64754be48da82803ee210b31 – no matter how many times Capybara presses the backspace key, it cannot clear the form value since the backspace key can only deletes values before the current cursor position.

Here is the example test code to reproduce the problem:

`run.rb`

```ruby
require "minitest/autorun"
require 'capybara/minitest'

Capybara.app = Rack::File.new File.dirname __FILE__

Capybara.register_driver :chrome do |app|
  Capybara::Selenium::Driver.new(app, browser: :chrome)
end

Capybara.current_driver = :chrome
Capybara.javascript_driver = :chrome

class Test < Minitest::Test
  include Capybara::DSL
  include Capybara::Minitest::Assertions

  def test_input
    visit '/test.html'
    find('input').set('bar', clear: :backspace)
    assert_equal 'bar', find('input').value
  end
end
```

`test.html`

```html
<!DOCTYPE html>
<html>
<body>
  <input autofocus value="foo">
</body>
</html>
```

```
$ ruby run.rb
Run options: --seed 27403

# Running:

F

Finished in 1.661836s, 0.6017 runs/s, 0.6017 assertions/s.

  1) Failure:
Test#test_input [run.rb:20]:
Expected: "bar"
  Actual: "barfoo"

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

![image](https://user-images.githubusercontent.com/1131567/26966226-2a94cac0-4d34-11e7-843d-2059b1a6b513.png)

### Solution

I added a keydown `↓` before backspaces and ensure the cursor always points the end of the form before clearing values.
