### PR TITLE
show attempted url when setting invalid app_host or default_host

### DIFF
--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -68,13 +68,13 @@ module Capybara
 
     remove_method :app_host=
     def app_host=(url)
-      raise ArgumentError, "Capybara.app_host should be set to a url (http://www.example.com)" unless url.nil? || (url =~ URI::DEFAULT_PARSER.make_regexp)
+      raise ArgumentError, "Capybara.app_host should be set to a url (http://www.example.com). Tried to set to #{url.inspect}." unless url.nil? || (url =~ URI::DEFAULT_PARSER.make_regexp)
       @app_host = url
     end
 
     remove_method :default_host=
     def default_host=(url)
-      raise ArgumentError, "Capybara.default_host should be set to a url (http://www.example.com)" unless url.nil? || (url =~ URI::DEFAULT_PARSER.make_regexp)
+      raise ArgumentError, "Capybara.default_host should be set to a url (http://www.example.com). Tried to set to #{url.inspect}." unless url.nil? || (url =~ URI::DEFAULT_PARSER.make_regexp)
       @default_host = url
     end
 


### PR DESCRIPTION
I've encountered this warning recently in tests that only run on a CI container. It seems like a more informative error message would help folks more generally, too.