### PR TITLE
[comments only] Clarify semantics of Finders#first

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -265,14 +265,17 @@ module Capybara
       # Find the first element on the page matching the given selector
       # and options. By default `first` will wait up to `Capybara.default_max_wait_time`
       # seconds for matching elements to appear and then raise an error if no matching
-      # element is found
+      # element is found. Providing the option `minimum: 0` changes this behavior to
+      # instead return `nil` if no matching elements appear in time.
       #
       # @overload first([kind], locator, options)
       #   @param [:css, :xpath] kind                 The type of selector
       #   @param [String] locator                    The selector
       #   @param [Hash] options                      Additional options; see {#all}
       # @return [Capybara::Node::Element]            The found element or nil
-      # @raise  [Capybara::ElementNotFound]          If the element can't be found before time expires
+      # @raise  [Capybara::ElementNotFound]          If the element can't be found before wait
+      #                                              time expires, unless option `minimum: 0`
+      #                                              was provided
       #
       def first(*args, **options, &optional_filter_block)
         options = { minimum: 1 }.merge(options)


### PR DESCRIPTION
Proposed change is only to documentation comments, to clarify the semantics
around exactly when and how the `Finders#first` method can be changed from
the default behavior (of throwing an exception) to the alternate behavior (of
returning `nil`) when no matching element is found before the max wait time
expires.

cc @twalpole

See original discussion on #1971