### PR TITLE
Retry navigation if unload alert disappears

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -142,7 +142,20 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         @browser.switch_to.alert.accept
         sleep 0.25 # allow time for the modal to be handled
       rescue modal_error
-        # The alert is now gone - nothing to do
+        # The alert is now gone
+
+        if navigated
+          # The alert appeared after attempting navigation but disappeared before we could accept it
+
+          # Try to navigate again, anticipating the alert this time
+          begin
+            accept_modal(nil, wait: 0.1) do
+              @browser.navigate.to("about:blank")
+            end
+          rescue Capybara::ModalNotFound
+            # No alert appeared this time
+          end
+        end
       end
       # try cleaning up the browser again
       retry


### PR DESCRIPTION
When a Selenium driver interaction raises an unexpected alert error, Firefox 59+ [automatically dismisses the user prompt][1] that caused it. Therefore, if the driver reset triggers an unload alert, we cannot wait to handle it until we receive an unexpected alert error. Instead, we must retry navigation and proactively attempt to accept any alert that appears.

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1416284