### PR TITLE
Add Window#fullscreen and support in Selenium driver

### DIFF
--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -90,7 +90,11 @@ class Capybara::Driver::Base
   end
 
   def maximize_window(handle)
-    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#maximize_current_window'
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#maximize_window'
+  end
+
+  def fullscreen_window(handle)
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#fullscreen_window'
   end
 
   def close_window(handle)

--- a/lib/capybara/spec/session/window/window_spec.rb
+++ b/lib/capybara/spec/session/window/window_spec.rb
@@ -184,4 +184,21 @@ Capybara::SpecHelper.spec Capybara::Window, requires: [:windows] do
       expect(ow_height).to be > 300
     end
   end
+
+  describe '#fullscreen' do
+    before do
+      @initial_size = @session.current_window.size
+    end
+
+    after do
+      @session.current_window.resize_to(*@initial_size)
+      sleep 0.5
+    end
+
+    it "should be able to fullscreen the window" do
+      expect do
+        @session.current_window.fullscreen
+      end.not_to raise_error
+    end
+  end
 end

--- a/lib/capybara/window.rb
+++ b/lib/capybara/window.rb
@@ -101,6 +101,17 @@ module Capybara
       wait_for_stable_size { @driver.maximize_window(handle) }
     end
 
+    ##
+    # Fullscreen window.
+    #
+    # If a particular driver doesn't have concept of fullscreen it may not support this method.
+    #
+    # @macro about_current
+    #
+    def fullscreen
+      @driver.fullscreen_window(handle)
+    end
+
     def eql?(other)
       other.is_a?(self.class) && @session == other.session && @handle == other.handle
     end


### PR DESCRIPTION
Also works around selenium-webdriver not currently supporting calling fullscreen with chrome and chromedriver not waiting long enough for the page state to change out of fullscreen when resetting the size.