### PR TITLE
Fix non-visible text error message

### DIFF
--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -70,7 +70,7 @@ module Capybara
             invisible_text = text(@node, :all)
             invisible_count = invisible_text.scan(@search_regexp).size
             if invisible_count != @count
-              details_message << ". it was found #{invisible_count} #{Capybara::Helpers.declension("time", "times", invisible_count)} including non-visible text"
+              details_message << "it was found #{invisible_count} #{Capybara::Helpers.declension("time", "times", invisible_count)} including non-visible text"
             end
           rescue
             # An error getting the non-visible text (if element goes out of scope) should not affect the response

--- a/lib/capybara/spec/session/assert_text.rb
+++ b/lib/capybara/spec/session/assert_text.rb
@@ -52,6 +52,14 @@ Capybara::SpecHelper.spec '#assert_text' do
     end.to raise_error(Capybara::ExpectationNotMet, /it was found 1 time using a case insensitive search/)
   end
 
+  it "should raise error with helpful message if requested text is present but invisible and with incorrect case", requires: [:js] do
+    @session.visit('/with_html')
+    el = @session.find(:css, '#uppercase')
+    expect do
+      el.assert_text('text here')
+    end.to raise_error(Capybara::ExpectationNotMet, /it was found 1 time using a case insensitive search and it was found 1 time including non-visible text/)
+  end
+
   it "should raise the correct error if requested text is missing but contains regex special characters" do
     @session.visit('/with_html')
     expect do

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -122,6 +122,10 @@ banana</textarea>
   <a id="link_blank_href" href="">Blank href</a>
 </div>
 
+<div id="uppercase" style="text-transform: uppercase;">
+  text here
+</div>
+
 <div id="ancestor3">
   Ancestor
   <div id="ancestor2">


### PR DESCRIPTION
- Remove extra period in the invisible text details message
- Add error validation test that requires `:js` for when text is changed by `text-transform` css
  - When asserting on text that is changed via css in a test that requires `:js`, the test must assert how the text exactly looks on the
  page, not just in HTML
  - Discrepancy between pure html and actual output on page
  - In this case, the text is found using case insensitive text and including non-visible text and displays both error detail messages
  - When those two error detail messages (case insensitive and non-visible) are concatenated, the error looks off because of the prepended period
  - Remove the prepended period so that the error looks correct

- For example before the removal of the period, the full error for [this test](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/spec/session/assert_text.rb#L45) is the following (notice the period after However):
`Capybara::ExpectationNotMet: expected to find text "Some of this text is hidden!" in "Some of this text is". (However, . it was found 1 time including non-visible text.)`

- Also the newly added test case's error message before the removal of the extra period would have been (notice period after and):
`Capybara::ExpectationNotMet: expected to find text "text here" in "TEXT HERE". (However, it was found 1 time using a case insensitive search and . it was found 1 time including non-visible text.)`

- After removing the period from the detail message, the error for the test that requires `:js` and incorrectly asserts on text that was changed via css `text-transform` will look like:
`Capybara::ExpectationNotMet: expected to find text "text here" in "TEXT HERE". (However, it was found 1 time using a case insensitive search and it was found 1 time including non-visible text.)`

My question is, what situation am I not seeing that required the prepended period for non-visible text error message?
Also, is showing the non-visible error incorrect for this situation? It could be seen as a bug with the error handling logic (the text isn't invisible, just masked by css changes)