### PR TITLE
Don't override port if it's explicitly specified

### DIFF
--- a/lib/capybara/spec/session/visit_spec.rb
+++ b/lib/capybara/spec/session/visit_spec.rb
@@ -63,6 +63,23 @@ Capybara::SpecHelper.spec '#visit' do
       expect(URI.parse(@session.current_url).port).to eq(root_uri.port)
       expect(@session).to have_content('Another World')
     end
+
+    it "should add the server port to a visited url if no port specified", requires: [:server] do
+      expect(@session.driver).to receive(:visit).with("http://www.example.com:#{@session.server.port}")
+      @session.visit("http://www.example.com")
+    end
+
+    it "should not override the visit specified port even if default for scheme", requires: [:server] do
+      expect(@session.driver).to receive(:visit).with("http://www.example.com:80")
+      @session.visit('http://www.example.com:80')
+    end
+
+    it "should give preference to app_host port if specified", requires: [:server] do
+      Capybara.app_host = "http://www.example.com:6666"
+      expect(@session.driver).to receive(:visit).with("http://www.example.com:6666/random")
+      @session.visit('/random')
+    end
+
   end
 
   context "without a server", requires: [:server] do


### PR DESCRIPTION
`Visit` with Capybara.always_include_port == true shouldn't override an explicitly specified default port.  ie.  

    visit('http://www.example.com') => should visit http://www.example.com:<server port>

but

    visit('http://www.example.com:80) => should visit http://www.example.com:80