### PR TITLE
Test and document has_select? for no selected options.

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -423,6 +423,10 @@ module Capybara
       #
       #     page.has_select?('Language', selected: ['English', 'German'])
       #
+      # Or, that no options should have the selected attribute:
+      #
+      #     page.has_select?('City', selected: [])
+      #
       # It's also possible to check if the exact set of options exists for
       # this select box:
       #

--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -17,6 +17,7 @@ Capybara::SpecHelper.spec '#has_select?' do
     it "should be true if a field with the given value is on the page" do
       expect(@session).to have_select('form_locale', selected: 'English')
       expect(@session).to have_select('Region', selected: 'Norway')
+      expect(@session).to have_select('City', selected: [])
       expect(@session).to have_select('Underwear', selected: [
         'Boxerbriefs', 'Briefs', 'Commando', "Frenchman's Pantalons", 'Long Johns'
       ])
@@ -24,6 +25,7 @@ Capybara::SpecHelper.spec '#has_select?' do
 
     it "should be false if the given field is not on the page" do
       expect(@session).not_to have_select('Locale', selected: 'Swedish')
+      expect(@session).not_to have_select('Locale', selected: [])
       expect(@session).not_to have_select('Does not exist', selected: 'John')
       expect(@session).not_to have_select('City', selected: 'Not there')
       expect(@session).not_to have_select('Underwear', selected: [


### PR DESCRIPTION
Typically, we use `has_select? 'foo', selected: 'a'` to determine if a select
element 'foo' has an option 'a' with the `selected` attribute. However, we can
also invoke `has_select? 'foo', selected: []` to determine that none of the
options has the `selected` attribute. This is handy, but not documented nor
tested.

Test and document `has_select? 'foo', selected: []`.