### PR TITLE
Include within scope in element not found/ambiguous errors

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -306,6 +306,7 @@ module Capybara
           else
             result = query.resolve_for(self)
           end
+
           if query.match == :one or query.match == :smart and result.size > 1
             raise Capybara::Ambiguous.new("Ambiguous match, found #{result.size} elements matching #{query.description}")
           end

--- a/lib/capybara/queries/ancestor_query.rb
+++ b/lib/capybara/queries/ancestor_query.rb
@@ -4,7 +4,7 @@ module Capybara
     class AncestorQuery < MatchQuery
       # @api private
       def resolve_for(node, exact = nil)
-        @resolved_node = node
+        @child_node = node
         node.synchronize do
           match_results = super(node.session.current_scope, exact)
           node.all(:xpath, XPath.ancestor) do |el|
@@ -15,7 +15,7 @@ module Capybara
 
       def description
         desc = super
-        if @resolved_node && (child_query = @resolved_node.instance_variable_get(:@query))
+        if @child_node && (child_query = @child_node.instance_variable_get(:@query))
           desc += " that is an ancestor of #{child_query.description}"
         end
         desc

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -8,6 +8,7 @@ module Capybara
       VALID_MATCH = [:first, :smart, :prefer_exact, :one]
 
       def initialize(*args, &filter_block)
+        @resolved_node = nil
         @options = if args.last.is_a?(Hash) then args.pop.dup else {} end
         super(@options)
 
@@ -53,6 +54,7 @@ module Capybara
         @description << " with classes [#{Array(options[:class]).join(',')}]" if options[:class]
         @description << selector.description(options)
         @description << " that also matches the custom filter block" if @filter_block
+        @description << " within #{@resolved_node.inspect}" if describe_within?
         @description
       end
 
@@ -140,6 +142,7 @@ module Capybara
 
       # @api private
       def resolve_for(node, exact = nil)
+        @resolved_node = node
         node.synchronize do
           children = if selector.format == :css
             node.find_css(self.css)
@@ -238,6 +241,11 @@ module Capybara
 
       def exact_text
         options.fetch(:exact_text, session_options.exact_text)
+      end
+
+      def describe_within?
+        @resolved_node && !(@resolved_node.is_a?(::Capybara::Node::Document) ||
+                            (@resolved_node.is_a?(::Capybara::Node::Simple) && @resolved_node.path == '/'))
       end
     end
   end

--- a/lib/capybara/queries/sibling_query.rb
+++ b/lib/capybara/queries/sibling_query.rb
@@ -4,7 +4,7 @@ module Capybara
     class SiblingQuery < MatchQuery
       # @api private
       def resolve_for(node, exact = nil)
-        @resolved_node = node
+        @sibling_node = node
         node.synchronize do
           match_results = super(node.session.current_scope, exact)
           node.all(:xpath, XPath.preceding_sibling.union(XPath.following_sibling)) do |el|
@@ -15,8 +15,8 @@ module Capybara
 
       def description
         desc = super
-        if @resolved_node && (child_query = @resolved_node.instance_variable_get(:@query))
-          desc += " that is a sibling of #{child_query.description}"
+        if @sibling_node && (sibling_query = @sibling_node.instance_variable_get(:@query))
+          desc += " that is a sibling of #{sibling_query.description}"
         end
         desc
       end

--- a/lib/capybara/spec/session/select_spec.rb
+++ b/lib/capybara/spec/session/select_spec.rb
@@ -94,7 +94,7 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible option \"Does not Exist\""
+      msg = /^Unable to find visible option "Does not Exist" within/
       expect do
         @session.select('Does not Exist', from: 'form_locale')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/unselect_spec.rb
+++ b/lib/capybara/spec/session/unselect_spec.rb
@@ -64,7 +64,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = 'Unable to find visible option "Does not Exist"'
+      msg = /^Unable to find visible option "Does not Exist" within/
       expect do
         @session.unselect('Does not Exist', from: 'form_underwear')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/within_spec.rb
+++ b/lib/capybara/spec/session/within_spec.rb
@@ -101,7 +101,7 @@ Capybara::SpecHelper.spec '#within' do
           expect do
             @session.within(".//div[@id='doesnotexist']") do
             end
-          end.to raise_error(Capybara::ElementNotFound)
+          end.to raise_error(Capybara::ElementNotFound, %Q{Unable to find visible xpath ".//div[@id='doesnotexist']" within #<Capybara::Node::Element tag="div" path="/html/body/div[1]">})
         end.to_not change { @session.has_xpath?(".//div[@id='another_foo']") }.from(false)
       end
     end.to_not change { @session.has_xpath?(".//div[@id='another_foo']") }.from(true)


### PR DESCRIPTION
Include details of the scoping element when find errors are raised