### PR TITLE
[fix] selenium set_text passing in empty string with options

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -209,7 +209,7 @@ private
   def set_text(value, options)
     if readonly?
       warn "Attempt to set readonly element with value: #{value} \n *This will raise an exception in a future version of Capybara"
-    elsif value.to_s.empty?
+    elsif value.to_s.empty? && options[:clear].nil?
       native.clear
     else
       if options[:clear] == :backspace

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -37,6 +37,9 @@ $(function() {
   $('#with_change_event').change(function() {
     $('body').append($('<p class="change_event_triggered"></p>').text(this.value));
   });
+  $('#with_change_event').on('input', function() {
+    $('body').append($('<p class="input_event_triggered"></p>').text(this.value));
+  });
   $('#checkbox_with_event').click(function() {
     $('body').append('<p id="checkbox_event_triggered">Checkbox event triggered</p>');
   });

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -71,6 +71,16 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
       end
     end
 
+    context '#fill_in_with empty string and no options' do
+      it 'should trigger change when clearing a field' do
+        @session.visit('/with_js')
+        @session.fill_in('with_change_event', with: '')
+        # click outside the field to trigger the change event
+        @session.find(:css, 'body').click
+        expect(@session).to have_selector(:css, '.change_event_triggered', match: :one)
+      end
+    end
+
     context "#fill_in with { :clear => :backspace } fill_option", requires: [:js] do
       it 'should fill in a field, replacing an existing value' do
         @session.visit('/form')
@@ -95,6 +105,15 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
         # click outside the field to trigger the change event
         @session.find(:css, 'body').click
         expect(@session).to have_selector(:css, '.change_event_triggered', match: :one)
+      end
+
+      it 'should trigger input event field_value.length times' do
+        @session.visit('/with_js')
+        @session.fill_in('with_change_event', with: '',
+                         fill_options: { :clear => :backspace })
+        # click outside the field to trigger the change event
+        @session.find(:css, 'body').click
+        expect(@session).to have_xpath('//p[@class="input_event_triggered"]', count: 13)
       end
     end
 


### PR DESCRIPTION
If an empty value if passed in with a clear option, it seems that the
caller's intent is for the option to be honored regardless of the value
to be set in the field.

Just passing in a blank value without options would behave as it did before.

Related to this PR/use case: https://github.com/teamcapybara/capybara/pull/1498