### PR TITLE
Don't wait for element during inspection

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -371,9 +371,9 @@ module Capybara
       end
 
       def inspect
-        %(#<Capybara::Node::Element tag="#{tag_name}" path="#{path}">)
+        %(#<Capybara::Node::Element tag="#{base.tag_name}" path="#{base.path}">)
       rescue NotSupportedByDriverError
-        %(#<Capybara::Node::Element tag="#{tag_name}">)
+        %(#<Capybara::Node::Element tag="#{base.tag_name}">)
       rescue => e
         if session.driver.invalid_element_errors.any? { |et| e.is_a?(et)}
           %(Obsolete #<Capybara::Node::Element>)

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -161,7 +161,8 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
       it "outputs obsolete elements" do
         @session.visit('/form')
         el = @session.find(:button, 'Click me!').click
-        sleep 2
+        expect(@session).to have_no_button('Click me!')
+        expect(el).not_to receive(:synchronize)
         expect(el.inspect).to eq "Obsolete #<Capybara::Node::Element>"
       end
     end


### PR DESCRIPTION
In the current implementation, if you inspecting stale element, Capybara will wait for `default_max_wait_time` before inspecting it.
In proposed patch, this behavior is changed to immediately return obsolete element

If you have the stale collection of element this wait is multiplied by the number of elements in the collection.