### PR TITLE
Allow registered servers to receive options

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,13 @@ Capybara.app = MyRackApp
 ```
 
 If you need to test JavaScript, or if your app interacts with (or is located at)
-a remote URL, you'll need to [use a different driver](#drivers).
+a remote URL, you'll need to [use a different driver](#drivers).  If using Rails 5.0+, but not using the Rails system tests from 5.1, you'll probably also
+want to swap the "server" used to launch your app to Puma in order to match Rails defaults.
+
+```ruby
+Capybara.server = :puma # Until your setup is working
+Capybara.server = :puma, { Silent: true } # To clean up your test output
+```
 
 ## <a name="using-capybara-with-cucumber"></a>Using Capybara with Cucumber
 

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -441,14 +441,14 @@ Capybara.register_server :default do |app, port, _host|
   Capybara.run_default_server(app, port)
 end
 
-Capybara.register_server :webrick do |app, port, host|
+Capybara.register_server :webrick do |app, port, host, options={}|
   require 'rack/handler/webrick'
-  Rack::Handler::WEBrick.run(app, Host: host, Port: port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0))
+  Rack::Handler::WEBrick.run(app, {Host: host, Port: port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0)}.merge(options))
 end
 
-Capybara.register_server :puma do |app, port, host|
+Capybara.register_server :puma do |app, port, host, options={}|
   require 'rack/handler/puma'
-  Rack::Handler::Puma.run(app, Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false)
+  Rack::Handler::Puma.run(app, {Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false}.merge(options))
 end
 
 Capybara.configure do |config|

--- a/lib/capybara/config.rb
+++ b/lib/capybara/config.rb
@@ -51,15 +51,25 @@ module Capybara
     # Set the server to use.
     #
     #     Capybara.server = :webrick
+    #     Capybara.server = :puma, { Silent: true }
     #
-    # @param [Symbol] name     Name of the server type to use
+    # @overload server=(name)
+    #   @param [Symbol] name     Name of the server type to use
+    # @overload server=([name, options])
+    #   @param [Symbol] name Name of the server type to use
+    #   @param [Hash] options Options to pass to the server block
     # @see register_server
     #
     def server=(name)
+      name, options = *name if name.is_a? Array
       @server = if name.respond_to? :call
         name
       else
-        Capybara.servers[name.to_sym]
+        if options
+          Proc.new { |app, port, host| Capybara.servers[name.to_sym].call(app,port,host,options) }
+        else
+          Capybara.servers[name.to_sym]
+        end
       end
     end
 

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -92,8 +92,16 @@ RSpec.describe Capybara do
       require 'rack/handler/puma'
       mock_app = double('app')
       Capybara.server = :puma
-      expect(Rack::Handler::Puma).to receive(:run)
+      expect(Rack::Handler::Puma).to receive(:run).with(mock_app, hash_including(Host: nil, Port: 8000))
       Capybara.server.call(mock_app, 8000)
+    end
+
+    it "should pass options to server" do
+      require 'rack/handler/puma'
+      mock_app = double('app')
+      Capybara.server = :puma, { Silent: true }
+      expect(Rack::Handler::Puma).to receive(:run).with(mock_app, hash_including(Host: nil, Port: 9000, Silent: true))
+      Capybara.server.call(mock_app, 9000)
     end
   end
 


### PR DESCRIPTION
Option to PR# 1896 that leaves the default outputting useful info.  Experience users can then opt to silence Puma when wanted without having to register their own server block.