### PR TITLE
Add No Sandbox to Selenium Chrome Headless

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -478,5 +478,6 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--headless'
   browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end


### PR DESCRIPTION
In some non-Rails projects I like using Capybara defaults and testing on TravisCI. However, I found this memory issue to be an ever constant problem https://github.com/travis-ci/travis-ci/issues/7150

Can we add `--no-sandbox` to the default options here for the `:selenium_chrome_headless` driver? Are there drawbacks to this?