### PR TITLE
Remove uses of `Timeout.timeout` from `Server`

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -107,11 +107,15 @@ module Capybara
           Capybara.server.call(middleware, port, host)
         end
 
-        Timeout.timeout(60) { @server_thread.join(0.1) until responsive? }
+        start_time = Capybara::Helpers.monotonic_time
+        until responsive?
+          if (Capybara::Helpers.monotonic_time - start_time) > 60
+            raise "Rack application timed out during boot"
+          end
+          @server_thread.join(0.1)
+        end
       end
-    rescue Timeout::Error
-      raise "Rack application timed out during boot"
-    else
+
       self
     end
 

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -90,9 +90,13 @@ module Capybara
     end
 
     def wait_for_pending_requests
-      Timeout.timeout(60) { sleep(0.01) while pending_requests? }
-    rescue Timeout::Error
-      raise "Requests did not finish in 60 seconds"
+      start_time = Capybara::Helpers.monotonic_time
+      while pending_requests?
+        if (Capybara::Helpers.monotonic_time - start_time) > 60
+          raise "Requests did not finish in 60 seconds"
+        end
+        sleep 0.01
+      end
     end
 
     def boot


### PR DESCRIPTION
We've recently had some intermittent failures in our test suite with the error 'Requests did not finish in 60 seconds'. After investigating we found that the block passed to `Timeout.timeout` that was hanging. We were unable to find out why, but re-writing the code to use a `while` loop rather than `Timeout.timeout` stopped the issue from occurring. You can [read more on the mailing list](https://groups.google.com/forum/#!topic/ruby-capybara/0Glr6Fmy_rI).

Even if the intermittent problem is only effecting us, I think this change could be justified as an improvement. Timeout is generally considered dangerous to use since the exception may interrupt the code at any point. The `Server` class is the only part of capybara that uses `Timeout.timeout`, elsewhere uses a loop similar to the pattern I've followed here.

While we were only seeing problems from the call to `Timeout` in `wait_for_pending_requests`, I've changed the other use of `Timeout` in `Server#boot` since it was the only other use of `Timeout` in the codebase.

Since this timeout pattern exists in lots of places in capybara I looked at extracting it into `Capybara::Helpers` to make it easier to follow, however because of the diversity of the way that the timeouts work (different timings, predicates, sleep intervals and errors raised) I found it hard to bring together if without changing the existing behaviour or passing in lots of arguments & multiple blocks so decided not to.
