### PR TITLE
Rescue SessionNotCreatedError during Capybara::Selenium::Driver#quit

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -249,7 +249,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def quit
     @browser.quit if @browser
-  rescue Errno::ECONNREFUSED
+  rescue Selenium::WebDriver::Error::SessionNotCreatedError, Errno::ECONNREFUSED
     # Browser must have already gone
   rescue Selenium::WebDriver::Error::UnknownError => e
     unless silenced_unknown_error_message?(e.message) # Most likely already gone


### PR DESCRIPTION
It is possible for selenium to throw `Selenium::WebDriver::Error::SessionNotCreatedError` when calling `Capybara::Selenium::Driver#quit`.

I have not been able to determine exactly when this error might occur, but it does appear to have something to do with `geckodriver` crashing.  In these cases Firefox has quit so it seems reasonable to swallow the error in the same way that capybara handles `Errno::ECONNREFUSED`.

The stack trace looks something like this:
```
Tried to run command without establishing a connection (Selenium::WebDriver::Error::SessionNotCreatedError)
 from    0:           0x4edb3c - backtrace::backtrace::trace::hc4bd56a2f176de7e
 from    1:           0x4edb72 - backtrace::capture::Backtrace::new::he3b2a15d39027c46
 from    2:           0x4409a1 - webdriver::error::WebDriverError::new::h81babdd86c977032
 from    3:           0x4280ea - <webdriver::server::Dispatcher<T, U>>::run::h2119c674d7b88193
 from    4:           0x4029b9 - std::sys_common::backtrace::__rust_begin_short_backtrace::h21d98a9ff86d4c25
 from    5:           0x40be65 - std::panicking::try::do_call::h5cff0c9b18cfdbba
 from    6:           0x5e6a6c - panic_unwind::__rust_maybe_catch_panic
 from                         at /checkout/src/libpanic_unwind/lib.rs:99
 from    7:           0x41eb22 - <F as alloc::boxed::FnBox<A>>::call_box::h413eb1d9d9f1c473
 from    8:           0x5df13b - alloc::boxed::{{impl}}::call_once<(),()>
 from                         at /checkout/src/liballoc/boxed.rs:692
 from                          - std::sys_common::thread::start_thread
 from                         at /checkout/src/libstd/sys_common/thread.rs:21
 from                          - std::sys::imp::thread::{{impl}}::new::thread_start
 from                         at /checkout/src/libstd/sys/unix/thread.rs:84
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/response.rb:69:in 'assert_ok'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/response.rb:32:in 'initialize'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/http/common.rb:81:in 'new'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/http/common.rb:81:in 'create_response'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/http/default.rb:104:in 'request'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/http/common.rb:59:in 'call'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/bridge.rb:164:in 'execute'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/w3c/bridge.rb:535:in 'execute'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/remote/w3c/bridge.rb:139:in 'quit'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/common/driver.rb:166:in 'quit'
 from selenium-webdriver-3.8.0/lib/selenium/webdriver/firefox/marionette/driver.rb:62:in 'quit'
 from capybara-2.17.0/lib/capybara/selenium/driver.rb:268:in 'quit'
```