### PR TITLE
Loosen restrictions on where `within_window` can be called from

### DIFF
--- a/lib/capybara/spec/session/window/switch_to_window_spec.rb
+++ b/lib/capybara/spec/session/window/switch_to_window_spec.rb
@@ -79,7 +79,7 @@ Capybara::SpecHelper.spec '#switch_to_window', requires: [:windows] do
         @session.within(:css, '#doesNotOpenWindows') do
           @session.switch_to_window { @session.title == 'With Windows' }
         end
-      end.to raise_error(Capybara::ScopeError, "`switch_to_window` is not supposed to be invoked from `within`'s, `within_frame`'s' or `within_window`'s' block.")
+      end.to raise_error(Capybara::ScopeError, /`switch_to_window` is not supposed to be invoked/)
     end
 
     it "should raise error when invoked inside `within_frame` as it's nonsense" do
@@ -87,16 +87,18 @@ Capybara::SpecHelper.spec '#switch_to_window', requires: [:windows] do
         @session.within_frame('frameOne') do
           @session.switch_to_window { @session.title == 'With Windows' }
         end
-      end.to raise_error(Capybara::ScopeError, "`switch_to_window` is not supposed to be invoked from `within`'s, `within_frame`'s' or `within_window`'s' block.")
+      end.to raise_error(Capybara::ScopeError, /`switch_to_window` is not supposed to be invoked from/)
     end
 
-    it "should raise error when invoked inside `within_window` as it's nonsense" do
-      window = (@session.windows - [@window]).first
-      expect do
-        @session.within_window window do
-          @session.switch_to_window { @session.title == 'With Windows' }
-        end
-      end.to raise_error(Capybara::ScopeError, "`switch_to_window` is not supposed to be invoked from `within`'s, `within_frame`'s' or `within_window`'s' block.")
+    it "should allow to be called inside within_window and within_window will still return to original" do
+      other_windows = (@session.windows - [@window])
+      expect(@session.current_window).to eq(@window)
+      @session.within_window other_windows[0] do
+        expect(@session.current_window).to eq(other_windows[0])
+        @session.switch_to_window other_windows[1]
+        expect(@session.current_window).to eq(other_windows[1])
+      end
+      expect(@session.current_window).to eq(@window)
     end
 
     it "should raise error if window matching block wasn't found" do

--- a/lib/capybara/spec/views/with_windows.erb
+++ b/lib/capybara/spec/views/with_windows.erb
@@ -46,5 +46,9 @@
     <button id="doesNotOpenWindows">Does not open windows</button>
 
     <iframe src="/frame_one" id="frameOne"></iframe>
+
+    <div id="scope">
+      <span>My scoped content</span>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Theres's no longer any need to prevent a user from doing

     within_window(window1) do
       ... do something ...
       within_window(window2) do
         ... do something in window2
       end
       .... do something else in window1
    end

This PR loosens the restrictions to allow for this (still can't be used inside `within_frame` blocks).  The restriction stays for `switch_to_window` since it can really screw things up if used inside within's