### PR TITLE
Only include node filters in error descriptions if at least one was applied

### DIFF
--- a/features/step_definitions/capybara_steps.rb
+++ b/features/step_definitions/capybara_steps.rb
@@ -21,5 +21,5 @@ When(/^I use a matcher that fails$/) do
 end
 
 Then(/^the failing exception should be nice$/) do
-  expect(@error_message).to match(/expected to find visible css \"h1#doesnotexist\"/)
+  expect(@error_message).to match(/expected to find css \"h1#doesnotexist\"/)
 end

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -290,8 +290,8 @@ module Capybara
             result = query.resolve_for(self)
           end
 
-          raise Capybara::Ambiguous, "Ambiguous match, found #{result.size} elements matching #{query.description}" if ambiguous?(query, result)
-          raise Capybara::ElementNotFound, "Unable to find #{query.description}" if result.empty?
+          raise Capybara::Ambiguous, "Ambiguous match, found #{result.size} elements matching #{query.applied_description}" if ambiguous?(query, result)
+          raise Capybara::ElementNotFound, "Unable to find #{query.applied_description}" if result.empty?
 
           result.first
         end.tap(&:allow_reload!)

--- a/lib/capybara/queries/ancestor_query.rb
+++ b/lib/capybara/queries/ancestor_query.rb
@@ -12,7 +12,7 @@ module Capybara
         end
       end
 
-      def description
+      def description(applied = false)
         child_query = @child_node&.instance_variable_get(:@query)
         desc = super
         desc += " that is an ancestor of #{child_query.description}" if child_query

--- a/lib/capybara/queries/sibling_query.rb
+++ b/lib/capybara/queries/sibling_query.rb
@@ -14,7 +14,7 @@ module Capybara
         end
       end
 
-      def description
+      def description(applied = false)
         desc = super
         sibling_query = @sibling_node&.instance_variable_get(:@query)
         desc += " that is a sibling of #{sibling_query.description}" if sibling_query

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -138,6 +138,10 @@ module Capybara
       failure_message.sub(/(to find)/, 'not \1')
     end
 
+    def unfiltered_size
+      @elements.length
+    end
+
   private
 
     def full_results

--- a/lib/capybara/selector/filter_set.rb
+++ b/lib/capybara/selector/filter_set.rb
@@ -5,11 +5,12 @@ require 'capybara/selector/filter'
 module Capybara
   class Selector
     class FilterSet
-      attr_reader :descriptions, :node_filters, :expression_filters
+      attr_reader :descriptions, :node_filter_descriptions, :node_filters, :expression_filters
 
       def initialize(name, &block)
         @name = name
         @descriptions = []
+        @node_filter_descriptions = []
         @expression_filters = {}
         @node_filters = {}
         instance_eval(&block)
@@ -24,13 +25,19 @@ module Capybara
         add_filter(name, Filters::ExpressionFilter, *types_and_options, &block)
       end
 
-      def describe(&block)
-        descriptions.push block
+      def describe(node_filters: false, &block)
+        if node_filters
+          node_filter_descriptions.push block
+        else
+          descriptions.push block
+        end
       end
 
-      def description(**options)
+      def description(skip_node_filters: false, **options)
         opts = options_with_defaults(options)
-        @descriptions.map { |desc| desc.call(opts).to_s }.join
+        d = @descriptions.map { |desc| desc.call(opts).to_s }.join
+        d += @node_filter_descriptions.map { |desc| desc.call(opts).to_s }.join unless skip_node_filters
+        d
       end
 
       class << self

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -354,9 +354,24 @@ module Capybara
       @filter_set.expression_filters.merge!(f_set.expression_filters.select(&filter_selector))
       @filter_set.node_filters.merge!(f_set.node_filters.select(&filter_selector))
       f_set.descriptions.each { |desc| @filter_set.describe(&desc) }
+      f_set.node_filter_descriptions.each { |desc| @filter_set.describe(node_filters: true, &desc) }
     end
 
     def_delegator :@filter_set, :describe
+
+    def describe_expression_filters(&block)
+      if block_given?
+        describe(node_filters: false, &block)
+      else
+        describe(node_filters: false) do |**options|
+          describe_all_expression_filters(options)
+        end
+      end
+    end
+
+    def describe_node_filters(&block)
+      describe(node_filters: true, &block)
+    end
 
     ##
     #

--- a/lib/capybara/spec/session/ancestor_spec.rb
+++ b/lib/capybara/spec/session/ancestor_spec.rb
@@ -62,7 +62,7 @@ Capybara::SpecHelper.spec '#ancestor' do
     el = @session.find(:css, '#child')
     expect do
       el.ancestor(:xpath, '//div[@id="nosuchthing"]')
-    end.to raise_error(Capybara::ElementNotFound, "Unable to find visible xpath \"//div[@id=\\\"nosuchthing\\\"]\" that is an ancestor of visible css \"#child\"")
+    end.to raise_error(Capybara::ElementNotFound, "Unable to find xpath \"//div[@id=\\\"nosuchthing\\\"]\" that is an ancestor of visible css \"#child\"")
   end
 
   context "within a scope" do

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -98,7 +98,7 @@ Capybara::SpecHelper.spec "#attach_file" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible file field \"does not exist\" that is not disabled"
+      msg = "Unable to find file field \"does not exist\""
       expect do
         @session.attach_file('does not exist', with_os_path_separators(@test_file_path))
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -76,7 +76,7 @@ Capybara::SpecHelper.spec "#check" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible checkbox \"does not exist\" that is not disabled"
+      msg = "Unable to find checkbox \"does not exist\""
       expect do
         @session.check('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -85,9 +85,10 @@ Capybara::SpecHelper.spec "#check" do
 
   context "with a disabled checkbox" do
     it "should raise an error" do
+      msg = "Unable to find visible checkbox \"Disabled Checkbox\" that is not disabled"
       expect do
         @session.check('Disabled Checkbox')
-      end.to raise_error(Capybara::ElementNotFound)
+      end.to raise_error(Capybara::ElementNotFound, msg)
     end
   end
 
@@ -149,11 +150,11 @@ Capybara::SpecHelper.spec "#check" do
       end
 
       it "should raise original error when no label available" do
-        expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_ariel" that is not disabled')
+        expect { @session.check('form_cars_ariel') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_ariel"')
       end
 
       it "should raise error if not allowed to click label" do
-        expect { @session.check('form_cars_mclaren', allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_mclaren" that is not disabled')
+        expect { @session.check('form_cars_mclaren', allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_mclaren"')
       end
     end
 
@@ -165,7 +166,11 @@ Capybara::SpecHelper.spec "#check" do
       end
 
       it "should raise error if checkbox not visible" do
-        expect { @session.check('form_cars_mclaren') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_mclaren" that is not disabled')
+        expect { @session.check('form_cars_mclaren') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_mclaren"')
+      end
+
+      it "should include node filter in error if verified" do
+        expect { @session.check('form_cars_maserati') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_maserati" that is not disabled')
       end
 
       context "with allow_label_click == true" do

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -31,7 +31,7 @@ Capybara::SpecHelper.spec "#choose" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible radio button \"does not exist\" that is not disabled"
+      msg = "Unable to find radio button \"does not exist\""
       expect do
         @session.choose('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -89,7 +89,7 @@ Capybara::SpecHelper.spec "#choose" do
       end
 
       it "should raise error if not allowed to click label" do
-        expect { @session.choose("party_democrat", allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible radio button "party_democrat" that is not disabled')
+        expect { @session.choose("party_democrat", allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible radio button "party_democrat"')
       end
     end
   end

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -345,7 +345,7 @@ Capybara::SpecHelper.spec '#click_button' do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible button \"does not exist\""
+      msg = "Unable to find button \"does not exist\""
       expect do
         @session.click_button('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/click_link_or_button_spec.rb
+++ b/lib/capybara/spec/session/click_link_or_button_spec.rb
@@ -56,7 +56,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
     context "when `true`" do
       it "does not click on link which matches approximately" do
         @session.visit('/with_html')
-        msg = "Unable to find visible link or button \"abore\""
+        msg = "Unable to find link or button \"abore\""
         expect do
           @session.click_link_or_button('abore', exact: true)
         end.to raise_error(Capybara::ElementNotFound, msg)
@@ -64,7 +64,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
 
       it "does not click on approximately matching button" do
         @session.visit('/form')
-        msg = "Unable to find visible link or button \"awe\""
+        msg = "Unable to find link or button \"awe\""
 
         expect do
           @session.click_link_or_button('awe', exact: true)
@@ -76,7 +76,7 @@ Capybara::SpecHelper.spec '#click_link_or_button' do
   context "with a locator that doesn't exist" do
     it "should raise an error" do
       @session.visit('/with_html')
-      msg = "Unable to find visible link or button \"does not exist\""
+      msg = "Unable to find link or button \"does not exist\""
       expect do
         @session.click_link_or_button('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -69,7 +69,7 @@ Capybara::SpecHelper.spec '#click_link' do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible link \"does not exist\""
+      msg = "Unable to find link \"does not exist\""
       expect do
         @session.click_link('does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -193,7 +193,7 @@ Capybara::SpecHelper.spec "#fill_in" do
     after  { Capybara.ignore_hidden_elements = false }
 
     it "should not find a hidden field" do
-      msg = "Unable to find visible field \"Super Secret\" that is not disabled"
+      msg = "Unable to find visible field \"Super Secret\""
       expect do
         @session.fill_in('Super Secret', with: '777')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -202,7 +202,7 @@ Capybara::SpecHelper.spec "#fill_in" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible field \"does not exist\" that is not disabled"
+      msg = "Unable to find field \"does not exist\""
       expect do
         @session.fill_in('does not exist', with: 'Blah blah')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -218,7 +218,7 @@ Capybara::SpecHelper.spec '#find' do
   it "should raise ElementNotFound with a useful default message if nothing was found" do
     expect do
       @session.find(:xpath, '//div[@id="nosuchthing"]').to be_nil
-    end.to raise_error(Capybara::ElementNotFound, "Unable to find visible xpath \"//div[@id=\\\"nosuchthing\\\"]\"")
+    end.to raise_error(Capybara::ElementNotFound, "Unable to find xpath \"//div[@id=\\\"nosuchthing\\\"]\"")
   end
 
   it "should accept an XPath instance" do

--- a/lib/capybara/spec/session/node_wrapper_spec.rb
+++ b/lib/capybara/spec/session/node_wrapper_spec.rb
@@ -31,6 +31,9 @@ Capybara::SpecHelper.spec "#to_capybara_node" do
     end.to raise_error(/^expected to find text "Header Class Test One" in "Lore/)
     expect do
       expect(para).to have_css('#second')
-    end.to raise_error(/^expected to find visible css "#second" within #<Capybara::Node::Element/)
+    end.to raise_error(/^expected to find css "#second" within #<Capybara::Node::Element/)
+    expect do
+      expect(para).to have_link(href: %r{/without_simple_html})
+    end.to raise_error(%r{^expected to find visible link nil with href matching /\\/without_simple_html/ within #<Capybara::Node::Element})
   end
 end

--- a/lib/capybara/spec/session/select_spec.rb
+++ b/lib/capybara/spec/session/select_spec.rb
@@ -94,7 +94,7 @@ Capybara::SpecHelper.spec "#select" do
     it "should not find an input without a datalist" do
       expect do
         @session.select("Thomas", from: 'form_first_name')
-      end.to raise_error(/Unable to find visible input box with datalist completion "form_first_name" that is not disabled/)
+      end.to raise_error(/Unable to find input box with datalist completion "form_first_name"/)
     end
 
     it "should not select an option that doesn't exist" do
@@ -112,7 +112,7 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = /Unable to find visible select box "does not exist" that is not disabled/
+      msg = /Unable to find select box "does not exist"/
       expect do
         @session.select('foo', from: 'does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -121,7 +121,7 @@ Capybara::SpecHelper.spec "#select" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = /^Unable to find visible option "Does not Exist" within/
+      msg = /^Unable to find option "Does not Exist" within/
       expect do
         @session.select('Does not Exist', from: 'form_locale')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -77,11 +77,15 @@ Capybara::SpecHelper.spec "#uncheck" do
       end
 
       it "should raise original error when no label available" do
-        expect { @session.uncheck('form_cars_porsche') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_porsche" that is not disabled')
+        expect { @session.uncheck('form_cars_porsche') }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_porsche"')
       end
 
       it "should raise error if not allowed to click label" do
-        expect { @session.uncheck('form_cars_jaguar', allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_jaguar" that is not disabled')
+        expect { @session.uncheck('form_cars_jaguar', allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_jaguar"')
+      end
+
+      it "should include node filter description in error if necessary" do
+        expect { @session.uncheck('form_cars_maserati', allow_label_click: false) }.to raise_error(Capybara::ElementNotFound, 'Unable to find visible checkbox "form_cars_maserati" that is not disabled')
       end
     end
   end

--- a/lib/capybara/spec/session/unselect_spec.rb
+++ b/lib/capybara/spec/session/unselect_spec.rb
@@ -56,7 +56,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with a locator that doesn't exist" do
     it "should raise an error" do
-      msg = "Unable to find visible select box \"does not exist\" that is not disabled"
+      msg = "Unable to find select box \"does not exist\""
       expect do
         @session.unselect('foo', from: 'does not exist')
       end.to raise_error(Capybara::ElementNotFound, msg)
@@ -65,7 +65,7 @@ Capybara::SpecHelper.spec "#unselect" do
 
   context "with an option that doesn't exist" do
     it "should raise an error" do
-      msg = /^Unable to find visible option "Does not Exist" within/
+      msg = /^Unable to find option "Does not Exist" within/
       expect do
         @session.unselect('Does not Exist', from: 'form_underwear')
       end.to raise_error(Capybara::ElementNotFound, msg)

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -195,6 +195,8 @@ New line after and before textarea tag
       Koenigsegg
       <input type="checkbox" value="koenigsegg" name="form[cars][]" id="form_cars_koenigsegg" checked="checked" style="display: none"/>
     </label>
+    <input type="checkbox" value="maserati" name="form[cars][]" id="form_cars_maserati" disabled="disabled"/>
+    <label for="form_cars_maserati">Maserati</label>
   </p>
 
   <p>

--- a/spec/minitest_spec_spec.rb
+++ b/spec/minitest_spec_spec.rb
@@ -138,6 +138,6 @@ RSpec.describe 'capybara/minitest/spec' do
     reporter.report
     expect(output.string).to include("19 runs, 41 assertions, 1 failures, 0 errors, 1 skips")
     # Make sure error messages are displayed
-    expect(output.string).to include('expected to find visible select box "non_existing_form_title" that is not disabled but there were no matches')
+    expect(output.string).to include('expected to find select box "non_existing_form_title" but there were no matches')
   end
 end

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if has_css? returns false" do
           expect do
             expect("<h1>Text</h1>").to have_css('h2')
-          end.to raise_error(/expected to find visible css "h2" but there were no matches/)
+          end.to raise_error(/expected to find css "h2" but there were no matches/)
         end
 
         it "passes if matched node count equals expected count" do
@@ -41,7 +41,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if matched node count is less than expected minimum count" do
           expect do
             expect("<h1>Text</h1>").to have_css('p', minimum: 1)
-          end.to raise_error("expected to find visible css \"p\" at least 1 time but there were no matches")
+          end.to raise_error("expected to find css \"p\" at least 1 time but there were no matches")
         end
 
         it "fails if matched node count is more than expected maximum count" do
@@ -100,7 +100,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if has_css? returns false" do
           expect do
             expect(page).to have_css('h1#doesnotexist')
-          end.to raise_error(/expected to find visible css "h1#doesnotexist" but there were no matches/)
+          end.to raise_error(/expected to find css "h1#doesnotexist" but there were no matches/)
         end
       end
 
@@ -132,7 +132,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if has_xpath? returns false" do
           expect do
             expect("<h1>Text</h1>").to have_xpath('//h2')
-          end.to raise_error(%r{expected to find visible xpath "//h2" but there were no matches})
+          end.to raise_error(%r{expected to find xpath "//h2" but there were no matches})
         end
       end
 
@@ -169,7 +169,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if has_xpath? returns false" do
           expect do
             expect(page).to have_xpath("//h1[@id='doesnotexist']")
-          end.to raise_error(%r{expected to find visible xpath "//h1\[@id='doesnotexist'\]" but there were no matches})
+          end.to raise_error(%r{expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches})
         end
       end
 
@@ -203,7 +203,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if has_selector? returns false" do
           expect do
             expect("<h1>Text</h1>").to have_selector('//h2')
-          end.to raise_error(%r{expected to find visible xpath "//h2" but there were no matches})
+          end.to raise_error(%r{expected to find xpath "//h2" but there were no matches})
         end
       end
 
@@ -233,7 +233,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
         it "fails if has_selector? returns false" do
           expect do
             expect(page).to have_selector("//h1[@id='doesnotexist']")
-          end.to raise_error(%r{expected to find visible xpath "//h1\[@id='doesnotexist'\]" but there were no matches})
+          end.to raise_error(%r{expected to find xpath "//h1\[@id='doesnotexist'\]" but there were no matches})
         end
 
         it "includes text in error message" do
@@ -503,7 +503,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
     it "fails if there is no such button" do
       expect do
         expect(html).to have_link('No such Link')
-      end.to raise_error(/expected to find visible link "No such Link"/)
+      end.to raise_error(/expected to find link "No such Link"/)
     end
 
     it "supports compounding" do
@@ -638,7 +638,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
     it "fails if there is no such button" do
       expect do
         expect(html).to have_button('No such Button')
-      end.to raise_error(/expected to find visible button "No such Button"/)
+      end.to raise_error(/expected to find button "No such Button"/)
     end
 
     it "supports compounding" do
@@ -668,7 +668,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
     it "fails if there is no such field" do
       expect do
         expect(html).to have_field('No such Field')
-      end.to raise_error(/expected to find visible field "No such Field"/)
+      end.to raise_error(/expected to find field "No such Field"/)
     end
 
     it "fails if there is such field but with false value" do
@@ -715,7 +715,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
       it "fails if there is no such field" do
         expect do
           expect(html).to have_checked_field('no such field')
-        end.to raise_error(/expected to find visible field "no such field"/)
+        end.to raise_error(/expected to find field "no such field"/)
       end
     end
 
@@ -764,7 +764,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
       it "fails if there is no such field" do
         expect do
           expect(html).to have_unchecked_field('no such field')
-        end.to raise_error(/expected to find visible field "no such field"/)
+        end.to raise_error(/expected to find field "no such field"/)
       end
     end
 
@@ -807,7 +807,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
     it "fails if there is no such select" do
       expect do
         expect(html).to have_select('No such Select box')
-      end.to raise_error(/expected to find visible select box "No such Select box"/)
+      end.to raise_error(/expected to find select box "No such Select box"/)
     end
 
     it "supports compounding" do
@@ -820,6 +820,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
 
     it "gives proper description" do
       expect(have_table('Lovely table').description).to eq("have visible table \"Lovely table\"")
+      expect(have_table('Lovely table', caption: 'my caption').description).to eq('have visible table "Lovely table" with caption "my caption"')
     end
 
     it "gives proper description when :visible option passed" do
@@ -829,14 +830,14 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
       expect(have_table('Lovely table', visible: false).description).to eq("have table \"Lovely table\"")
     end
 
-    it "passes if there is such a select" do
+    it "passes if there is such a table" do
       expect(html).to have_table('Lovely table')
     end
 
-    it "fails if there is no such select" do
+    it "fails if there is no such table" do
       expect do
         expect(html).to have_table('No such Table')
-      end.to raise_error(/expected to find visible table "No such Table"/)
+      end.to raise_error(/expected to find table "No such Table"/)
     end
 
     it "supports compounding" do

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -159,11 +159,12 @@ RSpec.shared_examples "Capybara::Session" do |session, mode|
     context  '#fill_in with Date' do
       before do
         session.visit('/form')
-        session.execute_script <<-JS
+        fd = session.find(:css, '#form_date')
+        fd.execute_script <<-JS
           window.capybara_formDateFiredEvents = [];
+          var fd = this;
           ['focus', 'input', 'change'].forEach(function(eventType) {
-            document.getElementById('form_date')
-              .addEventListener(eventType, function() { window.capybara_formDateFiredEvents.push(eventType); });
+            fd.addEventListener(eventType, function() { window.capybara_formDateFiredEvents.push(eventType); });
           });
         JS
         # work around weird FF issue where it would create an extra focus issue in some cases


### PR DESCRIPTION
This attempts to make errors when matching elements are not found clearer.  Previously if doing

    expect(page).to have_checked_field('My field', disabled: false)

with no matching elements the error would always be 

    Unable to find visible field "My field" that is checked and not disabled

With this PR if there were no field elements with "My field" associated the error would be 

    Unable to find field "My field"

If there was a field but it was non-visible the error would be

    Unable to find visible field "My field"

and if there was a visible field but it was either disabled, not checked or both the error would be

    Unable to find visible field "My field" that is checked and not disabled
