### PR TITLE
Test file uploading with remote selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
     - gemfile: Gemfile
       rvm: 2.5.1
       env: CAPYBARA_CHROME_REMOTE=true
+    - gemfile: Gemfile
+      rvm: 2.5.1
+      env: CAPYBARA_FIREFOX_REMOTE=true
     - gemfile: gemfiles/Gemfile.rspec-34
       rvm: 2.3.6
       env: CAPYBARA_FF=true
@@ -71,6 +74,7 @@ matrix:
     - gemfile: gemfiles/Gemfile.beta-versions
     - gemfile: gemfiles/Gemfile.edge-marionette
     - env: CAPYBARA_CHROME_REMOTE=true
+    - env: CAPYBARA_FIREFOX_REMOTE=true
 before_install:
   - gem update --system
   - gem install bundler
@@ -82,7 +86,7 @@ before_install:
       bundle config local.selenium-webdriver ../selenium/build/rb;
     fi
 before_script:
-  - if [[ -z $HEADLESS && -z $CAPYBARA_CHROME_REMOTE ]]; then
+  - if [[ -z $HEADLESS && -z $CAPYBARA_CHROME_REMOTE && -z $CAPYBARA_FIREFOX_REMOTE ]]; then
       export DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
       sleep 1;
@@ -91,11 +95,21 @@ before_script:
       awesome &
     fi
   - if [[ $CAPYBARA_CHROME_REMOTE = true ]]; then
-      docker-compose up -d selenium
+      docker-compose up -d selenium_chrome
 
       TIMEOUT=10
 
       until wget --spider http://localhost:4444 > /dev/null 2>&1 || [ $TIMEOUT -eq 0 ]; do
+        echo "Waiting for selenium server, $((TIMEOUT--)) remaining attempts...";
+        sleep 1;
+      done
+    fi
+  - if [[ $CAPYBARA_FIREFOX_REMOTE = true ]]; then
+      docker-compose up -d selenium_firefox
+
+      TIMEOUT=10
+
+      until wget --spider http://localhost:4445 > /dev/null 2>&1 || [ $TIMEOUT -eq 0 ]; do
         echo "Waiting for selenium server, $((TIMEOUT--)) remaining attempts...";
         sleep 1;
       done

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,12 @@ matrix:
   include:
     - gemfile: Gemfile
       rvm: 2.5.1
-      env: CAPYBARA_CHROME_REMOTE=true
+      env: CAPYBARA_REMOTE=true
     - gemfile: Gemfile
       rvm: 2.5.1
-      env: CAPYBARA_FIREFOX_REMOTE=true
+      env:
+        - CAPYBARA_REMOTE=true
+        - CAPYBARA_FF=true
     - gemfile: gemfiles/Gemfile.rspec-34
       rvm: 2.3.6
       env: CAPYBARA_FF=true
@@ -73,8 +75,6 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.beta-versions
     - gemfile: gemfiles/Gemfile.edge-marionette
-    - env: CAPYBARA_CHROME_REMOTE=true
-    - env: CAPYBARA_FIREFOX_REMOTE=true
 before_install:
   - gem update --system
   - gem install bundler
@@ -86,7 +86,7 @@ before_install:
       bundle config local.selenium-webdriver ../selenium/build/rb;
     fi
 before_script:
-  - if [[ -z $HEADLESS && -z $CAPYBARA_CHROME_REMOTE && -z $CAPYBARA_FIREFOX_REMOTE ]]; then
+  - if [[ -z $HEADLESS && -z $CAPYBARA_REMOTE ]]; then
       export DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
       sleep 1;
@@ -94,8 +94,8 @@ before_script:
       echo "require('awful'); tags = {}; tags[1] = awful.tag({'name'})" > ~/.config/awesome/rc.lua;
       awesome &
     fi
-  - if [[ $CAPYBARA_CHROME_REMOTE = true ]]; then
-      docker-compose up -d selenium_chrome
+  - if [[ $CAPYBARA_REMOTE = true ]]; then
+      docker-compose up -d
 
       TIMEOUT=10
 
@@ -103,9 +103,6 @@ before_script:
         echo "Waiting for selenium server, $((TIMEOUT--)) remaining attempts...";
         sleep 1;
       done
-    fi
-  - if [[ $CAPYBARA_FIREFOX_REMOTE = true ]]; then
-      docker-compose up -d selenium_firefox
 
       TIMEOUT=10
 

--- a/Rakefile
+++ b/Rakefile
@@ -38,16 +38,16 @@ Cucumber::Rake::Task.new(:cucumber) do |task|
 end
 
 task :travis do
-  if ENV['CAPYBARA_FF']
+  if ENV['CAPYBARA_REMOTE'] && ENV['CAPYBARA_FF']
+    Rake::Task[:spec_firefox_remote].invoke
+  elsif ENV['CAPYBARA_FF']
     Rake::Task[:spec_marionette].invoke
   elsif ENV['CAPYBARA_IE']
     Rake::Task[:spec_ie].invoke
   elsif ENV['CAPYBARA_EDGE']
     Rake::Task[:spec_edge].invoke
-  elsif ENV['CAPYBARA_CHROME_REMOTE']
+  elsif ENV['CAPYBARA_REMOTE']
     Rake::Task[:spec_chrome_remote].invoke
-  elsif ENV['CAPYBARA_FIREFOX_REMOTE']
-    Rake::Task[:spec_firefox_remote].invoke
   else
     Rake::Task[:spec_chrome].invoke
   end

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ RSpec::Core::RakeTask.new(:spec_marionette) do |t|
   t.pattern = './spec{,/*/**}/*{_spec.rb,_spec_marionette.rb}'
 end
 
-%w[chrome ie edge chrome_remote].each do |driver|
+%w[chrome ie edge chrome_remote firefox_remote].each do |driver|
   RSpec::Core::RakeTask.new(:"spec_#{driver}") do |t|
     t.rspec_opts = rspec_opts
     t.pattern = "./spec/*{_spec_#{driver}.rb}"
@@ -46,6 +46,8 @@ task :travis do
     Rake::Task[:spec_edge].invoke
   elsif ENV['CAPYBARA_CHROME_REMOTE']
     Rake::Task[:spec_chrome_remote].invoke
+  elsif ENV['CAPYBARA_FIREFOX_REMOTE']
+    Rake::Task[:spec_firefox_remote].invoke
   else
     Rake::Task[:spec_chrome].invoke
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
     image: "selenium/${SELENIUM_IMAGE:-standalone-chrome-debug}"
     volumes:
       - "/dev/shm:/dev/shm"
-      - "${PWD}:${PWD}" # For making attach_file specs work
+      # - "${PWD}:${PWD}" # For making attach_file specs work
   selenium_firefox:
     network_mode: "host"
     image: "selenium/${SELENIUM_IMAGE:-standalone-firefox-debug}"
     volumes:
       - "/dev/shm:/dev/shm"
-      - "${PWD}:${PWD}" # For making attach_file specs work
+      # - "${PWD}:${PWD}" # For making attach_file specs work
     environment:
       - SE_OPTS=-port 4445

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "2.1"
+version: "3"
 
 services:
   selenium_chrome:
@@ -7,12 +7,10 @@ services:
     image: "selenium/${SELENIUM_IMAGE:-standalone-chrome-debug}"
     volumes:
       - "/dev/shm:/dev/shm"
-      # - "${PWD}:${PWD}" # For making attach_file specs work
   selenium_firefox:
     network_mode: "host"
     image: "selenium/${SELENIUM_IMAGE:-standalone-firefox-debug}"
     volumes:
       - "/dev/shm:/dev/shm"
-      # - "${PWD}:${PWD}" # For making attach_file specs work
     environment:
       - SE_OPTS=-port 4445

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,17 @@
 version: "2.1"
 
 services:
-  selenium:
+  selenium_chrome:
     network_mode: "host"
     image: "selenium/${SELENIUM_IMAGE:-standalone-chrome-debug}"
     volumes:
       - "/dev/shm:/dev/shm"
       - "${PWD}:${PWD}" # For making attach_file specs work
+  selenium_firefox:
+    network_mode: "host"
+    image: "selenium/${SELENIUM_IMAGE:-standalone-firefox-debug}"
+    volumes:
+      - "/dev/shm:/dev/shm"
+      - "${PWD}:${PWD}" # For making attach_file specs work
+    environment:
+      - SE_OPTS=-port 4445

--- a/lib/capybara/selenium/driver_specializations/chrome_driver.rb
+++ b/lib/capybara/selenium/driver_specializations/chrome_driver.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'capybara/selenium/nodes/chrome_node'
+
 module Capybara::Selenium::Driver::ChromeDriver
   def fullscreen_window(handle)
     within_given_window(handle) do
@@ -31,5 +33,11 @@ module Capybara::Selenium::Driver::ChromeDriver
     switch_to_window(window_handles.first)
     window_handles.slice(1..-1).each { |win| close_window(win) }
     super
+  end
+
+private
+
+  def build_node(native_node)
+    ::Capybara::Selenium::ChromeNode.new(self, native_node)
   end
 end

--- a/lib/capybara/selenium/nodes/chrome_node.rb
+++ b/lib/capybara/selenium/nodes/chrome_node.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Capybara::Selenium::ChromeNode < Capybara::Selenium::Node
+  def set_file(value) # rubocop:disable Naming/AccessorMethodName
+    super(value)
+  rescue ::Selenium::WebDriver::Error::ExpectedError => e
+    if e.message =~ /File not found : .+\n.+/m
+      raise ArgumentError, "Selenium with remote Chrome doesn't currently support multiple file upload"
+    end
+    raise
+  end
+
+private
+
+  def bridge
+    driver.browser.send(:bridge)
+  end
+end

--- a/lib/capybara/selenium/nodes/marionette_node.rb
+++ b/lib/capybara/selenium/nodes/marionette_node.rb
@@ -26,6 +26,28 @@ class Capybara::Selenium::MarionetteNode < Capybara::Selenium::Node
   def set_file(value) # rubocop:disable Naming/AccessorMethodName
     path_names = value.to_s.empty? ? [] : value
     native.clear
-    Array(path_names).each { |p| native.send_keys(p) }
+    Array(path_names).each do |path|
+      unless driver.browser.respond_to?(:upload)
+        if (fd =  bridge.file_detector)
+          local_file = fd.call([path])
+          path = upload(local_file) if local_file
+        end
+      end
+      native.send_keys(path)
+    end
+  end
+
+private
+  def bridge
+    driver.browser.send(:bridge)
+  end
+
+  def upload(local_file)
+    unless File.file?(local_file)
+      raise Error::WebDriverError, "you may only upload files: #{local_file.inspect}"
+    end
+
+    result = bridge.http.call(:post, "session/#{bridge.session_id}/file", {file: Selenium::WebDriver::Zipper.zip_file(local_file)})
+    result['value']
   end
 end

--- a/lib/capybara/selenium/nodes/marionette_node.rb
+++ b/lib/capybara/selenium/nodes/marionette_node.rb
@@ -28,7 +28,7 @@ class Capybara::Selenium::MarionetteNode < Capybara::Selenium::Node
     native.clear
     Array(path_names).each do |path|
       unless driver.browser.respond_to?(:upload)
-        if (fd =  bridge.file_detector)
+        if (fd = bridge.file_detector)
           local_file = fd.call([path])
           path = upload(local_file) if local_file
         end
@@ -38,6 +38,7 @@ class Capybara::Selenium::MarionetteNode < Capybara::Selenium::Node
   end
 
 private
+
   def bridge
     driver.browser.send(:bridge)
   end
@@ -47,7 +48,7 @@ private
       raise Error::WebDriverError, "you may only upload files: #{local_file.inspect}"
     end
 
-    result = bridge.http.call(:post, "session/#{bridge.session_id}/file", {file: Selenium::WebDriver::Zipper.zip_file(local_file)})
+    result = bridge.http.call(:post, "session/#{bridge.session_id}/file", file: Selenium::WebDriver::Zipper.zip_file(local_file))
     result['value']
   end
 end

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -88,12 +88,11 @@ Capybara::SpecHelper.spec "#attach_file" do
 
     it "should not append files to already attached" do
       @session.attach_file "Multiple Documents", with_os_path_separators(@test_file_path)
-      @session.attach_file("Multiple Documents",
-                           [@test_file_path, @another_test_file_path].map { |f| with_os_path_separators(f) })
+      @session.attach_file "Multiple Documents", with_os_path_separators(@another_test_file_path)
       @session.click_button('Upload Multiple')
-      expect(@session.body).to include("2 | ") # number of files
-      expect(@session.body).to include(File.read(@test_file_path))
+      expect(@session.body).to include("1 | ") # number of files
       expect(@session.body).to include(File.read(@another_test_file_path))
+      expect(@session.body).not_to include(File.read(@test_file_path))
     end
   end
 

--- a/spec/selenium_spec_chrome_remote.rb
+++ b/spec/selenium_spec_chrome_remote.rb
@@ -49,6 +49,15 @@ skipped_tests = %i[response_headers status_code trigger download]
 # skip window tests when headless for now - closing a window not supported by chromedriver/chrome
 skipped_tests << :windows if ENV['TRAVIS'] && (ENV['SKIP_WINDOW'] || ENV['HEADLESS'])
 
+RSpec.configure do |config|
+  config.define_derived_metadata do |metadata|
+    case metadata[:full_description]
+    when /^Capybara::Session selenium_chrome_remote #attach_file with multipart form should not break when using HTML5 multiple file input uploading multiple files$/
+      metadata[:pending] = "Selenium with Remote Chrome doesn't support multiple file upload"
+    end
+  end
+end
+
 Capybara::SpecHelper.run_specs TestSessions::Chrome, CHROME_REMOTE_DRIVER.to_s, capybara_skip: skipped_tests
 
 RSpec.describe "Capybara::Session with remote Chrome" do

--- a/spec/selenium_spec_chrome_remote.rb
+++ b/spec/selenium_spec_chrome_remote.rb
@@ -18,7 +18,7 @@ def ensure_selenium_running!
 rescue
   raise 'Selenium is not running. ' \
         "You can run a selenium server easily with: \n" \
-        '  $ docker-compose up -d selenium'
+        '  $ docker-compose up -d selenium_chrome'
 end
 
 Capybara.register_driver :selenium_chrome_remote do |app|
@@ -40,17 +40,10 @@ module TestSessions
 end
 
 TestSessions::Chrome.driver.browser.file_detector = lambda do |args|
-          # args => ["/path/to/file"]
-          str = args.first.to_s
-          str if File.exist?(str)
-        end
-
-session.driver.browser.file_detector = lambda do |args|
   # args => ["/path/to/file"]
   str = args.first.to_s
   str if File.exist?(str)
 end
-
 
 skipped_tests = %i[response_headers status_code trigger download]
 # skip window tests when headless for now - closing a window not supported by chromedriver/chrome

--- a/spec/selenium_spec_chrome_remote.rb
+++ b/spec/selenium_spec_chrome_remote.rb
@@ -39,6 +39,19 @@ module TestSessions
   Chrome = Capybara::Session.new(CHROME_REMOTE_DRIVER, TestApp)
 end
 
+TestSessions::Chrome.driver.browser.file_detector = lambda do |args|
+          # args => ["/path/to/file"]
+          str = args.first.to_s
+          str if File.exist?(str)
+        end
+
+session.driver.browser.file_detector = lambda do |args|
+  # args => ["/path/to/file"]
+  str = args.first.to_s
+  str if File.exist?(str)
+end
+
+
 skipped_tests = %i[response_headers status_code trigger download]
 # skip window tests when headless for now - closing a window not supported by chromedriver/chrome
 skipped_tests << :windows if ENV['TRAVIS'] && (ENV['SKIP_WINDOW'] || ENV['HEADLESS'])

--- a/spec/selenium_spec_firefox_remote.rb
+++ b/spec/selenium_spec_firefox_remote.rb
@@ -10,7 +10,7 @@ def selenium_host
 end
 
 def selenium_port
-  ENV.fetch('SELENIUM_PORT', 4444)
+  ENV.fetch('SELENIUM_PORT', 4445)
 end
 
 def ensure_selenium_running!
@@ -21,11 +21,11 @@ rescue
         '  $ docker-compose up -d selenium'
 end
 
-Capybara.register_driver :selenium_chrome_remote do |app|
+Capybara.register_driver :selenium_firefox_remote do |app|
   ensure_selenium_running!
 
   url = "http://#{selenium_host}:#{selenium_port}/wd/hub"
-  caps = Selenium::WebDriver::Remote::Capabilities.chrome
+  caps = Selenium::WebDriver::Remote::Capabilities.firefox
 
   Capybara::Selenium::Driver.new app,
                                  browser: :remote,
@@ -33,24 +33,25 @@ Capybara.register_driver :selenium_chrome_remote do |app|
                                  url: url
 end
 
-CHROME_REMOTE_DRIVER = :selenium_chrome_remote
+FIREFOX_REMOTE_DRIVER = :selenium_firefox_remote
 
 module TestSessions
-  Chrome = Capybara::Session.new(CHROME_REMOTE_DRIVER, TestApp)
+  Firefox = Capybara::Session.new(FIREFOX_REMOTE_DRIVER, TestApp)
 end
 
 skipped_tests = %i[response_headers status_code trigger download]
 # skip window tests when headless for now - closing a window not supported by chromedriver/chrome
 skipped_tests << :windows if ENV['TRAVIS'] && (ENV['SKIP_WINDOW'] || ENV['HEADLESS'])
 
-Capybara::SpecHelper.run_specs TestSessions::Chrome, CHROME_REMOTE_DRIVER.to_s, capybara_skip: skipped_tests
+Capybara::SpecHelper.run_specs TestSessions::Firefox, FIREFOX_REMOTE_DRIVER.to_s, capybara_skip: skipped_tests
 
-RSpec.describe "Capybara::Session with remote Chrome" do
+RSpec.describe "Capybara::Session with remote firefox" do
   include Capybara::SpecHelper
-  include_examples  "Capybara::Session", TestSessions::Chrome, CHROME_REMOTE_DRIVER
-  include_examples  Capybara::RSpecMatchers, TestSessions::Chrome, CHROME_REMOTE_DRIVER
+  include_examples  "Capybara::Session", TestSessions::Firefox, FIREFOX_REMOTE_DRIVER
+  include_examples  Capybara::RSpecMatchers, TestSessions::Firefox, FIREFOX_REMOTE_DRIVER
 
-  it 'is considered to be chrome' do
-    expect(session.driver.send(:chrome?)).to be_truthy
+  it 'is considered to be firefox' do
+    expect(session.driver.send(:firefox?)).to be_truthy
+    expect(session.driver.send(:marionette?)).to be_truthy
   end
 end

--- a/spec/selenium_spec_firefox_remote.rb
+++ b/spec/selenium_spec_firefox_remote.rb
@@ -18,7 +18,7 @@ def ensure_selenium_running!
 rescue
   raise 'Selenium is not running. ' \
         "You can run a selenium server easily with: \n" \
-        '  $ docker-compose up -d selenium'
+        '  $ docker-compose up -d selenium_firefox'
 end
 
 Capybara.register_driver :selenium_firefox_remote do |app|

--- a/spec/selenium_spec_firefox_remote.rb
+++ b/spec/selenium_spec_firefox_remote.rb
@@ -39,6 +39,12 @@ module TestSessions
   Firefox = Capybara::Session.new(FIREFOX_REMOTE_DRIVER, TestApp)
 end
 
+TestSessions::Firefox.driver.browser.file_detector = lambda do |args|
+  # args => ["/path/to/file"]
+  str = args.first.to_s
+  str if File.exist?(str)
+end
+
 skipped_tests = %i[response_headers status_code trigger download]
 # skip window tests when headless for now - closing a window not supported by chromedriver/chrome
 skipped_tests << :windows if ENV['TRAVIS'] && (ENV['SKIP_WINDOW'] || ENV['HEADLESS'])

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -325,5 +325,4 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
   def with_os_path_separators(path)
     Gem.win_platform? ? path.to_s.tr('/', '\\') : path.to_s
   end
-
 end

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -264,27 +264,27 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
       end
     end
 
-    describe "#attach_file" do
-      before do
-        session.visit('/form')
-      end
-
-      after do
-        session.driver.browser.file_detector = nil if session.driver.browser.respond_to?(:file_detector=)
-      end
-
-      it "uploads the file when file_detector is used", :focus_ do
-        skip "Only test on remote drivers" unless session.driver.browser.respond_to?(:file_detector=)
-        session.driver.browser.file_detector = lambda do |args|
-          # args => ["/path/to/file"]
-          str = args.first.to_s
-          str if File.exist?(str)
-        end
-        session.attach_file "form_image", with_os_path_separators(__FILE__)
-        session.click_button('awesome')
-        expect(extract_results(session)['image']).to eq(File.basename(__FILE__))
-      end
-    end
+    # describe "#attach_file" do
+    #   before do
+    #     session.visit('/form')
+    #   end
+    #
+    #   after do
+    #     session.driver.browser.file_detector = nil if session.driver.browser.respond_to?(:file_detector=)
+    #   end
+    #
+    #   it "uploads the file when file_detector is used", :focus_ do
+    #     skip "Only test on remote drivers" unless session.driver.browser.respond_to?(:file_detector=)
+    #     session.driver.browser.file_detector = lambda do |args|
+    #       # args => ["/path/to/file"]
+    #       str = args.first.to_s
+    #       str if File.exist?(str)
+    #     end
+    #     session.attach_file "form_image", with_os_path_separators(__FILE__)
+    #     session.click_button('awesome')
+    #     expect(extract_results(session)['image']).to eq(File.basename(__FILE__))
+    #   end
+    # end
 
     context "Windows" do
       it "can't close the primary window" do

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -264,28 +264,6 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
       end
     end
 
-    # describe "#attach_file" do
-    #   before do
-    #     session.visit('/form')
-    #   end
-    #
-    #   after do
-    #     session.driver.browser.file_detector = nil if session.driver.browser.respond_to?(:file_detector=)
-    #   end
-    #
-    #   it "uploads the file when file_detector is used", :focus_ do
-    #     skip "Only test on remote drivers" unless session.driver.browser.respond_to?(:file_detector=)
-    #     session.driver.browser.file_detector = lambda do |args|
-    #       # args => ["/path/to/file"]
-    #       str = args.first.to_s
-    #       str if File.exist?(str)
-    #     end
-    #     session.attach_file "form_image", with_os_path_separators(__FILE__)
-    #     session.click_button('awesome')
-    #     expect(extract_results(session)['image']).to eq(File.basename(__FILE__))
-    #   end
-    # end
-
     context "Windows" do
       it "can't close the primary window" do
         expect do
@@ -322,7 +300,4 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
     !ENV['HEADLESS'].nil? || session.driver.options[:browser] == :remote
   end
 
-  def with_os_path_separators(path)
-    Gem.win_platform? ? path.to_s.tr('/', '\\') : path.to_s
-  end
 end


### PR DESCRIPTION
This tests attach_file with remote selenium chrome and firefox.  It works around Seleniums current lack of support for file_detector/remote file upload with geckodriver/firefox, unfortunately there isn't a way to work around the lack of support for multiple file uploading with chrome when using remote.