### PR TITLE
Fix running IE tests on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'bundler', '~> 1.1'
 gemspec
 
 gem 'xpath', git: 'git://github.com/teamcapybara/xpath.git'
+gem 'webdrivers', git: 'git://github.com/hron/webdrivers', branch: 'iedriver-sorting-fix' if ENV['CI']
 
 group :doc do
   gem 'redcarpet', platforms: :mri

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,9 @@ matrix:
 install:
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - cinst Firefox GoogleChrome
+  # Registry hack so driver can maintain connection
+  - REG ADD "HKLM\SOFTWARE\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 00000000
+  - REG ADD "HKLM\SOFTWARE\Wow6432Node\Microsoft\Internet Explorer\MAIN\FeatureControl\FEATURE_BFCACHE" /v iexplore.exe /t REG_DWORD /d 00000000
   - bundle config --local path vendor/bundle
   - bundle install
 

--- a/spec/selenium_spec_edge.rb
+++ b/spec/selenium_spec_edge.rb
@@ -20,7 +20,7 @@ $stdout.puts `#{Selenium::WebDriver::Edge.driver_path} --version` if ENV['CI']
 
 Capybara::SpecHelper.run_specs TestSessions::SeleniumEdge, "selenium", capybara_skip: skipped_tests
 
-RSpec.describe "Capybara::Session with Edge" do
+RSpec.describe "Capybara::Session with Edge", capybara_skip: skipped_tests do
   include Capybara::SpecHelper
   include_examples  "Capybara::Session", TestSessions::SeleniumEdge, :selenium_edge
   include_examples  Capybara::RSpecMatchers, TestSessions::SeleniumEdge, :selenium_edge

--- a/spec/selenium_spec_ie.rb
+++ b/spec/selenium_spec_ie.rb
@@ -18,7 +18,7 @@ module TestSessions
   SeleniumIE = Capybara::Session.new(:selenium_ie, TestApp)
 end
 
-skipped_tests = %i[response_headers status_code trigger js modals]
+skipped_tests = %i[response_headers status_code trigger modals]
 
 $stdout.puts `#{Selenium::WebDriver::IE.driver_path} --version` if ENV['CI']
 

--- a/spec/selenium_spec_ie.rb
+++ b/spec/selenium_spec_ie.rb
@@ -7,7 +7,11 @@ require 'rspec/shared_spec_matchers'
 
 Capybara.register_driver :selenium_ie do |app|
   # ::Selenium::WebDriver.logger.level = "debug"
-  Capybara::Selenium::Driver.new(app, browser: :ie)
+  Capybara::Selenium::Driver.new(
+      app,
+      browser: :ie,
+      desired_capabilities: ::Selenium::WebDriver::Remote::Capabilities.ie('requireWindowFocus': true)
+  )
 end
 
 module TestSessions

--- a/spec/selenium_spec_ie.rb
+++ b/spec/selenium_spec_ie.rb
@@ -14,14 +14,14 @@ module TestSessions
   SeleniumIE = Capybara::Session.new(:selenium_ie, TestApp)
 end
 
-skipped_tests = %i[response_headers status_code trigger]
+skipped_tests = %i[response_headers status_code trigger js modals]
 
 $stdout.puts `#{Selenium::WebDriver::IE.driver_path} --version` if ENV['CI']
 
 Capybara::SpecHelper.run_specs TestSessions::SeleniumIE, "selenium", capybara_skip: skipped_tests
 
-RSpec.describe "Capybara::Session with Internet Explorer" do
+RSpec.describe "Capybara::Session with Internet Explorer", capybara_skip: skipped_tests do
   include Capybara::SpecHelper
-  include_examples  "Capybara::Session", TestSessions::SeleniumIE, :selenium_ie
-  include_examples  Capybara::RSpecMatchers, TestSessions::SeleniumIE, :selenium_ie
+  include_examples "Capybara::Session", TestSessions::SeleniumIE, :selenium_ie
+  include_examples Capybara::RSpecMatchers, TestSessions::SeleniumIE, :selenium_ie
 end

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
       end
     end
 
-    describe "#accept_alert" do
+    describe "#accept_alert", requires: [:modals] do
       it "supports a blockless mode" do
         @session.visit('/with_js')
         @session.click_link('Open alert')
@@ -64,7 +64,6 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
       end
 
       it "can be called before visiting" do
-        skip "Edge driver doesn't get any interactions when alert is set" if edge?(@session)
         @session.accept_alert "Initial alert" do
           @session.visit('/initial_alert')
         end


### PR DESCRIPTION
This pull request incorporates all fixes for ability to run IE tests on CI. There are some failing tests still, but they are not related to CI configuration. I think it makes sense to work on them separately.

I'm also not sure about passing `capybara_skip: skipped_tests` to definition of browser specs. 

There is a fix for `webdrivers` gem for sorting IEDriver versions properly. I guess it's fine to have it from my github profile while the pull requests is not yet accepted.

Anyway let me know what you think!