### PR TITLE
Avoid testing control+shift+click in Firefox

### DIFF
--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -377,6 +377,7 @@ Capybara::SpecHelper.spec "node" do
     end
 
     it "should allow multiple modifiers", requires: [:js] do
+      pending "Firefox doesn't generate an event for shift+control+click" if marionette_gte?(62, @session)
       @session.visit('with_js')
       @session.find(:css, '#click-test').click(:control, :alt, :meta, :shift)
       # Selenium with Chrome on OSX ctrl-click generates a right click so just verify all keys but not click type

--- a/spec/selenium_spec_marionette.rb
+++ b/spec/selenium_spec_marionette.rb
@@ -163,5 +163,13 @@ RSpec.describe Capybara::Selenium::Node do
       tr.click
       expect(tr.base).to have_received(:warn).with(/Clicking the first cell in the row instead/)
     end
+
+    it "should allow multiple modifiers", requires: [:js] do
+      session = TestSessions::SeleniumMarionette
+      session.visit('with_js')
+      # Firefox doesn't generate an event for control+shift+click
+      session.find(:css, '#click-test').click(:alt, :ctrl, :meta)
+      expect(session).to have_link("Has been alt control meta clicked")
+    end
   end
 end


### PR DESCRIPTION
Click with the control key triggers a context-click and, [in Firefox, the shift key causes it to bypass JavaScript event handling][1].

[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=692139