### PR TITLE
Add all condtions to selector query error messages

### DIFF
--- a/features/step_definitions/capybara_steps.rb
+++ b/features/step_definitions/capybara_steps.rb
@@ -20,6 +20,6 @@ When(/^I use a matcher that fails$/) do
 end
 
 Then(/^the failing exception should be nice$/) do
-  expect(@error_message).to match %r(expected to find css \"h1#doesnotexist\")
+  expect(@error_message).to match %r(expected to find visible css \"h1#doesnotexist\")
 end
 

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -44,6 +44,8 @@ module Capybara
 
       def description
         @description = String.new()
+        @description << "visible " if visible == :visible
+        @description << "non-visible " if visible == :hidden
         @description << "#{label} #{locator.inspect}"
         @description << " with#{" exact" if exact_text == true} text #{options[:text].inspect}" if options[:text]
         @description << " with exact text #{options[:exact_text]}" if options[:exact_text].is_a?(String)

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -43,7 +43,8 @@ module Capybara
       def label; selector.label or selector.name; end
 
       def description
-        @description = String.new("#{label} #{locator.inspect}")
+        @description = String.new()
+        @description << "#{label} #{locator.inspect}"
         @description << " with#{" exact" if exact_text == true} text #{options[:text].inspect}" if options[:text]
         @description << " with exact text #{options[:exact_text]}" if options[:exact_text].is_a?(String)
         @description << " with id #{options[:id]}" if options[:id]

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -14,6 +14,7 @@ Capybara::Selector::FilterSet.add(:_field) do
     states << 'checked' if options[:checked] || (options[:unchecked] == false)
     states << 'not checked' if options[:unchecked] || (options[:checked] == false)
     states << 'disabled' if options[:disabled] == true
+    states << 'not disabled' if options[:disabled] == false
     desc << " that is #{states.join(' and ')}" unless states.empty?
     desc << " with the multiple attribute" if options[:multiple] == true
     desc << " without the multiple attribute" if options[:multiple] == false

--- a/lib/capybara/selector/filter_set.rb
+++ b/lib/capybara/selector/filter_set.rb
@@ -25,7 +25,14 @@ module Capybara
       end
 
       def description(options={})
-        @descriptions.map {|desc| desc.call(options).to_s }.join
+        options_with_defaults = options.dup
+        filters.each do |name, filter|
+          options_with_defaults[name] = filter.default if filter.default? && !options_with_defaults.has_key?(name)
+        end
+
+        @descriptions.map do |desc|
+          desc.call(options_with_defaults).to_s
+        end.join
       end
 
       def filters

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -202,6 +202,7 @@ module Capybara
       f_set.filters.each do |n, filter|
         custom_filters[n] = filter if filters_to_use.nil? || filters_to_use.include?(n)
       end
+
       f_set.descriptions.each { |desc| @filter_set.describe(&desc) }
     end
 

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -81,7 +81,7 @@ Capybara::SpecHelper.spec "#attach_file" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find file field \"does not exist\" that is not disabled"
+      msg = "Unable to find visible file field \"does not exist\" that is not disabled"
       expect do
         @session.attach_file('does not exist', @test_file_path)
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -81,7 +81,7 @@ Capybara::SpecHelper.spec "#attach_file" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find file field \"does not exist\""
+      msg = "Unable to find file field \"does not exist\" that is not disabled"
       expect do
         @session.attach_file('does not exist', @test_file_path)
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -69,7 +69,7 @@ Capybara::SpecHelper.spec "#check" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find checkbox \"does not exist\" that is not disabled"
+      msg = "Unable to find visible checkbox \"does not exist\" that is not disabled"
       expect do
         @session.check('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -142,11 +142,11 @@ Capybara::SpecHelper.spec "#check" do
       end
 
       it "should raise original error when no label available" do
-        expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel" that is not disabled')
+        expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_ariel" that is not disabled')
       end
 
       it "should raise error if not allowed to click label" do
-        expect{@session.check('form_cars_mclaren', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren" that is not disabled')
+        expect{@session.check('form_cars_mclaren', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_mclaren" that is not disabled')
       end
     end
 
@@ -158,7 +158,7 @@ Capybara::SpecHelper.spec "#check" do
       end
 
       it "should raise error if checkbox not visible" do
-        expect{@session.check('form_cars_mclaren')}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren" that is not disabled')
+        expect{@session.check('form_cars_mclaren')}.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_mclaren" that is not disabled')
       end
 
       context "with allow_label_click == true" do

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -69,7 +69,7 @@ Capybara::SpecHelper.spec "#check" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find checkbox \"does not exist\""
+      msg = "Unable to find checkbox \"does not exist\" that is not disabled"
       expect do
         @session.check('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -142,11 +142,11 @@ Capybara::SpecHelper.spec "#check" do
       end
 
       it "should raise original error when no label available" do
-        expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel"')
+        expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel" that is not disabled')
       end
 
       it "should raise error if not allowed to click label" do
-        expect{@session.check('form_cars_mclaren', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren"')
+        expect{@session.check('form_cars_mclaren', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren" that is not disabled')
       end
     end
 
@@ -158,7 +158,7 @@ Capybara::SpecHelper.spec "#check" do
       end
 
       it "should raise error if checkbox not visible" do
-        expect{@session.check('form_cars_mclaren')}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren"')
+        expect{@session.check('form_cars_mclaren')}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_mclaren" that is not disabled')
       end
 
       context "with allow_label_click == true" do

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -24,7 +24,7 @@ Capybara::SpecHelper.spec "#choose" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find radio button \"does not exist\" that is not disabled"
+      msg = "Unable to find visible radio button \"does not exist\" that is not disabled"
       expect do
         @session.choose('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -82,7 +82,7 @@ Capybara::SpecHelper.spec "#choose" do
       end
 
       it "should raise error if not allowed to click label" do
-        expect{@session.choose("party_democrat", allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find radio button "party_democrat" that is not disabled')
+        expect{@session.choose("party_democrat", allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find visible radio button "party_democrat" that is not disabled')
       end
     end
   end

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -24,7 +24,7 @@ Capybara::SpecHelper.spec "#choose" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find radio button \"does not exist\""
+      msg = "Unable to find radio button \"does not exist\" that is not disabled"
       expect do
         @session.choose('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -82,7 +82,7 @@ Capybara::SpecHelper.spec "#choose" do
       end
 
       it "should raise error if not allowed to click label" do
-        expect{@session.choose("party_democrat", allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find radio button "party_democrat"')
+        expect{@session.choose("party_democrat", allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find radio button "party_democrat" that is not disabled')
       end
     end
   end

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -353,7 +353,7 @@ Capybara::SpecHelper.spec '#click_button' do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find button \"does not exist\""
+      msg = "Unable to find visible button \"does not exist\""
       expect do
         @session.click_button('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/click_link_or_button_spec.rb
+++ b/lib/capybara/spec/session/click_link_or_button_spec.rb
@@ -54,7 +54,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
     context "when `false`" do
       it "does not click on link which matches approximately" do
         @session.visit('/with_html')
-        msg = "Unable to find link or button \"abore\""
+        msg = "Unable to find visible link or button \"abore\""
         expect do
           @session.click_link_or_button('abore', exact:  true)
         end.to raise_error(Capybara::ElementNotFound, msg)
@@ -62,7 +62,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
 
       it "does not click on approximately matching button" do
         @session.visit('/form')
-        msg = "Unable to find link or button \"awe\""
+        msg = "Unable to find visible link or button \"awe\""
 
         expect do
           @session.click_link_or_button('awe', exact:  true)
@@ -74,7 +74,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
   context "with a locator that doesn't exist" do
     it "should raise an error" do
       @session.visit('/with_html')
-      msg = "Unable to find link or button \"does not exist\""
+      msg = "Unable to find visible link or button \"does not exist\""
       expect do
         @session.click_link_or_button('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -67,7 +67,7 @@ Capybara::SpecHelper.spec '#click_link' do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find link \"does not exist\""
+      msg = "Unable to find visible link \"does not exist\""
       expect do
         @session.click_link('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -156,7 +156,7 @@ Capybara::SpecHelper.spec "#fill_in" do
     before { Capybara.ignore_hidden_elements = true }
     after  { Capybara.ignore_hidden_elements = false }
     it "should not find a hidden field" do
-      msg = "Unable to find field \"Super Secret\" that is not disabled"
+      msg = "Unable to find visible field \"Super Secret\" that is not disabled"
       expect do
         @session.fill_in('Super Secret', with: '777')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -165,7 +165,7 @@ Capybara::SpecHelper.spec "#fill_in" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find field \"does not exist\" that is not disabled"
+      msg = "Unable to find visible field \"does not exist\" that is not disabled"
       expect do
         @session.fill_in('does not exist', with: 'Blah blah')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -156,7 +156,7 @@ Capybara::SpecHelper.spec "#fill_in" do
     before { Capybara.ignore_hidden_elements = true }
     after  { Capybara.ignore_hidden_elements = false }
     it "should not find a hidden field" do
-      msg = "Unable to find field \"Super Secret\""
+      msg = "Unable to find field \"Super Secret\" that is not disabled"
       expect do
         @session.fill_in('Super Secret', with: '777')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -165,7 +165,7 @@ Capybara::SpecHelper.spec "#fill_in" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find field \"does not exist\""
+      msg = "Unable to find field \"does not exist\" that is not disabled"
       expect do
         @session.fill_in('does not exist', with: 'Blah blah')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -205,7 +205,7 @@ Capybara::SpecHelper.spec '#find' do
   it "should raise ElementNotFound with a useful default message if nothing was found" do
     expect do
       @session.find(:xpath, '//div[@id="nosuchthing"]').to be_nil
-    end.to raise_error(Capybara::ElementNotFound, "Unable to find xpath \"//div[@id=\\\"nosuchthing\\\"]\"")
+    end.to raise_error(Capybara::ElementNotFound, "Unable to find visible xpath \"//div[@id=\\\"nosuchthing\\\"]\"")
   end
 
   it "should accept an XPath instance" do

--- a/lib/capybara/spec/session/select_spec.rb
+++ b/lib/capybara/spec/session/select_spec.rb
@@ -85,7 +85,7 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find select box \"does not exist\""
+      msg = "Unable to find select box \"does not exist\" that is not disabled"
       expect do
         @session.select('foo', from: 'does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/select_spec.rb
+++ b/lib/capybara/spec/session/select_spec.rb
@@ -85,7 +85,7 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find select box \"does not exist\" that is not disabled"
+      msg = "Unable to find visible select box \"does not exist\" that is not disabled"
       expect do
         @session.select('foo', from: 'does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -94,7 +94,7 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find option \"Does not Exist\""
+      msg = "Unable to find visible option \"Does not Exist\""
       expect do
         @session.select('Does not Exist', from: 'form_locale')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -69,11 +69,11 @@ Capybara::SpecHelper.spec "#uncheck" do
       end
 
       it "should raise original error when no label available" do
-        expect { @session.uncheck('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel" that is not disabled')
+        expect { @session.uncheck('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_ariel" that is not disabled')
       end
 
       it "should raise error if not allowed to click label" do
-        expect{@session.uncheck('form_cars_jaguar', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_jaguar" that is not disabled')
+        expect{@session.uncheck('form_cars_jaguar', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_jaguar" that is not disabled')
       end
     end
   end

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -69,11 +69,11 @@ Capybara::SpecHelper.spec "#uncheck" do
       end
 
       it "should raise original error when no label available" do
-        expect { @session.uncheck('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel"')
+        expect { @session.uncheck('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_ariel" that is not disabled')
       end
 
       it "should raise error if not allowed to click label" do
-        expect{@session.uncheck('form_cars_jaguar', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_jaguar"')
+        expect{@session.uncheck('form_cars_jaguar', allow_label_click: false)}.to raise_error(Capybara::ElementNotFound, 'Unable to find checkbox "form_cars_jaguar" that is not disabled')
       end
     end
   end

--- a/lib/capybara/spec/session/unselect_spec.rb
+++ b/lib/capybara/spec/session/unselect_spec.rb
@@ -55,7 +55,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find select box \"does not exist\""
+      msg = "Unable to find select box \"does not exist\" that is not disabled"
       expect do
         @session.unselect('foo', from: 'does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -64,7 +64,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find option \"Does not Exist\""
+      msg = 'Unable to find option "Does not Exist"'
       expect do
         @session.unselect('Does not Exist', from: 'form_underwear')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/unselect_spec.rb
+++ b/lib/capybara/spec/session/unselect_spec.rb
@@ -55,7 +55,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find select box \"does not exist\" that is not disabled"
+      msg = "Unable to find visible select box \"does not exist\" that is not disabled"
       expect do
         @session.unselect('foo', from: 'does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -64,7 +64,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = 'Unable to find option "Does not Exist"'
+      msg = 'Unable to find visible option "Does not Exist"'
       expect do
         @session.unselect('Does not Exist', from: 'form_underwear')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/spec/minitest_spec_spec.rb
+++ b/spec/minitest_spec_spec.rb
@@ -122,6 +122,6 @@ RSpec.describe 'capybara/minitest/spec' do
     reporter.report
     expect(output.string).to include("16 runs, 39 assertions, 1 failures, 0 errors, 0 skips")
     #Make sure error messages are displayed
-    expect(output.string).to include('expected to find select box "non_existing_form_title" that is not disabled but there were no matches')
+    expect(output.string).to include('expected to find visible select box "non_existing_form_title" that is not disabled but there were no matches')
   end
 end

--- a/spec/minitest_spec_spec.rb
+++ b/spec/minitest_spec_spec.rb
@@ -122,6 +122,6 @@ RSpec.describe 'capybara/minitest/spec' do
     reporter.report
     expect(output.string).to include("16 runs, 39 assertions, 1 failures, 0 errors, 0 skips")
     #Make sure error messages are displayed
-    expect(output.string).to include('expected to find select box "non_existing_form_title" but there were no matches')
+    expect(output.string).to include('expected to find select box "non_existing_form_title" that is not disabled but there were no matches')
   end
 end

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
 
   describe "have_css matcher" do
     it "gives proper description" do
-      expect(have_css('h1').description).to eq("have css \"h1\"")
+      expect(have_css('h1').description).to eq("have visible css \"h1\"")
     end
 
     context "on a string" do
@@ -23,7 +23,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_css? returns false" do
           expect do
             expect("<h1>Text</h1>").to have_css('h2')
-          end.to raise_error(/expected to find css "h2" but there were no matches/)
+          end.to raise_error(/expected to find visible css "h2" but there were no matches/)
         end
 
         it "passes if matched node count equals expected count" do
@@ -33,25 +33,25 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if matched node count does not equal expected count" do
           expect do
             expect("<h1>Text</h1>").to have_css('h1', count: 2)
-          end.to raise_error("expected to find css \"h1\" 2 times, found 1 match: \"Text\"")
+          end.to raise_error("expected to find visible css \"h1\" 2 times, found 1 match: \"Text\"")
         end
 
         it "fails if matched node count is less than expected minimum count" do
           expect do
             expect("<h1>Text</h1>").to have_css('p', minimum: 1)
-          end.to raise_error("expected to find css \"p\" at least 1 time but there were no matches")
+          end.to raise_error("expected to find visible css \"p\" at least 1 time but there were no matches")
         end
 
         it "fails if matched node count is more than expected maximum count" do
           expect do
             expect("<h1>Text</h1><h1>Text</h1><h1>Text</h1>").to have_css('h1', maximum: 2)
-          end.to raise_error('expected to find css "h1" at most 2 times, found 3 matches: "Text", "Text", "Text"')
+          end.to raise_error('expected to find visible css "h1" at most 2 times, found 3 matches: "Text", "Text", "Text"')
         end
 
         it "fails if matched node count does not belong to expected range" do
           expect do
             expect("<h1>Text</h1>").to have_css('h1', between: 2..3)
-          end.to raise_error("expected to find css \"h1\" between 2 and 3 times, found 1 match: \"Text\"")
+          end.to raise_error("expected to find visible css \"h1\" between 2 and 3 times, found 1 match: \"Text\"")
         end
 
       end
@@ -64,7 +64,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_no_css? returns false" do
           expect do
             expect("<h1>Text</h1>").not_to have_css('h1')
-          end.to raise_error(/expected not to find css "h1"/)
+          end.to raise_error(/expected not to find visible css "h1"/)
         end
 
         it "passes if matched node count does not equal expected count" do
@@ -74,7 +74,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if matched node count equals expected count" do
           expect do
             expect("<h1>Text</h1>").not_to have_css('h1', count: 1)
-          end.to raise_error(/expected not to find css "h1"/)
+          end.to raise_error(/expected not to find visible css "h1"/)
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_css? returns false" do
           expect do
             expect(page).to have_css('h1#doesnotexist')
-          end.to raise_error(/expected to find css "h1#doesnotexist" but there were no matches/)
+          end.to raise_error(/expected to find visible css "h1#doesnotexist" but there were no matches/)
         end
       end
 
@@ -109,7 +109,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_no_css? returns false" do
           expect do
             expect(page).not_to have_css('h1')
-          end.to raise_error(/expected not to find css "h1"/)
+          end.to raise_error(/expected not to find visible css "h1"/)
         end
       end
     end
@@ -117,7 +117,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
 
   describe "have_xpath matcher" do
     it "gives proper description" do
-      expect(have_xpath('//h1').description).to eq("have xpath \"\/\/h1\"")
+      expect(have_xpath('//h1').description).to eq("have visible xpath \"\/\/h1\"")
     end
 
     context "on a string" do
@@ -129,7 +129,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_xpath? returns false" do
           expect do
             expect("<h1>Text</h1>").to have_xpath('//h2')
-          end.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
+          end.to raise_error(%r(expected to find visible xpath "//h2" but there were no matches))
         end
       end
 
@@ -141,7 +141,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_no_xpath? returns false" do
           expect do
             expect("<h1>Text</h1>").not_to have_xpath('//h1')
-          end.to raise_error(%r(expected not to find xpath "//h1"))
+          end.to raise_error(%r(expected not to find visible xpath "//h1"))
         end
       end
 
@@ -164,7 +164,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_xpath? returns false" do
           expect do
             expect(page).to have_xpath("//h1[@id='doesnotexist']")
-          end.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
+          end.to raise_error(%r(expected to find visible xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
         end
       end
 
@@ -176,7 +176,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_no_xpath? returns false" do
           expect do
             expect(page).not_to have_xpath('//h1')
-          end.to raise_error(%r(expected not to find xpath "//h1"))
+          end.to raise_error(%r(expected not to find visible xpath "//h1"))
         end
       end
     end
@@ -186,7 +186,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     it "gives proper description" do
       matcher = have_selector('//h1')
       expect("<h1>Text</h1>").to matcher
-      expect(matcher.description).to eq("have xpath \"//h1\"")
+      expect(matcher.description).to eq("have visible xpath \"//h1\"")
     end
 
     context "on a string" do
@@ -198,7 +198,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_selector? returns false" do
           expect do
             expect("<h1>Text</h1>").to have_selector('//h2')
-          end.to raise_error(%r(expected to find xpath "//h2" but there were no matches))
+          end.to raise_error(%r(expected to find visible xpath "//h2" but there were no matches))
         end
       end
 
@@ -210,7 +210,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_no_selector? returns false" do
           expect do
             expect("<h1>Text</h1>").not_to have_selector(:css, 'h1')
-          end.to raise_error(%r(expected not to find css "h1"))
+          end.to raise_error(%r(expected not to find visible css "h1"))
         end
       end
     end
@@ -228,13 +228,13 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_selector? returns false" do
           expect do
             expect(page).to have_selector("//h1[@id='doesnotexist']")
-          end.to raise_error(%r(expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
+          end.to raise_error(%r(expected to find visible xpath "//h1\[@id='doesnotexist'\]" but there were no matches))
         end
 
         it "includes text in error message" do
           expect do
             expect(page).to have_selector("//h1", text: 'wrong text')
-          end.to raise_error(%r(expected to find xpath "//h1" with text "wrong text" but there were no matches))
+          end.to raise_error(%r(expected to find visible xpath "//h1" with text "wrong text" but there were no matches))
         end
       end
 
@@ -246,7 +246,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
         it "fails if has_no_selector? returns false" do
           expect do
             expect(page).not_to have_selector(:css, 'h1', text: 'test')
-          end.to raise_error(%r(expected not to find css "h1" with text "test"))
+          end.to raise_error(%r(expected not to find visible css "h1" with text "test"))
         end
       end
     end
@@ -484,7 +484,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<a href="#">Just a link</a><a href="#">Another link</a>' }
 
     it "gives proper description" do
-      expect(have_link('Just a link').description).to eq("have link \"Just a link\"")
+      expect(have_link('Just a link').description).to eq("have visible link \"Just a link\"")
     end
 
     it "passes if there is such a button" do
@@ -494,7 +494,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     it "fails if there is no such button" do
       expect do
         expect(html).to have_link('No such Link')
-      end.to raise_error(/expected to find link "No such Link"/)
+      end.to raise_error(/expected to find visible link "No such Link"/)
     end
 
     it "supports compounding" do
@@ -618,7 +618,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<button>A button</button><input type="submit" value="Another button"/>' }
 
     it "gives proper description" do
-      expect(have_button('A button').description).to eq("have button \"A button\"")
+      expect(have_button('A button').description).to eq("have visible button \"A button\"")
     end
 
     it "passes if there is such a button" do
@@ -628,7 +628,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     it "fails if there is no such button" do
       expect do
         expect(html).to have_button('No such Button')
-      end.to raise_error(/expected to find button "No such Button"/)
+      end.to raise_error(/expected to find visible button "No such Button"/)
     end
 
     it "supports compounding" do
@@ -640,11 +640,11 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<p><label>Text field<input type="text" value="some value"/></label></p>' }
 
     it "gives proper description" do
-      expect(have_field('Text field').description).to eq("have field \"Text field\" that is not disabled")
+      expect(have_field('Text field').description).to eq("have visible field \"Text field\" that is not disabled")
     end
 
     it "gives proper description for a given value" do
-      expect(have_field('Text field', with: 'some value').description).to eq("have field \"Text field\" that is not disabled with value \"some value\"")
+      expect(have_field('Text field', with: 'some value').description).to eq("have visible field \"Text field\" that is not disabled with value \"some value\"")
     end
 
     it "passes if there is such a field" do
@@ -658,13 +658,13 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     it "fails if there is no such field" do
       expect do
         expect(html).to have_field('No such Field')
-      end.to raise_error(/expected to find field "No such Field"/)
+      end.to raise_error(/expected to find visible field "No such Field"/)
     end
 
     it "fails if there is such field but with false value" do
       expect do
         expect(html).to have_field('Text field', with: 'false value')
-      end.to raise_error(/expected to find field "Text field"/)
+      end.to raise_error(/expected to find visible field "Text field"/)
     end
 
     it "treats a given value as a string" do
@@ -688,7 +688,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     end
 
     it "gives proper description" do
-      expect(have_checked_field('it is checked').description).to eq("have field \"it is checked\" that is checked and not disabled")
+      expect(have_checked_field('it is checked').description).to eq("have visible field \"it is checked\" that is checked and not disabled")
     end
 
     context "with should" do
@@ -699,13 +699,13 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
       it "fails if there is such a field but it is not checked" do
         expect do
           expect(html).to have_checked_field('unchecked field')
-        end.to raise_error(/expected to find field "unchecked field"/)
+        end.to raise_error(/expected to find visible field "unchecked field"/)
       end
 
       it "fails if there is no such field" do
         expect do
           expect(html).to have_checked_field('no such field')
-        end.to raise_error(/expected to find field "no such field"/)
+        end.to raise_error(/expected to find visible field "no such field"/)
       end
     end
 
@@ -713,7 +713,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
       it "fails if there is such a field and it is checked" do
         expect do
           expect(html).not_to have_checked_field('it is checked')
-        end.to raise_error(/expected not to find field "it is checked"/)
+        end.to raise_error(/expected not to find visible field "it is checked"/)
       end
 
       it "passes if there is such a field but it is not checked" do
@@ -737,7 +737,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     end
 
     it "gives proper description" do
-      expect(have_unchecked_field('unchecked field').description).to eq("have field \"unchecked field\" that is not checked and not disabled")
+      expect(have_unchecked_field('unchecked field').description).to eq("have visible field \"unchecked field\" that is not checked and not disabled")
     end
 
     context "with should" do
@@ -748,13 +748,13 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
       it "fails if there is such a field but it is checked" do
         expect do
           expect(html).to have_unchecked_field('it is checked')
-        end.to raise_error(/expected to find field "it is checked"/)
+        end.to raise_error(/expected to find visible field "it is checked"/)
       end
 
       it "fails if there is no such field" do
         expect do
           expect(html).to have_unchecked_field('no such field')
-        end.to raise_error(/expected to find field "no such field"/)
+        end.to raise_error(/expected to find visible field "no such field"/)
       end
     end
 
@@ -762,7 +762,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
       it "fails if there is such a field and it is not checked" do
         expect do
           expect(html).not_to have_unchecked_field('unchecked field')
-        end.to raise_error(/expected not to find field "unchecked field"/)
+        end.to raise_error(/expected not to find visible field "unchecked field"/)
       end
 
       it "passes if there is such a field but it is checked" do
@@ -783,11 +783,11 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<label>Select Box<select></select></label>' }
 
     it "gives proper description" do
-      expect(have_select('Select Box').description).to eq("have select box \"Select Box\" that is not disabled")
+      expect(have_select('Select Box').description).to eq("have visible select box \"Select Box\" that is not disabled")
     end
 
     it "gives proper description for a given selected value" do
-      expect(have_select('Select Box', selected: 'some value').description).to eq('have select box "Select Box" that is not disabled with "some value" selected')
+      expect(have_select('Select Box', selected: 'some value').description).to eq('have visible select box "Select Box" that is not disabled with "some value" selected')
     end
 
     it "passes if there is such a select" do
@@ -797,7 +797,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     it "fails if there is no such select" do
       expect do
         expect(html).to have_select('No such Select box')
-      end.to raise_error(/expected to find select box "No such Select box"/)
+      end.to raise_error(/expected to find visible select box "No such Select box"/)
     end
 
     it "supports compounding" do
@@ -809,7 +809,14 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<table><caption>Lovely table</caption></table>' }
 
     it "gives proper description" do
-      expect(have_table('Lovely table').description).to eq("have table \"Lovely table\"")
+      expect(have_table('Lovely table').description).to eq("have visible table \"Lovely table\"")
+    end
+
+    it "gives proper description when :visible option passed" do
+      expect(have_table('Lovely table', visible: true).description).to eq("have visible table \"Lovely table\"")
+      expect(have_table('Lovely table', visible: :hidden).description).to eq("have non-visible table \"Lovely table\"")
+      expect(have_table('Lovely table', visible: :all).description).to eq("have table \"Lovely table\"")
+      expect(have_table('Lovely table', visible: false).description).to eq("have table \"Lovely table\"")
     end
 
     it "passes if there is such a select" do
@@ -819,7 +826,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     it "fails if there is no such select" do
       expect do
         expect(html).to have_table('No such Table')
-      end.to raise_error(/expected to find table "No such Table"/)
+      end.to raise_error(/expected to find visible table "No such Table"/)
     end
 
     it "supports compounding" do

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -640,11 +640,11 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<p><label>Text field<input type="text" value="some value"/></label></p>' }
 
     it "gives proper description" do
-      expect(have_field('Text field').description).to eq("have field \"Text field\"")
+      expect(have_field('Text field').description).to eq("have field \"Text field\" that is not disabled")
     end
 
     it "gives proper description for a given value" do
-      expect(have_field('Text field', with: 'some value').description).to eq("have field \"Text field\" with value \"some value\"")
+      expect(have_field('Text field', with: 'some value').description).to eq("have field \"Text field\" that is not disabled with value \"some value\"")
     end
 
     it "passes if there is such a field" do
@@ -688,7 +688,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     end
 
     it "gives proper description" do
-      expect(have_checked_field('it is checked').description).to eq("have field \"it is checked\" that is checked")
+      expect(have_checked_field('it is checked').description).to eq("have field \"it is checked\" that is checked and not disabled")
     end
 
     context "with should" do
@@ -737,7 +737,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     end
 
     it "gives proper description" do
-      expect(have_unchecked_field('unchecked field').description).to eq("have field \"unchecked field\" that is not checked")
+      expect(have_unchecked_field('unchecked field').description).to eq("have field \"unchecked field\" that is not checked and not disabled")
     end
 
     context "with should" do
@@ -783,11 +783,11 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
     let(:html) { '<label>Select Box<select></select></label>' }
 
     it "gives proper description" do
-      expect(have_select('Select Box').description).to eq("have select box \"Select Box\"")
+      expect(have_select('Select Box').description).to eq("have select box \"Select Box\" that is not disabled")
     end
 
     it "gives proper description for a given selected value" do
-      expect(have_select('Select Box', selected: 'some value').description).to eq("have select box \"Select Box\" with \"some value\" selected")
+      expect(have_select('Select Box', selected: 'some value').description).to eq('have select box "Select Box" that is not disabled with "some value" selected')
     end
 
     it "passes if there is such a select" do


### PR DESCRIPTION
This adds the visibility requirement and filters with default values to the error descriptions for selector queries.  Issue #1891 