### PR TITLE
Remove 'at the moment' w.r.t. Selenium RC from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ See the section on adding and configuring drivers.
 
 ### <a name="selenium"></a>Selenium
 
-At the moment, Capybara supports [Selenium 2.0+
+Capybara supports [Selenium 2.0+
 (Webdriver)](http://seleniumhq.org/docs/01_introducing_selenium.html#selenium-2-aka-selenium-webdriver),
 *not* Selenium RC. In order to use Selenium, you'll need to install the
 `selenium-webdriver` gem, and add it to your Gemfile if you're using bundler.


### PR DESCRIPTION
I think at this point in 2018, it's overwhelmingly unlikely Selenium 1.x support will be backported