### PR TITLE
History.md: Fix header for 2.18.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,7 +14,7 @@ Release date: unreleased
 
 * `Capybara.exact_options` no longer exists. Just use `exact:true` on relevant actions/finders if necessary.
 
-#Version 2.18.0
+# Version 2.18.0
 Release date: 2018-02-12
 
 ### Fixed


### PR DESCRIPTION
Was not rendered as a header.