### PR TITLE
Derived object should call #initialize method of parent class.

### DIFF
--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -8,6 +8,7 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
   class NilUploadedFile < Rack::Test::UploadedFile
     def initialize
       @empty_file = Tempfile.new("nil_uploaded_file")
+      super @empty_file
       @empty_file.close
     end
 


### PR DESCRIPTION
Not calling #initialize might result in some weird behavior and unexpected access to uninitialized instance variables of object, such as https://github.com/rack-test/rack-test/issues/214