### PR TITLE
Add links for rubygems page

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("{lib,spec,.yard}/**/*") + %w(README.md History.md License.txt .yardopts)
 
-  s.homepage = "http://teamcapybara.github.io/capybara"
+  s.homepage = "https://github.com/teamcapybara/capybara"
   s.metadata = {
     "changelog_uri" => "https://github.com/teamcapybara/capybara/blob/master/History.md",
     "source_code_uri" => "https://github.com/teamcapybara/capybara"

--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -15,7 +15,11 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("{lib,spec,.yard}/**/*") + %w(README.md History.md License.txt .yardopts)
 
-  s.homepage = "https://github.com/teamcapybara/capybara"
+  s.homepage = "http://teamcapybara.github.io/capybara"
+  s.metadata = {
+    "changelog_uri" => "https://github.com/teamcapybara/capybara/blob/master/History.md",
+    "source_code_uri" => "https://github.com/teamcapybara/capybara"
+  }
   s.require_paths = ["lib"]
   s.summary = "Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb"
 


### PR DESCRIPTION
It would be useful to have direct links to http://rubygems.org/gems/capybara/ page