### PR TITLE
Add test for clicking label of a blocked element

### DIFF
--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -195,6 +195,13 @@ Capybara::SpecHelper.spec '#check' do
           @session.click_button('awesome')
           expect(extract_results(@session)['cars']).to include('pagani')
         end
+
+        it 'should check via the label if input is visible but blocked by another element' do
+          expect(@session.find(:checkbox, 'form_cars_bugatti', unchecked: true, visible: :all)).to be_truthy
+          @session.check('form_cars_bugatti', allow_label_click: true)
+          @session.click_button('awesome')
+          expect(extract_results(@session)['cars']).to include('bugatti')
+        end
       end
     end
   end

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -185,6 +185,12 @@ New line after and before textarea tag
     <label for="form_cars_ferrari">Ferrari</label>
     <input type="checkbox" value="pagani" name="form[cars][]" id="form_cars_pagani" style="position: absolute; left: -9999px"/>
     <label for="form_cars_pagani">Pagani</label>
+    <div style="position: relative;">
+      <input type="checkbox" value="bugatti" name="form[cars][]" id="form_cars_bugatti"/>
+      <div style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; background-color: #fff;">
+        <label for="form_cars_bugatti">Bugatti</label>
+      </div>
+    </div>
     <input type="checkbox" value="ariel" name="form[cars][]" id="form_cars_ariel" style="display: none"/>
     <input type="checkbox" value="porsche" name="form[cars][]" id="form_cars_porsche" checked="checked" style="display: none"/>
     <label>


### PR DESCRIPTION
An element positioned outside of the viewable document is considered hidden, effectively making that test a duplicate of [the "should check via the label if input is hidden" test][1]. The test was originally added as part of 272a052, but if one removes the implementation change, the test still passes in Chrome and Firefox. If we cover an otherwise visible element, we can address the scenario of a visible but not-interactable element, more thoroughly validating the need for the original implementation change.

[1]: https://github.com/teamcapybara/capybara/blob/master/lib/capybara/spec/session/check_spec.rb#L177