### PR TITLE
Add a mechanism to fill in `input[type=date]` in Chrome and Edge

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -268,7 +268,7 @@ private
         sequence[positions[2] - 1] = date.day
         sequence.each.with_index do |dp, i|
           native.send_keys :left, :left, :left, *Array.new(i, :right)
-          # When the date format contains month name Chrome needs this sleep to show monthname after number's been typed
+          # When the date format contains month name Chrome needs this sleep to show monthname after number's typed
           sleep 0.5
           native.send_keys :backspace, dp.to_s
         end

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -253,40 +253,22 @@ private
     yield
   end
 
-  def set_date(value) # rubocop:disable Naming/AccessorMethodName
-    if value.respond_to?(:to_date)
-      date = value.to_date
-
-      case driver.browser.browser
-      when :chrome
-        native.send_keys :left, :left, :left
-        native.send_keys :backspace, '1', :right, :backspace, '2', :right, :backspace, '3', :left, :left
-        positions = driver.evaluate_script("arguments[0].value", self).split('-').map(&:to_i)
-        sequence = []
-        sequence[positions[0] - 1] = date.year
-        sequence[positions[1] - 1] = date.month
-        sequence[positions[2] - 1] = date.day
-        sequence.each.with_index do |dp, i|
-          native.send_keys :left, :left, :left, *Array.new(i, :right)
-          # When the date format contains month name Chrome needs this sleep to show monthname after number's typed
-          sleep 0.5
-          native.send_keys :backspace, dp.to_s
-        end
-      when :edge
-        native.send_keys :enter
-        native.send_keys :enter
-        current_value = Date.strptime(driver.evaluate_script("arguments[0].value", self), '%Y-%m-%d')
-        native.send_keys :enter
-        %w[month day year].each do |dp|
-          diff = date.send(dp) - current_value.send(dp)
-          native.send_keys(*Array.new(diff.abs, diff.negative? ? :up : :down) + [:right])
-        end
-        native.send_keys :enter
-      else
-        set_text(date.strftime(SET_FORMATS[driver.browser.browser][:date]))
+  def set_date(new_value) # rubocop:disable Naming/AccessorMethodName
+    new_value = new_value.to_date.strftime('%Y-%m-%d') if new_value.respond_to?(:to_date)
+    begin
+      is_value_changing = new_value != value
+      driver.execute_script(<<-JS, self)
+        arguments[0].dispatchEvent(new Event('focus'));
+        arguments[0].value = '#{new_value}';
+      JS
+      if is_value_changing
+        driver.execute_script(<<-JS, self)
+          arguments[0].dispatchEvent(new Event('input'));
+          arguments[0].dispatchEvent(new Event('change'));
+        JS
       end
-    else
-      set_text(value)
+    rescue Capybara::NotSupportedByDriverError
+      set_text(new_value)
     end
   end
 

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -64,4 +64,40 @@ RSpec.describe "Capybara::Session with chrome" do
       end
     end
   end
+
+  describe '#fill_in' do
+    before do
+      @session = TestSessions::Chrome
+      @session.visit('/form')
+    end
+
+    context "Date/Time" do
+      before do
+        @session.execute_script <<-JS
+          window.capybara = {formDateFiredEvents: []};
+          ['focus', 'input', 'change'].forEach(function(eventType) {
+            document.getElementById('form_date')
+              .addEventListener(eventType, function() { window.capybara.formDateFiredEvents.push(eventType) });
+          });
+        JS
+      end
+
+      it "should generate standard events on changing value" do
+        expect {
+          @session.fill_in('form_date', with: Date.today)
+        }.to change {
+          @session.evaluate_script('window.capybara.formDateFiredEvents')
+        }.to %w[focus input change]
+      end
+
+      it "should not generate input and change events if the value is not changed" do
+        expect {
+          @session.fill_in('form_date', with: Date.today)
+          @session.fill_in('form_date', with: Date.today)
+        }.to change {
+          @session.evaluate_script('window.capybara.formDateFiredEvents')
+        }.to %w[focus input change focus]
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Abstract 

This is a work in progress change to allow Capybara works properly with `input[type=date]` and others in the family with different locale and date format settings. I've made some research on this and here are my thoughts.

## How different browsers display `input[type=date]`

It seems all browsers do displaying differently. Firefox relies on its internal languages set, Chrome & Edge use OS locale, but not for date picker. Additionally Chrome on Windows uses date short format from OS settings "Change date and time formats".

## How different browsers allow a user to set value for `input[type=date]`

Apparently there is no single way to do it. Firefox magically allows a user to type in date using `%Y-%m-%d` format and everything works regardless of how the controls are displayed. 

Chrome allows typing, but the typed parts go to date's parts and must respect the current date format. Also if the year part is the first one, you must type right arrow to move cursor to the next date part. 

Edge doesn't allow typing date at all! You must use arrows to choose the date.

## The Suggested approach

I suggest to tackle every browser separately. The current pull request is the demonstration for Chrome and Edge, but this approach could be used for all other inputs.

- [x] Fix filling in `input[type=date]` in Chrome and Edge for different date formats
- [ ] Fix filling in `input[type=time]` in Chrome and Edge for different time formats
- [ ] Fix filling in `input[type=datetime-local]` in Chrome and Edge for different time formats

Please let me know if the approach I suggested is good enough and it makes sense to use it for all other inputs from the family.

