### PR TITLE
Fix detection of headless Chrome

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -320,7 +320,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   def headless_chrome?
     if chrome?
       caps = @processed_options[:desired_capabilities]
-      chrome_options = caps[:chrome_options] || caps[:chromeOptions] || {}
+      chrome_options = caps[:chrome_options] || caps[:chromeOptions] || caps['chromeOptions'] || {}
       args = chrome_options['args'] || chrome_options[:args] || []
       return args.include?("--headless") || args.include?("headless")
     end


### PR DESCRIPTION
Passing in a symbol for `chromeOptions` does not appear to do the right
thing. `chromeOptions` in String form appears to be the correct format for
`Selenium::WebDriver::Remote::Capabilities`.