### PR TITLE
Set puma to leak_stack_on_error

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -458,6 +458,7 @@ Capybara.register_server :puma do |app, port, host, **options|
     s.binder.parse conf.options[:binds], s.events
     s.min_threads = conf.options[:min_threads]
     s.max_threads = conf.options[:max_threads]
+    s.leak_stack_on_error = true
   end.run.join
 end
 


### PR DESCRIPTION
Currently puma doesn't return full stacktraces when exceptions happen. I believe this is desirable behavior for test suites, so the browser doesn't just render the [generic](https://github.com/puma/puma/blob/5fb2df9144803f0f80ec1d9fb19d20d433706fef/lib/puma/server.rb#L873), and unhelpful "An unhandled lowlevel error occurred. The application logs may have details."

This could, of course, be made configurable, but I think this is a sane default that I can't imagine anyone would want to change.