### PR TITLE
Add `without` method to session to temporarily escape from `within`

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -59,7 +59,7 @@ module Capybara
     SESSION_METHODS = %i[
       body html source current_url current_host current_path
       execute_script evaluate_script visit refresh go_back go_forward
-      within within_element within_fieldset within_table within_frame switch_to_frame
+      within within_element within_fieldset within_table within_frame without switch_to_frame
       current_window windows open_new_window switch_to_window within_window window_opened_by
       save_page save_and_open_page save_screenshot
       save_and_open_screenshot reset_session! response_headers
@@ -424,6 +424,16 @@ module Capybara
       ensure
         switch_to_frame(:parent)
       end
+    end
+
+    ##
+    # Execute the given block with no scope. Used to temporarily "escape" from a `within` block.
+    #
+    def without
+      old_scopes = scopes
+      @scopes = [nil]
+      yield
+      @scopes = old_scopes
     end
 
     ##

--- a/lib/capybara/spec/session/within_spec.rb
+++ b/lib/capybara/spec/session/within_spec.rb
@@ -121,6 +121,16 @@ Capybara::SpecHelper.spec '#within' do
     expect(extract_results(@session)['first_name']).to eq('Dagobert')
   end
 
+  it "should allow escaping from within using without" do
+    @session.within(:css, "#for_foo") do
+      expect(@session).not_to have_content('This page is used')
+      @session.without do
+        expect(@session).to have_content('This page is used')
+      end
+      expect(@session).not_to have_content('This page is used')
+    end
+  end
+
   it "should have #within_element as an alias" do
     expect(Capybara::Session.instance_method(:within)).to eq Capybara::Session.instance_method(:within_element)
     @session.within_element(:css, "#for_foo") do


### PR DESCRIPTION
I have a need for this in a helper method for filling out a select2 box. The first step is to fill in the box itself, which triggers a popup element for doing the typedown search. The popup is inserted dynamically at the foot of the page, outside the within scope. So I need the within for only _part_ of my helper method.

I hope this is making some sense! Let me know what you think!

And thanks for the awesome tool!