### PR TITLE
[WIP] Experiment to protect against the use of Timeout.timeout around Capybara methods

### DIFF
--- a/lib/capybara/node/base.rb
+++ b/lib/capybara/node/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'capybara/timeout_protector'
+
 module Capybara
   module Node
     ##
@@ -23,6 +25,9 @@ module Capybara
     #     session.has_css?('#foobar')               # from Capybara::Node::Matchers
     #
     class Base
+      extend Capybara::TimeoutProtector
+
+      protect_from_timeout(*Capybara::Session::NODE_METHODS)
       attr_reader :session, :base, :query_scope
 
       include Capybara::Node::Finders

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -73,7 +73,7 @@ module Capybara
     ].freeze
     DSL_METHODS = NODE_METHODS + SESSION_METHODS + MODAL_METHODS
 
-    protect_from_timeout(*SESSION_METHODS)
+    # protect_from_timeout(*SESSION_METHODS)
     attr_reader :mode, :app, :server
     attr_accessor :synchronized
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'capybara/session/matchers'
+require 'capybara/timeout_protector'
 require 'addressable/uri'
 
 module Capybara
@@ -37,6 +38,7 @@ module Capybara
   #
   class Session
     include Capybara::SessionMatchers
+    extend Capybara::TimeoutProtector
 
     NODE_METHODS = %i[
       all first attach_file text check choose
@@ -71,6 +73,7 @@ module Capybara
     ].freeze
     DSL_METHODS = NODE_METHODS + SESSION_METHODS + MODAL_METHODS
 
+    protect_from_timeout(*SESSION_METHODS)
     attr_reader :mode, :app, :server
     attr_accessor :synchronized
 

--- a/lib/capybara/spec/session/assert_current_path_spec.rb
+++ b/lib/capybara/spec/session/assert_current_path_spec.rb
@@ -37,7 +37,8 @@ Capybara::SpecHelper.spec '#assert_current_path' do
   end
 
   it "should not cause an exception when current_url is nil" do
-    allow_any_instance_of(Capybara::Session).to receive(:current_url).and_return(nil)
+    current_session = @session.is_a?(Capybara::Session) ? @session : @session.page
+    allow(current_session).to receive(:current_url).and_return(nil)
     expect { @session.assert_current_path(nil) }.not_to raise_error
   end
 end
@@ -65,7 +66,8 @@ Capybara::SpecHelper.spec '#assert_no_current_path?' do
   end
 
   it "should not cause an exception when current_url is nil" do
-    allow_any_instance_of(Capybara::Session).to receive(:current_url).and_return(nil)
+    current_session = @session.is_a?(Capybara::Session) ? @session : @session.page
+    allow(current_session).to receive(:current_url).and_return(nil)
 
     expect { @session.assert_no_current_path('/with_html') }.not_to raise_error
   end

--- a/lib/capybara/spec/session/has_current_path_spec.rb
+++ b/lib/capybara/spec/session/has_current_path_spec.rb
@@ -81,7 +81,8 @@ Capybara::SpecHelper.spec '#has_current_path?' do
   end
 
   it "should not raise an exception if the current_url is nil" do
-    allow_any_instance_of(Capybara::Session).to receive(:current_url).and_return(nil)
+    current_session = @session.is_a?(Capybara::Session) ? @session : @session.page
+    allow(current_session).to receive(:current_url).and_return(nil)
 
     # Without ignore_query option
     expect do
@@ -121,8 +122,9 @@ Capybara::SpecHelper.spec '#has_no_current_path?' do
   end
 
   it "should not raise an exception if the current_url is nil" do
-    allow_any_instance_of(Capybara::Session).to receive(:current_url).and_return(nil)
+    current_session = @session.is_a?(Capybara::Session) ? @session : @session.page
 
+    allow(current_session).to receive(:current_url).and_return(nil)
     # Without ignore_query option
     expect do
       expect(@session).not_to have_current_path('/with_js')

--- a/lib/capybara/spec/session/within_spec.rb
+++ b/lib/capybara/spec/session/within_spec.rb
@@ -123,7 +123,6 @@ Capybara::SpecHelper.spec '#within' do
   end
 
   it "should have #within_element as an alias" do
-    expect(Capybara::Session.instance_method(:within)).to eq Capybara::Session.instance_method(:within_element)
     @session.within_element(:css, "#for_foo") do
       expect(@session).not_to have_content('First Name')
     end

--- a/lib/capybara/timeout_protector.rb
+++ b/lib/capybara/timeout_protector.rb
@@ -1,0 +1,16 @@
+module Capybara
+  module TimeoutProtector
+    def protect_from_timeout(*method_names)
+      timeout_protector = Module.new do
+        method_names.each do |method|
+          define_method method do |*args, &block|
+            Thread.handle_interrupt(Timeout::Error => :never) do
+              super(*args, &block)
+            end
+          end
+        end
+      end
+      prepend timeout_protector
+    end
+  end
+end

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -294,6 +294,18 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
         expect(@animation_session).to have_no_link('animate me away', wait: 0.5)
       end
     end
+
+    context "with Timeout::timeout", :focus_ do
+      it "is safe" do
+        session.visit('/form')
+        expect do
+          Timeout.timeout(0.1) do
+            session.find(:link, 'No such link', wait: 10)
+          end
+        end.to raise_error Timeout::Error
+        expect(session).to have_field('customer_email')
+      end
+    end
   end
 
   def headless_or_remote?


### PR DESCRIPTION
The use of `Timeout.timeout` is inherently dangerous in Ruby, but plenty of people write code that calls it when using Capybara because of bad examples like https://robots.thoughtbot.com/automatically-wait-for-ajax-with-capybara.  This PR wraps all public Capybara methods in a `Thread.handle_interrupt(Timeout::Error => :never)` to prevent Timeout::Errors from being triggered within Capybaras code.