### PR TITLE
Attempt to move element into view when selenium doesn't correctly do it

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -100,6 +100,14 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
 
   def click
     native.click
+  rescue => e
+    if e.message =~ /Other element would receive the click/
+      begin
+        driver.execute_script("arguments[0].scrollIntoView({behavior: 'instant', block: 'center', inline: 'center'})", self)
+      rescue
+      end
+    end
+    raise e
   end
 
   def right_click

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -101,7 +101,8 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   def click
     native.click
   rescue => e
-    if e.message =~ /Other element would receive the click/
+    if e.is_a?(::Selenium::WebDriver::Error::ElementClickInterceptedError) ||
+       e.message =~ /Other element would receive the click/
       begin
         driver.execute_script("arguments[0].scrollIntoView({behavior: 'instant', block: 'center', inline: 'center'})", self)
       rescue

--- a/lib/capybara/spec/views/with_fixed_header_footer.erb
+++ b/lib/capybara/spec/views/with_fixed_header_footer.erb
@@ -1,0 +1,17 @@
+<html>
+<head>
+  <style>
+    header { height: 45px; position: fixed; top: 0; background-color: red; width: 100%;}
+    footer { height: 45px; position: fixed; bottom: 0; background-color: red; width: 100%;}
+    #main { margin: 45px;}
+    #tall { display: block; height: 2000px;}
+  </style>
+</head>
+<body>
+  <header>My headers</header>
+    <div id="main">
+      <div id="tall">A tall block</div>
+      <a href="/">Go to root</a>
+    </div>
+  <footer>My footer</footer>
+</body>

--- a/spec/selenium_spec_marionette.rb
+++ b/spec/selenium_spec_marionette.rb
@@ -14,7 +14,7 @@ Capybara.register_driver :selenium_marionette do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :firefox,
-    desired_capabilities: {:marionette => true},
+    desired_capabilities: {marionette: true, 'moz:webdriverClick': true},
     options: browser_options
     # Get a trace level log from geckodriver
     # :driver_opts => { args: ['-vv'] }

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -194,7 +194,9 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
 
     describe "Element#click" do
       it "should handle fixed headers/footers" do
-        pending "geckodriver/firefox/marionette just fail to click without reporting an error - no way for us to detect/catch" if mode == :selenium_marionette
+        if mode == :selenium_marionette && !(ENV['TRAVIS_ALLOW_FAILURE']=='true')
+          pending "geckodriver/firefox/marionette just fail to click without reporting an error - no way for us to detect/catch"
+        end
         @session.visit('/with_fixed_header_footer')
         # @session.click_link('Go to root')
         @session.find(:link, 'Go to root').click

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -191,5 +191,15 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
         expect(el.inspect).to eq "Obsolete #<Capybara::Node::Element>"
       end
     end
+
+    describe "Element#click" do
+      it "should handle fixed headers/footers" do
+        pending "geckodriver/firefox/marionette just fail to click without reporting an error - no way for us to detect/catch" if mode == :selenium_marionette
+        @session.visit('/with_fixed_header_footer')
+        # @session.click_link('Go to root')
+        @session.find(:link, 'Go to root').click
+        expect(@session).to have_current_path('/')
+      end
+    end
   end
 end


### PR DESCRIPTION
On `click` when Chrome returns with an error about another element receiving the click this will attempt to move the target element to the middle of the page so it is out from behind fixed headers/footers - and then allow the click to retry.  Unfortunately current versions of Firefox with geckodriver don't return any error in this case, they just click the wrong element and silently move on so there's nothing we can really do for that.