### PR TITLE
Silence puma output

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -448,7 +448,7 @@ end
 
 Capybara.register_server :puma do |app, port, host|
   require 'rack/handler/puma'
-  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false)
+  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false, Silent: true)
 end
 
 Capybara.configure do |config|


### PR DESCRIPTION
Without this, I see the following output when I run my tests:

Puma starting in single mode...
* Version 3.8.2 (ruby 2.4.0-p0), codename: Sassy Salamander
* Min threads: 0, max threads: 4
* Environment: test
* Listening on tcp://127.0.0.1:37739
Use Ctrl-C to stop