### PR TITLE
Use backslashes for file path for Marionette driver on Windows

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -55,6 +55,8 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
         path_names = value.to_s.empty? ? [] : value
         if driver.chrome?
           native.send_keys(Array(path_names).join("\n"))
+        elsif driver.marionette? && Gem.win_platform?
+          native.send_keys(*Array(path_names).map {|p| p.tr('/', '\\')})
         else
           native.send_keys(*path_names)
         end


### PR DESCRIPTION
`attach_file` doesn't work on Windows when Marionette driver is in use.
It expects a pathname in backslash notation. For example if you try to
execute `attach_file("D:/Folder/Example.txt")` the driver returns the
following:

```ruby
  1) Capybara::Session selenium #attach_file with normal form should set a file path by id
     Failure/Error: native.send_keys(*path_names)

     Selenium::WebDriver::Error::InvalidArgumentError:
       File not found: D:/Folder/Example.txt
     # WebDriverError@chrome://marionette/content/error.js:235:5
     # InvalidArgumentError@chrome://marionette/content/error.js:362:5
     # interaction.uploadFile@chrome://marionette/content/interaction.js:360:11
     # ./lib/capybara/selenium/node.rb:61:in `set'
     # ./lib/capybara/node/element.rb:108:in `block in set'
     # ./lib/capybara/node/base.rb:85:in `synchronize'
     # ./lib/capybara/node/element.rb:106:in `set'
     # ./lib/capybara/node/actions.rb:256:in `attach_file'
     # ./lib/capybara/session.rb:808:in `block (2 levels) in <class:Session>'
     # ./lib/capybara/spec/session/attach_file_spec.rb:13:in `block (3 levels) in <top (required)>'
```