### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.4
 
 #################### Lint ################################
 

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ Cucumber::Rake::Task.new(:cucumber) do |task|
   task.cucumber_opts = ['--format=progress', 'features']
 end
 
-task :travis do |t|
+task :travis do |_t|
   if ENV['CAPYBARA_FF']
     Rake::Task[:spec_marionette].invoke
   elsif ENV['CAPYBARA_LEGACY_FF']

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -6,7 +6,7 @@ class Capybara::Driver::Base
     raise NotImplementedError
   end
 
-  def visit(path)
+  def visit(_path)
     raise NotImplementedError
   end
 
@@ -14,11 +14,11 @@ class Capybara::Driver::Base
     raise NotImplementedError
   end
 
-  def find_xpath(query)
+  def find_xpath(_query)
     raise NotImplementedError
   end
 
-  def find_css(query)
+  def find_css(_query)
     raise NotImplementedError
   end
 
@@ -34,15 +34,15 @@ class Capybara::Driver::Base
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#go_forward'
   end
 
-  def execute_script(script, *args)
+  def execute_script(_script, *_args)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#execute_script'
   end
 
-  def evaluate_script(script, *args)
+  def evaluate_script(_script, *_args)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#evaluate_script'
   end
 
-  def save_screenshot(path, options={})
+  def save_screenshot(_path, _options={})
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#save_screenshot'
   end
 
@@ -58,7 +58,7 @@ class Capybara::Driver::Base
   #
   # @param frame [Capybara::Node::Element, :parent, :top]  The iframe element to switch to
   #
-  def switch_to_frame(frame)
+  def switch_to_frame(_frame)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#switch_to_frame'
   end
 
@@ -66,19 +66,19 @@ class Capybara::Driver::Base
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#current_window_handle'
   end
 
-  def window_size(handle)
+  def window_size(_handle)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#window_size'
   end
 
-  def resize_window_to(handle, width, height)
+  def resize_window_to(_handle, _width, _height)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#resize_window_to'
   end
 
-  def maximize_window(handle)
+  def maximize_window(_handle)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#maximize_current_window'
   end
 
-  def close_window(handle)
+  def close_window(_handle)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#close_window'
   end
 
@@ -90,11 +90,11 @@ class Capybara::Driver::Base
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#open_new_window'
   end
 
-  def switch_to_window(handle)
+  def switch_to_window(_handle)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#switch_to_window'
   end
 
-  def within_window(locator)
+  def within_window(_locator)
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#within_window'
   end
 
@@ -113,7 +113,7 @@ class Capybara::Driver::Base
   # @return [String]  the message shown in the modal
   # @raise [Capybara::ModalNotFound]  if modal dialog hasn't been found
   #
-  def accept_modal(type, options={}, &blk)
+  def accept_modal(_type, _options={})
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#accept_modal'
   end
 
@@ -126,7 +126,7 @@ class Capybara::Driver::Base
   # @return [String]  the message shown in the modal
   # @raise [Capybara::ModalNotFound]  if modal dialog hasn't been found
   #
-  def dismiss_modal(type, options={}, &blk)
+  def dismiss_modal(_type, _options={})
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#dismiss_modal'
   end
 

--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -17,7 +17,7 @@ module Capybara
         raise NotImplementedError
       end
 
-      def [](name)
+      def [](_name)
         raise NotImplementedError
       end
 
@@ -27,7 +27,7 @@ module Capybara
 
       # @param value String or Array. Array is only allowed if node has 'multiple' attribute
       # @param options [Hash{}] Driver specific options for how to set a value on a node
-      def set(value, options={})
+      def set(_value, _options={})
         raise NotImplementedError
       end
 
@@ -51,7 +51,7 @@ module Capybara
         raise NotImplementedError
       end
 
-      def send_keys(*args)
+      def send_keys(*_args)
         raise NotImplementedError
       end
 
@@ -59,7 +59,7 @@ module Capybara
         raise NotImplementedError
       end
 
-      def drag_to(element)
+      def drag_to(_element)
         raise NotImplementedError
       end
 
@@ -95,7 +95,7 @@ module Capybara
         raise NotSupportedByDriverError, 'Capybara::Driver::Node#path'
       end
 
-      def trigger(event)
+      def trigger(_event)
         raise NotSupportedByDriverError, 'Capybara::Driver::Node#trigger'
       end
 
@@ -105,7 +105,7 @@ module Capybara
         %(#<#{self.class} tag="#{tag_name}">)
       end
 
-      def ==(other)
+      def ==(_other)
         raise NotSupportedByDriverError, 'Capybara::Driver::Node#=='
       end
     end

--- a/lib/capybara/minitest/spec.rb
+++ b/lib/capybara/minitest/spec.rb
@@ -8,13 +8,13 @@ module Capybara
         infect_an_assertion "refute_#{assertion}", "wont_have_#{assertion}", :reverse
       end
 
-      (%w(selector xpath css link button field select table checked_field unchecked_field).map do |assertion|
+      (%w(selector xpath css link button field select table checked_field unchecked_field).flat_map do |assertion|
         [["assert_#{assertion}", "must_have_#{assertion}"],
          ["refute_#{assertion}", "wont_have_#{assertion}"]]
-      end.flatten(1) + %w(selector xpath css).map do |assertion|
+      end + %w(selector xpath css).flat_map do |assertion|
         [["assert_matches_#{assertion}", "must_match_#{assertion}"],
          ["refute_matches_#{assertion}", "wont_match_#{assertion}"]]
-      end.flatten(1)).each do |(meth, new_name)|
+      end).each do |(meth, new_name)|
         self.class_eval <<-EOM, __FILE__, __LINE__ + 1
           def #{new_name} *args, &block
             ::Minitest::Expectation.new(self, ::Minitest::Spec.current).#{new_name}(*args, &block)

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -286,7 +286,7 @@ module Capybara
         JS
         begin
           session.execute_script(script, element)
-        rescue
+        rescue # rubocop:disable Lint/HandleExceptions
         end
       end
 

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -239,7 +239,7 @@ module Capybara
           raise Capybara::FileNotFound, "cannot attach file, #{p} does not exist" unless File.exist?(p.to_s)
         end
         # Allow user to update the CSS style of the file input since they are so often hidden on a page
-        if style = options.delete(:make_visible)
+        if (style = options.delete(:make_visible))
           style = { opacity: 1, display: 'block', visibility: 'visible' } if style == true
           ff = find(:file_field, locator, options.merge({visible: :all}))
           _update_style(ff, style)

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -28,7 +28,7 @@ module Capybara
       #
       # @return [String]    The text of the element
       #
-      def text(type=nil)
+      def text(_type=nil)
         native.text
       end
 
@@ -140,7 +140,7 @@ module Capybara
         native.has_attribute?('selected')
       end
 
-      def synchronize(seconds=nil)
+      def synchronize(_seconds=nil)
         yield # simple nodes don't need to wait
       end
 

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -17,7 +17,6 @@ module Capybara
         if args[0].is_a?(Symbol)
           @selector = Selector.all.fetch(args.shift) do |selector_type|
             raise ArgumentError, "Unknown selector type (:#{selector_type})"
-            nil
           end
           @locator = args.shift
         else

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -57,7 +57,7 @@ module Capybara
         @description
       end
 
-      def matches_filters?(node)
+      def matches_filters?(node) # rubocop:disable Metrics/MethodLength
         if options[:text]
           regexp = if options[:text].is_a?(Regexp)
             options[:text]

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -26,7 +26,7 @@ module Capybara
         end
         @selector ||= Selector.all[session_options.default_selector]
 
-        warn "Unused parameters passed to #{self.class.name} : #{args.to_s}" unless args.empty?
+        warn "Unused parameters passed to #{self.class.name} : #{args}" unless args.empty?
 
         # for compatibility with Capybara 2.0
         if session_options.exact_options and @selector == Selector.all[:option]
@@ -235,7 +235,7 @@ module Capybara
 
       def warn_exact_usage
         if options.has_key?(:exact) && !supports_exact?
-          warn "The :exact option only has an effect on queries using the XPath#is method. Using it with the query \"#{expression.to_s}\" has no effect."
+          warn "The :exact option only has an effect on queries using the XPath#is method. Using it with the query \"#{expression}\" has no effect."
         end
       end
 

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -16,7 +16,7 @@ module Capybara
           @expected_text = Capybara::Helpers.normalize_whitespace(@expected_text)
         end
         @search_regexp = Capybara::Helpers.to_regexp(@expected_text, nil, exact?)
-        warn "Unused parameters passed to #{self.class.name} : #{args.to_s}" unless args.empty?
+        warn "Unused parameters passed to #{self.class.name} : #{args}" unless args.empty?
         assert_valid_keys
       end
 

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -72,7 +72,7 @@ module Capybara
             if invisible_count != @count
               details_message << ". it was found #{invisible_count} #{Capybara::Helpers.declension("time", "times", invisible_count)} including non-visible text"
             end
-          rescue
+          rescue # rubocop:disable Lint/HandleExceptions
             # An error getting the non-visible text (if element goes out of scope) should not affect the response
           end
         end

--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -15,7 +15,7 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
     def path; @empty_file.path; end
   end
 
-  def params(button)
+  def params(button) # rubocop:disable Metrics/MethodLength
     params = make_params
 
     form_element_types=[:input, :select, :textarea]

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -87,7 +87,7 @@ module Capybara
         begin
           @result_cache << @results_enum.next while @result_cache.size <= max_opt
           return false
-        rescue StopIteration
+        rescue StopIteration # rubocop:disable Lint/HandleExceptions
         end
       end
 

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -62,7 +62,7 @@ module Capybara
       !any?
     end
 
-    def matches_count?
+    def matches_count? # rubocop:disable Metrics/MethodLength
       # Only check filters for as many elements as necessary to determine result
       if @query.options[:count]
         count_opt = Integer(@query.options[:count])

--- a/lib/capybara/selector/css.rb
+++ b/lib/capybara/selector/css.rb
@@ -6,10 +6,10 @@ module Capybara
         value = str.dup
         out << value.slice!(0...1) if value =~ /^[-_]/
         out << if value[0] =~ NMSTART
-          value.slice!(0...1)
-        else
-          escape_char(value.slice!(0...1))
-        end
+                 value.slice!(0...1)
+               else
+                 escape_char(value.slice!(0...1))
+               end
         out << value.gsub(/[^a-zA-Z0-9_-]/) {|c| escape_char c}
         out
       end

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "uri"
 
-class Capybara::Selenium::Driver < Capybara::Driver::Base
+class Capybara::Selenium::Driver < Capybara::Driver::Base # rubocop:disable Metrics/ClassLength
 
   DEFAULT_OPTIONS = {
     :browser => :firefox,

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -361,7 +361,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     raise Capybara::ElementNotFound, "Could not find a window identified by #{locator}"
   end
 
-  def insert_modal_handlers(accept, response_text, expected_text=nil)
+  def insert_modal_handlers(accept, response_text, _expected_text=nil)
     script = <<-JS
       if (typeof window.capybara  === 'undefined') {
         window.capybara = {

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -118,7 +118,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base # rubocop:disable Metr
     browser.save_screenshot(path)
   end
 
-  def reset!
+  def reset! # rubocop:disable Metrics/MethodLength
     # Use instance variable directly so we avoid starting the browser just to reset the session
     if @browser
       navigated = false
@@ -361,7 +361,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base # rubocop:disable Metr
     raise Capybara::ElementNotFound, "Could not find a window identified by #{locator}"
   end
 
-  def insert_modal_handlers(accept, response_text, _expected_text=nil)
+  def insert_modal_handlers(accept, response_text, _expected_text=nil) # rubocop:disable Metrics/MethodLength
     script = <<-JS
       if (typeof window.capybara  === 'undefined') {
         window.capybara = {

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -71,7 +71,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     accept_modal(nil, wait: 0.1) do
       browser.navigate.refresh
     end
-  rescue Capybara::ModalNotFound
+  rescue Capybara::ModalNotFound # rubocop:disable Lint/HandleExceptions
   end
 
   def go_back
@@ -143,7 +143,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
                 warn "localStorage clear requested but is not available for this driver"
               end
             end
-          rescue Selenium::WebDriver::Error::UnhandledError
+          rescue Selenium::WebDriver::Error::UnhandledError # rubocop:disable Lint/HandleExceptions
             # delete_all_cookies fails when we've previously gone
             # to about:blank, so we rescue this error and do nothing
             # instead.
@@ -164,7 +164,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         begin
           @browser.switch_to.alert.accept
           sleep 0.25 # allow time for the modal to be handled
-        rescue Selenium::WebDriver::Error::NoAlertPresentError
+        rescue Selenium::WebDriver::Error::NoAlertPresentError # rubocop:disable Lint/HandleExceptions
           # The alert is now gone - nothing to do
         end
         # try cleaning up the browser again
@@ -278,7 +278,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def quit
     @browser.quit if @browser
-  rescue Errno::ECONNREFUSED
+  rescue Errno::ECONNREFUSED # rubocop:disable Lint/HandleExceptions
     # Browser must have already gone
   rescue Selenium::WebDriver::Error::UnknownError => e
     unless silenced_unknown_error_message?(e.message) # Most likely already gone

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -35,7 +35,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   #   :none =>  append the new value to the existing value <br/>
   #   :backspace => send backspace keystrokes to clear the field <br/>
   #   Array => an array of keys to send before the value being set, e.g. [[:command, 'a'], :backspace]
-  def set(value, options={})
+  def set(value, options={}) # rubocop:disable Metrics/MethodLength
     tag_name = self.tag_name
     type = self[:type]
 

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -105,7 +105,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
        e.message =~ /Other element would receive the click/
       begin
         driver.execute_script("arguments[0].scrollIntoView({behavior: 'instant', block: 'center', inline: 'center'})", self)
-      rescue
+      rescue # rubocop:disable Lint/HandleExceptions
       end
     end
     raise e

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -190,7 +190,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
     path.unshift self
 
     result = []
-    while node = path.shift
+    while (node = path.shift)
       parent = path.first
 
       if parent

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -35,7 +35,7 @@ module Capybara
   #
   # When using capybara/dsl, the Session is initialized automatically for you.
   #
-  class Session
+  class Session # rubocop:disable Metrics/ClassLength
     include Capybara::SessionMatchers
 
     NODE_METHODS = [

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -259,7 +259,7 @@ module Capybara
         if visit_uri.relative?
           uri_base.port ||= @server.port if @server && config.always_include_port
 
-          visit_uri_parts = visit_uri.to_hash.delete_if { |k,v| v.nil? }
+          visit_uri_parts = visit_uri.to_hash.delete_if { |_k,v| v.nil? }
 
           # TODO - this is only for compatability with previous 2.x behavior that concatenated
           # Capybara.app_host and a "relative" path - Consider removing in 3.0

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -778,6 +778,7 @@ module Capybara
     # @param [Hash] options   a customizable set of options
     #
     def save_and_open_screenshot(path = nil, options = {})
+      # rubocop:disable Lint/Debugger
       path = save_screenshot(path, options)
       open_file(path)
     end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -535,7 +535,7 @@ module Capybara
     # @raise [Capybara::ScopeError]        if this method is invoked inside `within_frame` method
     # @return                              value returned by the block
     #
-    def within_window(window_or_handle)
+    def within_window(window_or_handle) # rubocop:disable Metrics/MethodLength
       if window_or_handle.instance_of?(Capybara::Window)
         original = current_window
         scopes << nil

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -98,7 +98,7 @@ module Capybara
 
   class ReadOnlySessionConfig < SimpleDelegator
     SessionConfig::OPTIONS.each do |m|
-      define_method "#{m}=" do |val|
+      define_method "#{m}=" do |_val|
         raise "Per session settings are only supported when Capybara.threadsafe == true"
       end
     end

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -71,7 +71,7 @@ Capybara::SpecHelper.spec "#attach_file" do
       expect(@session.body).to include("1 | ")#number of files
     end
 
-    it  "should not break when using HTML5 multiple file input uploading multiple files" do
+    it "should not break when using HTML5 multiple file input uploading multiple files" do
       pending "Selenium is buggy on this, see http://code.google.com/p/selenium/issues/detail?id=2239" if @session.respond_to?(:mode) && @session.mode.to_s =~ /^selenium_(firefox|marionette)/
       @session.attach_file "Multiple Documents", [@test_file_path, @another_test_file_path]
       @session.click_button('Upload Multiple')

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -313,7 +313,7 @@ Capybara::SpecHelper.spec '#click_button' do
       expect(@results['middle_name']).to eq('Darren')
       expect(@results['foo']).to be_nil
     end
-  end
+ end
 
  context "with value given on a button defined by <button> tag" do
     it "should submit the associated form" do
@@ -325,7 +325,7 @@ Capybara::SpecHelper.spec '#click_button' do
       @session.click_button('ck_me')
       expect(extract_results(@session)['first_name']).to eq('John')
     end
-  end
+ end
 
   context "with title given on a button defined by <button> tag" do
     it "should submit the associated form" do

--- a/lib/capybara/spec/session/evaluate_script_spec.rb
+++ b/lib/capybara/spec/session/evaluate_script_spec.rb
@@ -20,7 +20,6 @@ Capybara::SpecHelper.spec "#evaluate_script", requires: [:js] do
 
   it "should support returning elements", requires: [:js, :es_args] do
     @session.visit('/with_js')
-    el = @session.find(:css, '#change')
     el = @session.evaluate_script("document.getElementById('change')")
     expect(el).to be_instance_of(Capybara::Node::Element)
     expect(el).to eq(@session.find(:css, '#change'))

--- a/lib/capybara/spec/session/has_current_path_spec.rb
+++ b/lib/capybara/spec/session/has_current_path_spec.rb
@@ -59,7 +59,7 @@ Capybara::SpecHelper.spec '#has_current_path?' do
 
   it "should default to full url if value is a url" do
     url = @session.current_url
-    expect(url).to match /with_js$/
+    expect(url).to match(/with_js$/)
     expect(@session).to have_current_path(url)
     expect(@session).not_to have_current_path("http://www.not_example.com/with_js")
   end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -258,6 +258,7 @@ Capybara::SpecHelper.spec "node" do
 
   describe "#==" do
     it "preserve object identity" do
+      # rubocop:disable Lint/UselessComparison
       expect(@session.find('//h1') == @session.find('//h1')).to be true
       expect(@session.find('//h1') === @session.find('//h1')).to be true
       expect(@session.find('//h1').eql? @session.find('//h1')).to be false

--- a/lib/capybara/spec/session/window/within_window_spec.rb
+++ b/lib/capybara/spec/session/window/within_window_spec.rb
@@ -39,7 +39,7 @@ Capybara::SpecHelper.spec '#within_window', requires: [:windows] do
       window = (@session.windows - [@window]).first
       value = @session.within_window window do
                 43252003274489856000
-              end
+      end
       expect(value).to eq(43252003274489856000)
     end
 
@@ -141,7 +141,7 @@ Capybara::SpecHelper.spec '#within_window', requires: [:windows] do
     it "returns value from the block" do
       value = @session.within_window(->{ @session.title == 'Title of popup two'}) do
                 42
-              end
+      end
       expect(value).to eq(42)
     end
 

--- a/lib/capybara/window.rb
+++ b/lib/capybara/window.rb
@@ -119,12 +119,12 @@ module Capybara
       res = yield if block_given?
       prev_size = size
       start_time = Capybara::Helpers.monotonic_time
-      begin
+      while (Capybara::Helpers.monotonic_time - start_time) < seconds
         sleep 0.05
         cur_size = size
         return res if cur_size == prev_size
         prev_size = cur_size
-      end while (Capybara::Helpers.monotonic_time - start_time) < seconds
+      end
       #TODO raise error in 3.0
       #raise Capybara::WindowError, "Window size not stable."
       warn "Window size not stable in #{seconds} seconds.  This will raise an exception in a future version of Capybara"

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Capybara do
   describe '.register_server' do
     it "should add a new server" do
       handler = double("handler")
-      Capybara.register_server :blob do |app, port, host|
+      Capybara.register_server :blob do |_app, _port, _host|
         handler.run
       end
 

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Capybara::DSL do
       driver_before_block = Capybara.current_driver
       begin
         Capybara.using_driver(:selenium) { raise "ohnoes!" }
-      rescue StandardError
+      rescue StandardError # rubocop:disable Lint/HandleExceptions
       end
       expect(Capybara.current_driver).to eq(driver_before_block)
     end
@@ -211,7 +211,7 @@ RSpec.describe Capybara::DSL do
         Capybara.using_session(:raise) do
           raise
         end
-      rescue StandardError
+      rescue StandardError # rubocop:disable Lint/HandleExceptions
       end
       expect(Capybara.session_name).to eq(:default)
     end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Capybara::DSL do
       driver_before_block = Capybara.current_driver
       begin
         Capybara.using_driver(:selenium) { raise "ohnoes!" }
-      rescue Exception
+      rescue StandardError
       end
       expect(Capybara.current_driver).to eq(driver_before_block)
     end
@@ -211,7 +211,7 @@ RSpec.describe Capybara::DSL do
         Capybara.using_session(:raise) do
           raise
         end
-      rescue Exception
+      rescue StandardError
       end
       expect(Capybara.session_name).to eq(:default)
     end

--- a/spec/filter_set_spec.rb
+++ b/spec/filter_set_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Capybara::Selector::FilterSet do
 
   it "allows node filters" do
     fs = Capybara::Selector::FilterSet.add(:test) do
-      filter(:node_test, :boolean) { |node, value| true }
-      expression_filter(:expression_test, :boolean) { |expr, value| true }
+      filter(:node_test, :boolean) { |_node, _value| true }
+      expression_filter(:expression_test, :boolean) { |_expr, _value| true }
     end
 
     expect(fs.node_filters.keys).to include(:node_test)
@@ -18,8 +18,8 @@ RSpec.describe Capybara::Selector::FilterSet do
 
   it "allows expression filters" do
     fs = Capybara::Selector::FilterSet.add(:test) do
-      filter(:node_test, :boolean) { |node, value| true }
-      expression_filter(:expression_test, :boolean) { |expr, value| true }
+      filter(:node_test, :boolean) { |_node, _value| true }
+      expression_filter(:expression_test, :boolean) { |_expr, _value| true }
     end
 
     expect(fs.expression_filters.keys).to include(:expression_test)

--- a/spec/fixtures/selenium_driver_rspec_failure.rb
+++ b/spec/fixtures/selenium_driver_rspec_failure.rb
@@ -6,7 +6,7 @@ RSpec.describe Capybara::Selenium::Driver do
   it "should exit with a non-zero exit status" do
     options = { browser: (ENV['SELENIUM_BROWSER'] || :firefox).to_sym }
     options[:desired_capabilities] = Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false) if ENV['LEGACY_FIREFOX']
-    browser = Capybara::Selenium::Driver.new(TestApp, options).browser
+    Capybara::Selenium::Driver.new(TestApp, options).browser
     expect(true).to eq(false)
   end
 end

--- a/spec/fixtures/selenium_driver_rspec_success.rb
+++ b/spec/fixtures/selenium_driver_rspec_success.rb
@@ -6,7 +6,7 @@ RSpec.describe Capybara::Selenium::Driver do
   it "should exit with a zero exit status" do
     options = { browser: (ENV['SELENIUM_BROWSER'] || :firefox).to_sym }
     options[:desired_capabilities] = Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false) if ENV['LEGACY_FIREFOX']
-    browser = Capybara::Selenium::Driver.new(TestApp, options ).browser
+    Capybara::Selenium::Driver.new(TestApp, options ).browser
     expect(true).to eq(true)
   end
 end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -220,7 +220,7 @@ module CSSHandlerIncludeTester
 end
 include CSSHandlerIncludeTester
 
-RSpec.describe  Capybara::RackTest::CSSHandlers do
+RSpec.describe Capybara::RackTest::CSSHandlers do
   it "should not be extended by global includes" do
     expect(Capybara::RackTest::CSSHandlers.new).not_to respond_to(:dont_extend_css_handler)
   end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Capybara::Result do
 
   it "can be reduced" do
     expect(result.reduce('') do |memo, element|
-      memo += element.text[0]
+      memo + element.text[0]
     end).to eq('ABGD')
   end
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Capybara::Result do
 
       it 'lazily evaluates' do
         skip 'JRuby has an issue with lazy enumerator evaluation' if RUBY_PLATFORM == 'java'
-        result.each.with_index do |el, idx|
+        result.each.with_index do |_el, idx|
           expect(result.instance_variable_get('@result_cache').size).to eq(idx+1)  # 0 indexing
         end
       end

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -4,7 +4,7 @@ require 'capybara/dsl'
 require 'capybara/rspec/matchers'
 require 'benchmark'
 
-RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
+RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
 
   include Capybara::DSL
   include Capybara::RSpecMatchers

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Capybara do
       it "can set default visiblity" do
         Capybara.add_selector :hidden_field do
           visible :hidden
-          css { |sel| 'input[type="hidden"]' }
+          css { |_sel| 'input[type="hidden"]' }
         end
 
         expect(string).to have_no_css('input[type="hidden"]')

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Capybara::Server do
   def start_request(server, wait_time)
     # Start request, but don't wait for it to finish
     socket = TCPSocket.new(server.host, server.port)
-    socket.write "GET /?wait_time=#{wait_time.to_s} HTTP/1.0\r\n\r\n"
+    socket.write "GET /?wait_time=#{wait_time} HTTP/1.0\r\n\r\n"
     socket.close
     sleep 0.1
   end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 RSpec.describe Capybara::Server do
 
   it "should spool up a rack server" do
-    @app = proc { |env| [200, {}, ["Hello Server!"]]}
+    @app = proc { |_env| [200, {}, ["Hello Server!"]]}
     @server = Capybara::Server.new(@app).boot
 
     @res = Net::HTTP.start(@server.host, @server.port) { |http| http.get('/') }
@@ -20,7 +20,7 @@ RSpec.describe Capybara::Server do
 
   it "should bind to the specified host" do
     begin
-      app = proc { |env| [200, {}, ['Hello Server!']] }
+      app = proc { |_env| [200, {}, ['Hello Server!']] }
 
       Capybara.server_host = '127.0.0.1'
       server = Capybara::Server.new(app).boot
@@ -39,7 +39,7 @@ RSpec.describe Capybara::Server do
   it "should use specified port" do
     Capybara.server_port = 22789
 
-    @app = proc { |env| [200, {}, ["Hello Server!"]]}
+    @app = proc { |_env| [200, {}, ["Hello Server!"]]}
     @server = Capybara::Server.new(@app).boot
 
     @res = Net::HTTP.start(@server.host, 22789) { |http| http.get('/') }
@@ -49,7 +49,7 @@ RSpec.describe Capybara::Server do
   end
 
   it "should use given port" do
-    @app = proc { |env| [200, {}, ["Hello Server!"]]}
+    @app = proc { |_env| [200, {}, ["Hello Server!"]]}
     @server = Capybara::Server.new(@app, 22790).boot
 
     @res = Net::HTTP.start(@server.host, 22790) { |http| http.get('/') }
@@ -59,8 +59,8 @@ RSpec.describe Capybara::Server do
   end
 
   it "should find an available port" do
-    @app1 = proc { |env| [200, {}, ["Hello Server!"]]}
-    @app2 = proc { |env| [200, {}, ["Hello Second Server!"]]}
+    @app1 = proc { |_env| [200, {}, ["Hello Server!"]]}
+    @app2 = proc { |_env| [200, {}, ["Hello Second Server!"]]}
 
     @server1 = Capybara::Server.new(@app1).boot
     @server2 = Capybara::Server.new(@app2).boot
@@ -83,7 +83,7 @@ RSpec.describe Capybara::Server do
     end
 
     it "should use the existing server if it already running" do
-      @app = proc { |env| [200, {}, ["Hello Server!"]]}
+      @app = proc { |_env| [200, {}, ["Hello Server!"]]}
 
       @server1 = Capybara::Server.new(@app).boot
       @server2 = Capybara::Server.new(@app).boot
@@ -132,7 +132,7 @@ RSpec.describe Capybara::Server do
     end
 
     it "should not reuse an already running server" do
-      @app = proc { |env| [200, {}, ["Hello Server!"]]}
+      @app = proc { |_env| [200, {}, ["Hello Server!"]]}
 
       @server1 = Capybara::Server.new(@app).boot
       @server2 = Capybara::Server.new(@app).boot

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -149,7 +149,7 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
     describe "all with disappearing elements" do
       it "ignores stale elements in results" do
         @session.visit('/path')
-        elements = @session.all(:link) { |node| raise Selenium::WebDriver::Error::StaleElementReferenceError }
+        elements = @session.all(:link) { |_node| raise Selenium::WebDriver::Error::StaleElementReferenceError }
         expect(elements.size).to eq 0
       end
     end


### PR DESCRIPTION
I executed rubocop.
Then there was an indication of 108.
The version of rubocop is the same version of `0.46.0` as code climate.

<details>
<summary>Result before execution</summary>

Inspecting 164 files
.W.W.WCW..WW.....W.EWWW.W....W.WW..W..W....WW...W.........W.......W............W.................W...........................W.......C...W..C...W.W....W.C.....W....

Offenses:

Rakefile:40:18: W: Lint/UnusedBlockArgument: Unused block argument - t. You can omit the argument if you don't care about it.
task :travis do |t|
                 ^
spec/server_spec.rb:7:20: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
    @app = proc { |env| [200, {}, ["Hello Server!"]]}
                   ^^^
spec/server_spec.rb:23:21: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
      app = proc { |env| [200, {}, ['Hello Server!']] }
                    ^^^
spec/server_spec.rb:42:20: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
    @app = proc { |env| [200, {}, ["Hello Server!"]]}
                   ^^^
spec/server_spec.rb:52:20: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
    @app = proc { |env| [200, {}, ["Hello Server!"]]}
                   ^^^
spec/server_spec.rb:62:21: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
    @app1 = proc { |env| [200, {}, ["Hello Server!"]]}
                    ^^^
spec/server_spec.rb:63:21: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
    @app2 = proc { |env| [200, {}, ["Hello Second Server!"]]}
                    ^^^
spec/server_spec.rb:86:22: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
      @app = proc { |env| [200, {}, ["Hello Server!"]]}
                     ^^^
spec/server_spec.rb:135:22: W: Lint/UnusedBlockArgument: Unused block argument - env. You can omit the argument if you don't care about it.
      @app = proc { |env| [200, {}, ["Hello Server!"]]}
                     ^^^
spec/server_spec.rb:200:47: W: Lint/StringConversionInInterpolation: Redundant use of Object#to_s in interpolation.
    socket.write "GET /?wait_time=#{wait_time.to_s} HTTP/1.0\r\n\r\n"
                                              ^^^^
spec/result_spec.rb:53:7: W: Lint/UselessAssignment: Useless assignment to variable - memo. Use just operator +.
      memo += element.text[0]
      ^^^^
spec/result_spec.rb:135:36: W: Lint/UnusedBlockArgument: Unused block argument - el. If it's necessary, use _ or _el as an argument name to indicate that it won't be used.
        result.each.with_index do |el, idx|
                                   ^^
spec/rack_test_spec.rb:223:15: C: Style/SpaceBeforeFirstArg: Put one space between the method name and the first argument.
RSpec.describe  Capybara::RackTest::CSSHandlers do
              ^^
spec/selector_spec.rb:59:18: W: Lint/UnusedBlockArgument: Unused block argument - sel. You can omit the argument if you don't care about it.
          css { |sel| 'input[type="hidden"]' }
                 ^^^
spec/shared_selenium_session.rb:152:43: W: Lint/UnusedBlockArgument: Unused block argument - node. You can omit the argument if you don't care about it.
        elements = @session.all(:link) { |node| raise Selenium::WebDriver::Error::StaleElementReferenceError }
                                          ^^^^
spec/filter_set_spec.rb:11:39: W: Lint/UnusedBlockArgument: Unused block argument - node. You can omit all the arguments if you don't care about them.
      filter(:node_test, :boolean) { |node, value| true }
                                      ^^^^
spec/filter_set_spec.rb:11:45: W: Lint/UnusedBlockArgument: Unused block argument - value. You can omit all the arguments if you don't care about them.
      filter(:node_test, :boolean) { |node, value| true }
                                            ^^^^^
spec/filter_set_spec.rb:12:56: W: Lint/UnusedBlockArgument: Unused block argument - expr. You can omit all the arguments if you don't care about them.
      expression_filter(:expression_test, :boolean) { |expr, value| true }
                                                       ^^^^
spec/filter_set_spec.rb:12:62: W: Lint/UnusedBlockArgument: Unused block argument - value. You can omit all the arguments if you don't care about them.
      expression_filter(:expression_test, :boolean) { |expr, value| true }
                                                             ^^^^^
spec/filter_set_spec.rb:21:39: W: Lint/UnusedBlockArgument: Unused block argument - node. You can omit all the arguments if you don't care about them.
      filter(:node_test, :boolean) { |node, value| true }
                                      ^^^^
spec/filter_set_spec.rb:21:45: W: Lint/UnusedBlockArgument: Unused block argument - value. You can omit all the arguments if you don't care about them.
      filter(:node_test, :boolean) { |node, value| true }
                                            ^^^^^
spec/filter_set_spec.rb:22:56: W: Lint/UnusedBlockArgument: Unused block argument - expr. You can omit all the arguments if you don't care about them.
      expression_filter(:expression_test, :boolean) { |expr, value| true }
                                                       ^^^^
spec/filter_set_spec.rb:22:62: W: Lint/UnusedBlockArgument: Unused block argument - value. You can omit all the arguments if you don't care about them.
      expression_filter(:expression_test, :boolean) { |expr, value| true }
                                                             ^^^^^
spec/rspec/shared_spec_matchers.rb:7:60: W: Lint/UnusedBlockArgument: Unused block argument - mode. If it's necessary, use _ or _mode as an argument name to indicate that it won't be used.
RSpec.shared_examples Capybara::RSpecMatchers do |session, mode|
                                                           ^^^^
spec/selenium_spec_marionette.rb:17:66: E: unexpected token tCOLON
(Using Ruby 2.1 parser; configure using TargetRubyVersion parameter, under AllCops)
    desired_capabilities: {marionette: true, 'moz:webdriverClick': true},
                                                                 ^
spec/selenium_spec_marionette.rb:128:1: E: unexpected token $end
(Using Ruby 2.1 parser; configure using TargetRubyVersion parameter, under AllCops)
spec/capybara_spec.rb:40:42: W: Lint/UnusedBlockArgument: Unused block argument - app. You can omit all the arguments if you don't care about them.
      Capybara.register_server :blob do |app, port, host|
                                         ^^^
spec/capybara_spec.rb:40:47: W: Lint/UnusedBlockArgument: Unused block argument - port. You can omit all the arguments if you don't care about them.
      Capybara.register_server :blob do |app, port, host|
                                              ^^^^
spec/capybara_spec.rb:40:53: W: Lint/UnusedBlockArgument: Unused block argument - host. You can omit all the arguments if you don't care about them.
      Capybara.register_server :blob do |app, port, host|
                                                    ^^^^
spec/fixtures/selenium_driver_rspec_failure.rb:9:5: W: Lint/UselessAssignment: Useless assignment to variable - browser.
    browser = Capybara::Selenium::Driver.new(TestApp, options).browser
    ^^^^^^^
spec/fixtures/selenium_driver_rspec_success.rb:9:5: W: Lint/UselessAssignment: Useless assignment to variable - browser.
    browser = Capybara::Selenium::Driver.new(TestApp, options ).browser
    ^^^^^^^
spec/dsl_spec.rb:96:7: W: Lint/HandleExceptions: Do not suppress exceptions.
      rescue Exception
      ^^^^^^^^^^^^^^^^
spec/dsl_spec.rb:96:7: W: Lint/RescueException: Avoid rescuing the Exception class. Perhaps you meant to rescue StandardError?
      rescue Exception
      ^^^^^^^^^^^^^^^^
spec/dsl_spec.rb:214:7: W: Lint/HandleExceptions: Do not suppress exceptions.
      rescue Exception
      ^^^^^^^^^^^^^^^^
spec/dsl_spec.rb:214:7: W: Lint/RescueException: Avoid rescuing the Exception class. Perhaps you meant to rescue StandardError?
      rescue Exception
      ^^^^^^^^^^^^^^^^
lib/capybara/window.rb:127:11: W: Lint/Loop: Use Kernel#loop with break rather than begin/end/until(or while).
      end while (Capybara::Helpers.monotonic_time - start_time) < seconds
          ^^^^^
lib/capybara/selenium/node.rb:38:3: C: Metrics/MethodLength: Method has too many lines. [43/30]
  def set(value, options={}) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/node.rb:108:7: W: Lint/HandleExceptions: Do not suppress exceptions.
      rescue
      ^^^^^^
lib/capybara/selenium/node.rb:193:16: W: Lint/AssignmentInCondition: Assignment in condition - you probably meant to use ==.
    while node = path.shift
               ^
lib/capybara/selenium/driver.rb:4:1: C: Metrics/ClassLength: Class has too many lines. [393/250]
class Capybara::Selenium::Driver < Capybara::Driver::Base ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/driver.rb:74:3: W: Lint/HandleExceptions: Do not suppress exceptions.
  rescue Capybara::ModalNotFound
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/driver.rb:121:3: C: Metrics/MethodLength: Method has too many lines. [39/30]
  def reset! ...
  ^^^^^^^^^^
lib/capybara/selenium/driver.rb:146:11: W: Lint/HandleExceptions: Do not suppress exceptions.
          rescue Selenium::WebDriver::Error::UnhandledError
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/driver.rb:167:9: W: Lint/HandleExceptions: Do not suppress exceptions.
        rescue Selenium::WebDriver::Error::NoAlertPresentError
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/driver.rb:281:3: W: Lint/HandleExceptions: Do not suppress exceptions.
  rescue Errno::ECONNREFUSED
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/driver.rb:364:3: C: Metrics/MethodLength: Method has too many lines. [39/30]
  def insert_modal_handlers(accept, response_text, expected_text=nil) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/selenium/driver.rb:364:52: W: Lint/UnusedMethodArgument: Unused method argument - expected_text. If it's necessary, use _ or _expected_text as an argument name to indicate that it won't be used.
  def insert_modal_handlers(accept, response_text, expected_text=nil)
                                                   ^^^^^^^^^^^^^
lib/capybara/queries/text_query.rb:19:71: W: Lint/StringConversionInInterpolation: Redundant use of Object#to_s in interpolation.
        warn "Unused parameters passed to #{self.class.name} : #{args.to_s}" unless args.empty?
                                                                      ^^^^
lib/capybara/queries/text_query.rb:75:11: W: Lint/HandleExceptions: Do not suppress exceptions.
          rescue
          ^^^^^^
lib/capybara/queries/selector_query.rb:20:13: W: Lint/UnreachableCode: Unreachable code detected.
            nil
            ^^^
lib/capybara/queries/selector_query.rb:29:71: W: Lint/StringConversionInInterpolation: Redundant use of Object#to_s in interpolation.
        warn "Unused parameters passed to #{self.class.name} : #{args.to_s}" unless args.empty?
                                                                      ^^^^
lib/capybara/queries/selector_query.rb:61:7: C: Metrics/MethodLength: Method has too many lines. [41/30]
      def matches_filters?(node) ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/queries/selector_query.rb:238:131: W: Lint/StringConversionInInterpolation: Redundant use of Object#to_s in interpolation.
          warn "The :exact option only has an effect on queries using the XPath#is method. Using it with the query \"#{expression.to_s}\" has no effect."
                                                                                                                                  ^^^^
lib/capybara/driver/base.rb:9:13: W: Lint/UnusedMethodArgument: Unused method argument - path. If it's necessary, use _ or _path as an argument name to indicate that it won't be used. You can also write as visit(*) if you want the method to accept any arguments but don't care about them.
  def visit(path)
            ^^^^
lib/capybara/driver/base.rb:17:18: W: Lint/UnusedMethodArgument: Unused method argument - query. If it's necessary, use _ or _query as an argument name to indicate that it won't be used. You can also write as find_xpath(*) if you want the method to accept any arguments but don't care about them.
  def find_xpath(query)
                 ^^^^^
lib/capybara/driver/base.rb:21:16: W: Lint/UnusedMethodArgument: Unused method argument - query. If it's necessary, use _ or _query as an argument name to indicate that it won't be used. You can also write as find_css(*) if you want the method to accept any arguments but don't care about them.
  def find_css(query)
               ^^^^^
lib/capybara/driver/base.rb:37:22: W: Lint/UnusedMethodArgument: Unused method argument - script. If it's necessary, use _ or _script as an argument name to indicate that it won't be used. You can also write as execute_script(*) if you want the method to accept any arguments but don't care about them.
  def execute_script(script, *args)
                     ^^^^^^
lib/capybara/driver/base.rb:37:31: W: Lint/UnusedMethodArgument: Unused method argument - args. If it's necessary, use _ or _args as an argument name to indicate that it won't be used. You can also write as execute_script(*) if you want the method to accept any arguments but don't care about them.
  def execute_script(script, *args)
                              ^^^^
lib/capybara/driver/base.rb:41:23: W: Lint/UnusedMethodArgument: Unused method argument - script. If it's necessary, use _ or _script as an argument name to indicate that it won't be used. You can also write as evaluate_script(*) if you want the method to accept any arguments but don't care about them.
  def evaluate_script(script, *args)
                      ^^^^^^
lib/capybara/driver/base.rb:41:32: W: Lint/UnusedMethodArgument: Unused method argument - args. If it's necessary, use _ or _args as an argument name to indicate that it won't be used. You can also write as evaluate_script(*) if you want the method to accept any arguments but don't care about them.
  def evaluate_script(script, *args)
                               ^^^^
lib/capybara/driver/base.rb:45:23: W: Lint/UnusedMethodArgument: Unused method argument - path. If it's necessary, use _ or _path as an argument name to indicate that it won't be used. You can also write as save_screenshot(*) if you want the method to accept any arguments but don't care about them.
  def save_screenshot(path, options={})
                      ^^^^
lib/capybara/driver/base.rb:45:29: W: Lint/UnusedMethodArgument: Unused method argument - options. If it's necessary, use _ or _options as an argument name to indicate that it won't be used. You can also write as save_screenshot(*) if you want the method to accept any arguments but don't care about them.
  def save_screenshot(path, options={})
                            ^^^^^^^
lib/capybara/driver/base.rb:61:23: W: Lint/UnusedMethodArgument: Unused method argument - frame. If it's necessary, use _ or _frame as an argument name to indicate that it won't be used. You can also write as switch_to_frame(*) if you want the method to accept any arguments but don't care about them.
  def switch_to_frame(frame)
                      ^^^^^
lib/capybara/driver/base.rb:69:19: W: Lint/UnusedMethodArgument: Unused method argument - handle. If it's necessary, use _ or _handle as an argument name to indicate that it won't be used. You can also write as window_size(*) if you want the method to accept any arguments but don't care about them.
  def window_size(handle)
                  ^^^^^^
lib/capybara/driver/base.rb:73:24: W: Lint/UnusedMethodArgument: Unused method argument - handle. If it's necessary, use _ or _handle as an argument name to indicate that it won't be used. You can also write as resize_window_to(*) if you want the method to accept any arguments but don't care about them.
  def resize_window_to(handle, width, height)
                       ^^^^^^
lib/capybara/driver/base.rb:73:32: W: Lint/UnusedMethodArgument: Unused method argument - width. If it's necessary, use _ or _width as an argument name to indicate that it won't be used. You can also write as resize_window_to(*) if you want the method to accept any arguments but don't care about them.
  def resize_window_to(handle, width, height)
                               ^^^^^
lib/capybara/driver/base.rb:73:39: W: Lint/UnusedMethodArgument: Unused method argument - height. If it's necessary, use _ or _height as an argument name to indicate that it won't be used. You can also write as resize_window_to(*) if you want the method to accept any arguments but don't care about them.
  def resize_window_to(handle, width, height)
                                      ^^^^^^
lib/capybara/driver/base.rb:77:23: W: Lint/UnusedMethodArgument: Unused method argument - handle. If it's necessary, use _ or _handle as an argument name to indicate that it won't be used. You can also write as maximize_window(*) if you want the method to accept any arguments but don't care about them.
  def maximize_window(handle)
                      ^^^^^^
lib/capybara/driver/base.rb:81:20: W: Lint/UnusedMethodArgument: Unused method argument - handle. If it's necessary, use _ or _handle as an argument name to indicate that it won't be used. You can also write as close_window(*) if you want the method to accept any arguments but don't care about them.
  def close_window(handle)
                   ^^^^^^
lib/capybara/driver/base.rb:93:24: W: Lint/UnusedMethodArgument: Unused method argument - handle. If it's necessary, use _ or _handle as an argument name to indicate that it won't be used. You can also write as switch_to_window(*) if you want the method to accept any arguments but don't care about them.
  def switch_to_window(handle)
                       ^^^^^^
lib/capybara/driver/base.rb:97:21: W: Lint/UnusedMethodArgument: Unused method argument - locator. If it's necessary, use _ or _locator as an argument name to indicate that it won't be used. You can also write as within_window(*) if you want the method to accept any arguments but don't care about them.
  def within_window(locator)
                    ^^^^^^^
lib/capybara/driver/base.rb:116:20: W: Lint/UnusedMethodArgument: Unused method argument - type. If it's necessary, use _ or _type as an argument name to indicate that it won't be used. You can also write as accept_modal(*) if you want the method to accept any arguments but don't care about them.
  def accept_modal(type, options={}, &blk)
                   ^^^^
lib/capybara/driver/base.rb:116:26: W: Lint/UnusedMethodArgument: Unused method argument - options. If it's necessary, use _ or _options as an argument name to indicate that it won't be used. You can also write as accept_modal(*) if you want the method to accept any arguments but don't care about them.
  def accept_modal(type, options={}, &blk)
                         ^^^^^^^
lib/capybara/driver/base.rb:116:39: W: Lint/UnusedMethodArgument: Unused method argument - blk. If it's necessary, use _ or _blk as an argument name to indicate that it won't be used. You can also write as accept_modal(*) if you want the method to accept any arguments but don't care about them.
  def accept_modal(type, options={}, &blk)
                                      ^^^
lib/capybara/driver/base.rb:129:21: W: Lint/UnusedMethodArgument: Unused method argument - type. If it's necessary, use _ or _type as an argument name to indicate that it won't be used. You can also write as dismiss_modal(*) if you want the method to accept any arguments but don't care about them.
  def dismiss_modal(type, options={}, &blk)
                    ^^^^
lib/capybara/driver/base.rb:129:27: W: Lint/UnusedMethodArgument: Unused method argument - options. If it's necessary, use _ or _options as an argument name to indicate that it won't be used. You can also write as dismiss_modal(*) if you want the method to accept any arguments but don't care about them.
  def dismiss_modal(type, options={}, &blk)
                          ^^^^^^^
lib/capybara/driver/base.rb:129:40: W: Lint/UnusedMethodArgument: Unused method argument - blk. If it's necessary, use _ or _blk as an argument name to indicate that it won't be used. You can also write as dismiss_modal(*) if you want the method to accept any arguments but don't care about them.
  def dismiss_modal(type, options={}, &blk)
                                       ^^^
lib/capybara/driver/node.rb:20:14: W: Lint/UnusedMethodArgument: Unused method argument - name. If it's necessary, use _ or _name as an argument name to indicate that it won't be used. You can also write as [](*) if you want the method to accept any arguments but don't care about them.
      def [](name)
             ^^^^
lib/capybara/driver/node.rb:30:15: W: Lint/UnusedMethodArgument: Unused method argument - value. If it's necessary, use _ or _value as an argument name to indicate that it won't be used. You can also write as set(*) if you want the method to accept any arguments but don't care about them.
      def set(value, options={})
              ^^^^^
lib/capybara/driver/node.rb:30:22: W: Lint/UnusedMethodArgument: Unused method argument - options. If it's necessary, use _ or _options as an argument name to indicate that it won't be used. You can also write as set(*) if you want the method to accept any arguments but don't care about them.
      def set(value, options={})
                     ^^^^^^^
lib/capybara/driver/node.rb:54:22: W: Lint/UnusedMethodArgument: Unused method argument - args. If it's necessary, use _ or _args as an argument name to indicate that it won't be used. You can also write as send_keys(*) if you want the method to accept any arguments but don't care about them.
      def send_keys(*args)
                     ^^^^
lib/capybara/driver/node.rb:62:19: W: Lint/UnusedMethodArgument: Unused method argument - element. If it's necessary, use _ or _element as an argument name to indicate that it won't be used. You can also write as drag_to(*) if you want the method to accept any arguments but don't care about them.
      def drag_to(element)
                  ^^^^^^^
lib/capybara/driver/node.rb:98:19: W: Lint/UnusedMethodArgument: Unused method argument - event. If it's necessary, use _ or _event as an argument name to indicate that it won't be used. You can also write as trigger(*) if you want the method to accept any arguments but don't care about them.
      def trigger(event)
                  ^^^^^
lib/capybara/driver/node.rb:108:14: W: Lint/UnusedMethodArgument: Unused method argument - other. If it's necessary, use _ or _other as an argument name to indicate that it won't be used. You can also write as ==(*) if you want the method to accept any arguments but don't care about them.
      def ==(other)
             ^^^^^
lib/capybara/selector/css.rb:12:9: W: Lint/EndAlignment: end at 12, 8 is not aligned with if at 8, 15.
        end
        ^^^
lib/capybara/result.rb:65:5: C: Metrics/MethodLength: Method has too many lines. [33/30]
    def matches_count? ...
    ^^^^^^^^^^^^^^^^^^
lib/capybara/result.rb:90:9: W: Lint/HandleExceptions: Do not suppress exceptions.
        rescue StopIteration
        ^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/node_spec.rb:261:36: W: Lint/UselessComparison: Comparison of something with itself detected.
      expect(@session.find('//h1') == @session.find('//h1')).to be true
                                   ^^
lib/capybara/spec/session/node_spec.rb:262:36: W: Lint/UselessComparison: Comparison of something with itself detected.
      expect(@session.find('//h1') === @session.find('//h1')).to be true
                                   ^^^
lib/capybara/spec/session/click_button_spec.rb:316:3: W: Lint/BlockAlignment: end at 316, 2 is not aligned with context "with id given on a button defined by <button> tag" do at 303, 1.
  end
  ^^^
lib/capybara/spec/session/click_button_spec.rb:328:3: W: Lint/BlockAlignment: end at 328, 2 is not aligned with context "with value given on a button defined by <button> tag" do at 318, 1.
  end
  ^^^
lib/capybara/spec/session/window/within_window_spec.rb:42:15: W: Lint/BlockAlignment: end at 42, 14 is not aligned with value = @session.within_window window do at 40, 6.
              end
              ^^^
lib/capybara/spec/session/window/within_window_spec.rb:144:15: W: Lint/BlockAlignment: end at 144, 14 is not aligned with value = @session.within_window(->{ @session.title == 'Title of popup two'}) do at 142, 6.
              end
              ^^^
lib/capybara/spec/session/has_current_path_spec.rb:62:26: W: Lint/AmbiguousRegexpLiteral: Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the / if it should be a division.
    expect(url).to match /with_js$/
                         ^
lib/capybara/spec/session/attach_file_spec.rb:74:7: C: Style/SpaceBeforeFirstArg: Put one space between the method name and the first argument.
    it  "should not break when using HTML5 multiple file input uploading multiple files" do
      ^^
lib/capybara/spec/session/evaluate_script_spec.rb:23:5: W: Lint/UselessAssignment: Useless assignment to variable - el.
    el = @session.find(:css, '#change')
    ^^
lib/capybara/rack_test/form.rb:18:3: C: Metrics/MethodLength: Method has too many lines. [49/30]
  def params(button) ...
  ^^^^^^^^^^^^^^^^^^
lib/capybara/session.rb:38:3: C: Metrics/ClassLength: Class has too many lines. [481/250]
  class Session ...
  ^^^^^^^^^^^^^
lib/capybara/session.rb:262:60: W: Lint/UnusedBlockArgument: Unused block argument - k. If it's necessary, use _ or _k as an argument name to indicate that it won't be used.
          visit_uri_parts = visit_uri.to_hash.delete_if { |k,v| v.nil? }
                                                           ^
lib/capybara/session.rb:538:5: C: Metrics/MethodLength: Method has too many lines. [38/30]
    def within_window(window_or_handle) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/session.rb:781:14: W: Lint/Debugger: Remove debugger entry point save_screenshot(path, options).
      path = save_screenshot(path, options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/node/actions.rb:242:18: W: Lint/AssignmentInCondition: Assignment in condition - you probably meant to use ==.
        if style = options.delete(:make_visible)
                 ^
lib/capybara/node/actions.rb:289:9: W: Lint/HandleExceptions: Do not suppress exceptions.
        rescue
        ^^^^^^
lib/capybara/node/simple.rb:31:16: W: Lint/UnusedMethodArgument: Unused method argument - type. If it's necessary, use _ or _type as an argument name to indicate that it won't be used. You can also write as text(*) if you want the method to accept any arguments but don't care about them.
      def text(type=nil)
               ^^^^
lib/capybara/node/simple.rb:143:23: W: Lint/UnusedMethodArgument: Unused method argument - seconds. If it's necessary, use _ or _seconds as an argument name to indicate that it won't be used. You can also write as synchronize(*) if you want the method to accept any arguments but don't care about them.
      def synchronize(seconds=nil)
                      ^^^^^^^
lib/capybara/minitest/spec.rb:11:92: C: Performance/FlatMap: Use flat_map instead of map...flatten.
      (%w(selector xpath css link button field select table checked_field unchecked_field).map do |assertion| ...
                                                                                           ^^^^^^^^^^^^^^^^^^
lib/capybara/minitest/spec.rb:14:47: C: Performance/FlatMap: Use flat_map instead of map...flatten.
      end.flatten(1) + %w(selector xpath css).map do |assertion| ...
                                              ^^^^^^^^^^^^^^^^^^
lib/capybara/session/config.rb:101:33: W: Lint/UnusedBlockArgument: Unused block argument - val. If it's necessary, use _ or _val as an argument name to indicate that it won't be used.
      define_method "#{m}=" do |val|
                                ^^^

164 files inspected, 108 offenses detected

</details>

#### Result after renovation

```
$ rubocop
Inspecting 164 files
....................................................................................................................................................................

164 files inspected, no offenses detected
```