### PR TITLE
refute_selector and refute_matches_selector only with minitest

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -344,7 +344,9 @@ module Capybara
       ##
       #
       # Trigger any event on the current element, for example mouseover or focus
-      # events. Does not work in Selenium.
+      # events. Not supported with the Selenium driver, and SHOULDN'T BE USED IN TESTING unless you
+      # fully understand why you're using it, that it can allow actions a user could never
+      # perform, and that it may completely invalidate your test.
       #
       # @param [String] event       The name of the event to trigger
       #

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -203,7 +203,6 @@ module Capybara
           end
         end
       end
-      alias_method :refute_selector, :assert_no_selector
 
       ##
       #
@@ -529,7 +528,25 @@ module Capybara
           raise Capybara::ExpectationNotMet, 'Item matched the provided selector' if result.include? self
         end
       end
-      alias_method :refute_matches_selector, :assert_not_matches_selector
+
+
+      # Deprecated
+      # TODO: remove
+      def refute_selector(*args, &optional_filter_block)
+        warn "`refute_selector` was never meant to be in this scope unless "
+             "using minitest.  Either replace with `assert_no_selector` "
+             "or require 'capybara/minitest'."
+        assert_no_selector(*args, &optional_filter_block)
+      end
+
+      # Deprecated
+      # TODO: remove
+      def refute_matches_elector(*args, &optional_filter_block)
+        warn "`refute_matches_selector` was never meant to be in this scope unless "
+             "using minitest.  Either replace with `assert_not_matches_selector` "
+             "or require 'capybara/minitest'."
+        assert_not_matches_selector(*args, &optional_filter_block)
+      end
 
       ##
       #

--- a/lib/capybara/spec/session/assert_selector_spec.rb
+++ b/lib/capybara/spec/session/assert_selector_spec.rb
@@ -73,8 +73,12 @@ Capybara::SpecHelper.spec '#assert_selector' do
 end
 
 Capybara::SpecHelper.spec '#refute_selector' do
-  it 'should be an alias of #assert_no_selector' do
-    expect(Capybara::Node::Matchers.instance_method(:refute_selector)).to eq Capybara::Node::Matchers.instance_method(:assert_no_selector)
+  it 'should warn not to use' do
+    @session.visit('/with_html')
+    doc = @session.document
+    allow(doc).to receive(:warn)
+    doc.refute_selector(:xpath, '//abbr')
+    expect(doc).to have_received(:warn)
   end
 end
 

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -11,7 +11,8 @@ Capybara::SpecHelper.run_specs TestClass.new, 'DSL', capybara_skip: %i[
   js modals screenshot frames windows send_keys server hover about_scheme psc download css
 ] do |example|
   case example.metadata[:full_description]
-  when /doesn't raise exception on a nil current_url$/
+  when /doesn't raise exception on a nil current_url$/,
+       /#refute_selector should warn not to use$/
     skip 'Only makes sense when there is a real driver'
   end
 end

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -47,6 +47,14 @@ class MinitestTest < Minitest::Test
     assert_no_css('select#not_form_title')
   end
 
+  def test_assert_selector
+    assert_selector(:css, 'select#form_title')
+    assert_selector(:xpath, './/select[@id="form_title"]')
+    assert_no_selector(:css, 'select#not_form_title')
+    assert_no_selector(:xpath, './/select[@id="not_form_title"]')
+    refute_selector(:css, 'select#not_form_title')
+  end
+
   def test_assert_link
     visit('/with_html')
     assert_link('A link')
@@ -132,6 +140,6 @@ RSpec.describe 'capybara/minitest' do
     reporter.start
     MinitestTest.run reporter, {}
     reporter.report
-    expect(output.string).to include('18 runs, 44 assertions, 0 failures, 0 errors, 1 skips')
+    expect(output.string).to include('19 runs, 49 assertions, 0 failures, 0 errors, 1 skips')
   end
 end


### PR DESCRIPTION
`refute_selector` and `refute_matches_selector` should not have been defined unless the user was using minitest.  This PR raises a warning - trying to decide whether to remove them in the next minor release, or wait to a major release as SemVer would technically require.....  Usage of them without minitest should be really low since they are the only two `refute_xxx` methods that are defined without requiring capybara/minitest so it's already pretty clear to a user they should be requiring the minitest file if they want `refute_xxx` methods.