### PR TITLE
Fix default puma server if puma gem is not present

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -232,7 +232,8 @@ module Capybara
     # @param [Integer] port              The port to run the application on
     #
     def run_default_server(app, port)
-      servers[:puma].call(app, port, server_host)
+      server = defined?(Puma) ? :puma : :webrick
+      servers[server].call(app, port, server_host)
     end
 
     ##

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe Capybara do
       Capybara.server.call(mock_app, 8000)
     end
 
+    it "should call the webrick server when puma is not available" do
+      mock_app = double('app')
+      expect(Capybara.servers[:webrick]).to receive(:call)
+      Capybara.server.call(mock_app, 8000)
+    end
+
+    it "should call the puma server when puma is available" do
+      module Puma; end
+      mock_app = double('app')
+      expect(Capybara.servers[:puma]).to receive(:call)
+      Capybara.server.call(mock_app, 8000)
+      Object.send(:remove_const, :Puma)
+    end
+
     it "should return a custom server proc" do
       server = ->(_app, _port) {}
       Capybara.register_server :custom, &server


### PR DESCRIPTION
Currently when upgrading to Capybara 3, the puma server is the default
server regardless if puma is present in the test application itself.

This causes the following error to be raised in non-puma apps test
suites:

```
LoadError:
  cannot load such file -- rack/handler/puma
/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
/gems/capybara-3.0.0/lib/capybara.rb:441:in `block in <top (required)>'
/gems/capybara-3.0.0/lib/capybara.rb:235:in `run_default_server'
/gems/capybara-3.0.0/lib/capybara.rb:432:in `block in <top (required)>'
/gems/capybara-3.0.0/lib/capybara/server.rb:103:in `block in boot'
```

This requires the following modification to be made to the app to get it
to work again.

```
Capybara.server = :webrick
```

Instead, check if puma is present and only then default to puma as the
default server. This will make the upgrade path easier for those
upgrading to 3.0.0 and running alternative servers such as Unicorn.