### PR TITLE
Switch to mini_mime gem from mime-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Capybara requires Ruby 1.9.3 or later. To install, add this line to your
 gem 'capybara'
 ```
 
-**Note:** If using Ruby < 2.0 you will also need to limit the version of mime-types to < 3.0 and the version of rack to < 2.0
+**Note:** If using Ruby < 2.0 you will also need to limit the version of rack to < 2.0
 
 If the application that you are testing is a Rails app, add this line to your test helper file:
 

--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.summary = "Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb"
 
   s.add_runtime_dependency("nokogiri", [">= 1.3.3"])
-  s.add_runtime_dependency("mime-types", [">= 1.16"])
+  s.add_runtime_dependency("mini_mime", [">= 0.1.3"])
   s.add_runtime_dependency("rack", [">= 1.0.0"])
   s.add_runtime_dependency("rack-test", [">= 0.5.4"])
   s.add_runtime_dependency("xpath", ["~> 2.0"])

--- a/gemfiles/Gemfile.base-versions
+++ b/gemfiles/Gemfile.base-versions
@@ -11,7 +11,6 @@ gem 'nokogiri', '= 1.3.3'
 gem 'rspec', '= 2.2.0'
 gem 'cucumber', '= 0.10.5'
 gem 'tins', '= 1.6.0'  # 1.7.0 requires ruby 2.0
-gem 'mime-types', '<3.0' # 3.0 require ruby 2.0
 gem 'addressable', '< 2.4.0' # 2.4.0 allows require 'addressable' previous don't
 gem 'json', '< 2.0'
 gem 'rake', '< 11.0'

--- a/gemfiles/Gemfile.ruby-19
+++ b/gemfiles/Gemfile.ruby-19
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gem 'bundler', '~> 1.1'
 gemspec path: '..'
 
-gem 'mime-types', '< 3.0'
 gem 'xpath', :git => 'git://github.com/teamcapybara/xpath.git'
 
 gem 'term-ansicolor', '< 1.4.0'

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rack/test'
 require 'rack/utils'
-require 'mime/types'
+require 'mini_mime'
 require 'nokogiri'
 require 'cgi'
 

--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -42,9 +42,7 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
               if (value = field['value']).to_s.empty?
                 NilUploadedFile.new
               else
-                types = MIME::Types.type_for(value)
-                content_type = types.sort_by.with_index { |type, idx| [type.obsolete? ? 1 : 0, idx] }.first.to_s
-                Rack::Test::UploadedFile.new(value, content_type)
+                Rack::Test::UploadedFile.new(value, MiniMime.lookup_by_filename(value).content_type)
               end
             merge_param!(params, field['name'].to_s, file)
           else


### PR DESCRIPTION
[mini_mime](https://github.com/discourse/mini_mime) is a much more performant replacement for the mime-types gem.  It uses the same database as mime-types, but loads it in a much more efficient manner, improving the number of allocations, memory, and speed.  The [mail](https://github.com/mikel/mail) gem, which is a core component of Rails, has already switched to it.  See https://github.com/mikel/mail/pull/1059 for more details on the mail gem changes, as well as the some performance numbers.  Bonus is that mini_mime supports Ruby versions all the way back to 1.8.7, so there's no need for a caveat anymore.

cc @SamSaffron
