### PR TITLE
fix selenium driver detection

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -14,7 +14,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def self.load_selenium
     require 'selenium-webdriver'
-    warn "Warning: You're using an unsupported version of selenium-webdriver, please upgrade." if Gem::Version.new(Selenium::WebDriver::VERSION) < Gem::Version.new('3.5.0')
+    warn "Warning: You're using an unsupported version of selenium-webdriver, please upgrade." if Gem.loaded_specs["selenium-webdriver"].version < Gem::Version.new('3.5.0')
   rescue LoadError => e
     raise e if e.message !~ /selenium-webdriver/
     raise LoadError, "Capybara's selenium driver is unable to load `selenium-webdriver`, please install the gem and add `gem 'selenium-webdriver'` to your Gemfile if you are using bundler."


### PR DESCRIPTION
hi, there's a bug introduced in
https://github.com/teamcapybara/capybara/commit/ada77d8b91ab1b8367af5a14e9f6e434defc3818

the problem is that selenium_webdriver has Selenium::WebDriver::VERSION constant since version 3.12.0 and the code in capybara tries to detect older versions then 3.5.0
Gem::Version.new(Selenium::WebDriver::VERSION) < Gem::Version.new('3.5.0')

In my rails app I used gem selenium_webdriver, '3.11.0' (that should be fine), but after upgrading to capybara 3.3.0 all tests start to fail.
Selenium::WebDriver::VERSION wasn't defined, so rails tried to autoload it from ./app/models/version.rb which is obviously wrong.
```
Failure/Error: raise LoadError, "Unable to autoload constant #{qualified_name}, expected #{file_path} to define it" unless from_mod.const_defined?(const_name, false)

            LoadError:
              Unable to autoload constant VERSION, expected /data/builds/abf04988/0/devel/devel/app/models/version.rb to define it
            # /usr/local/rvm/gems/ruby-2.5.0/gems/activesupport-4.2.8/lib/active_support/dependencies.rb:495:in `load_missing_constant'
```