### PR TITLE
WIP: Add Capybara.predicates_wait setting - defaults to true

### DIFF
--- a/History.md
+++ b/History.md
@@ -5,6 +5,7 @@ Release date: unreleased
 
 * Workaround geckodriver/firefox send_keys issues as much as possible using the Selenium actions API
 * Workaround lack of HTML5 native drag and drop events when using Selenium driver with Chrome and FF >= 62
+* `Capybara.predicates_wait` option which sets whether or not Capybaras matcher predicate methods (`has_css?`, `has_selector?`, `has_text?`, etc.) default to using waiting/retrying behavior (defaults to true)
 
 # Version 3.5.1
 Release date: 2018-08-03

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -84,6 +84,7 @@ module Capybara
     # [server = Symbol]  The name of the registered server to use when running the app under test (Default: :webrick)
     # [default_set_options = Hash]  The default options passed to Node::set (Default: {})
     # [test_id = Symbol/String/nil] Optional attribute to match locator aginst with builtin selectors along with id (Default: nil)
+    # [predicates_wait = Boolean]  Whether Capybaras predicate matchers use waiting behavior by default (Default: true)
     #
     # === DSL Options
     #
@@ -484,6 +485,7 @@ Capybara.configure do |config|
   config.reuse_server = true
   config.default_set_options = {}
   config.test_id = nil
+  config.predicates_wait = true
 end
 
 Capybara.register_driver :rack_test do |app|

--- a/lib/capybara/node/document_matchers.rb
+++ b/lib/capybara/node/document_matchers.rb
@@ -38,9 +38,7 @@ module Capybara
       # @return [Boolean]
       #
       def has_title?(title, **options)
-        assert_title(title, options)
-      rescue Capybara::ExpectationNotMet
-        false
+        make_predicate(options) { assert_title(title, options) }
       end
 
       ##
@@ -50,9 +48,7 @@ module Capybara
       # @return [Boolean]
       #
       def has_no_title?(title, **options)
-        assert_no_title(title, options)
-      rescue Capybara::ExpectationNotMet
-        false
+        make_predicate(options) { assert_no_title(title, options) }
       end
 
     private

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -36,10 +36,8 @@ module Capybara
       # @option args [Range]   :between (nil)   Range of times that should contain number of times text occurs
       # @return [Boolean]                       If the expression exists
       #
-      def has_selector?(*args, &optional_filter_block)
-        assert_selector(*args, &optional_filter_block)
-      rescue Capybara::ExpectationNotMet
-        false
+      def has_selector?(*args, **options, &optional_filter_block)
+        make_predicate(options) { assert_selector(*args, options, &optional_filter_block) }
       end
 
       ##
@@ -50,10 +48,8 @@ module Capybara
       # @param (see Capybara::Node::Finders#has_selector?)
       # @return [Boolean]
       #
-      def has_no_selector?(*args, &optional_filter_block)
-        assert_no_selector(*args, &optional_filter_block)
-      rescue Capybara::ExpectationNotMet
-        false
+      def has_no_selector?(*args, **options, &optional_filter_block)
+        make_predicate(options) { assert_no_selector(*args, options, &optional_filter_block) }
       end
 
       ##
@@ -66,9 +62,7 @@ module Capybara
       # @return [Boolean]                       If the styles match
       #
       def has_style?(styles, **options)
-        assert_style(styles, **options)
-      rescue Capybara::ExpectationNotMet
-        false
+        make_predicate(options) { assert_style(styles, options) }
       end
 
       ##
@@ -554,10 +548,8 @@ module Capybara
       # @param (see Capybara::Node::Finders#has_selector?)
       # @return [Boolean]
       #
-      def matches_selector?(*args, &optional_filter_block)
-        assert_matches_selector(*args, &optional_filter_block)
-      rescue Capybara::ExpectationNotMet
-        false
+      def matches_selector?(*args, **options, &optional_filter_block)
+        make_predicate(options) { assert_matches_selector(*args, options, &optional_filter_block) }
       end
 
       ##
@@ -590,10 +582,8 @@ module Capybara
       # @param (see Capybara::Node::Finders#has_selector?)
       # @return [Boolean]
       #
-      def not_matches_selector?(*args, &optional_filter_block)
-        assert_not_matches_selector(*args, &optional_filter_block)
-      rescue Capybara::ExpectationNotMet
-        false
+      def not_matches_selector?(*args, **options, &optional_filter_block)
+        make_predicate(options) { assert_not_matches_selector(*args, options, &optional_filter_block) }
       end
 
       ##
@@ -683,10 +673,8 @@ module Capybara
       # @macro text_query_params
       # @return [Boolean]                            Whether it exists
       #
-      def has_text?(*args)
-        assert_text(*args)
-      rescue Capybara::ExpectationNotMet
-        false
+      def has_text?(*args, **options)
+        make_predicate(options) { assert_text(*args, options) }
       end
       alias_method :has_content?, :has_text?
 
@@ -697,10 +685,8 @@ module Capybara
       # @macro text_query_params
       # @return [Boolean]  Whether it doesn't exist
       #
-      def has_no_text?(*args)
-        assert_no_text(*args)
-      rescue Capybara::ExpectationNotMet
-        false
+      def has_no_text?(*args, **options)
+        make_predicate(options) { assert_no_text(*args, options) }
       end
       alias_method :has_no_content?, :has_no_text?
 
@@ -744,6 +730,13 @@ module Capybara
       def _set_query_session_options(*query_args, **query_options)
         query_options[:session_options] = session_options
         query_args.push(query_options)
+      end
+
+      def make_predicate(options)
+        options[:wait] = 0 unless options.key?(:wait) || session_options.predicates_wait
+        yield
+      rescue Capybara::ExpectationNotMet
+        false
       end
     end
   end

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -7,7 +7,8 @@ module Capybara
     OPTIONS = %i[always_include_port run_server default_selector default_max_wait_time ignore_hidden_elements
                  automatic_reload match exact exact_text raise_server_errors visible_text_only
                  automatic_label_click enable_aria_label save_path asset_host default_host app_host
-                 server_host server_port server_errors default_set_options disable_animation test_id].freeze
+                 server_host server_port server_errors default_set_options disable_animation test_id
+                 predicates_wait].freeze
 
     attr_accessor(*OPTIONS)
 

--- a/lib/capybara/session/matchers.rb
+++ b/lib/capybara/session/matchers.rb
@@ -47,9 +47,7 @@ module Capybara
     # @return [Boolean]
     #
     def has_current_path?(path, **options)
-      assert_current_path(path, options)
-    rescue Capybara::ExpectationNotMet
-      false
+      make_predicate(options) { assert_current_path(path, options) }
     end
 
     ##
@@ -62,9 +60,7 @@ module Capybara
     # @return [Boolean]
     #
     def has_no_current_path?(path, **options)
-      assert_no_current_path(path, options)
-    rescue Capybara::ExpectationNotMet
-      false
+      make_predicate(options) { assert_no_current_path(path, options) }
     end
 
   private
@@ -75,6 +71,13 @@ module Capybara
         yield(query)
       end
       true
+    end
+
+    def make_predicate(options)
+      options[:wait] = 0 unless options.key?(:wait) || config.predicates_wait
+      yield
+    rescue Capybara::ExpectationNotMet
+      false
     end
   end
 end

--- a/lib/capybara/spec/session/has_css_spec.rb
+++ b/lib/capybara/spec/session/has_css_spec.rb
@@ -30,6 +30,26 @@ Capybara::SpecHelper.spec '#has_css?' do
     expect(@session).to have_css("input[type='submit'][value='New Here']")
   end
 
+  context 'with predicates_wait == true' do
+    it 'should wait for content to appear', requires: [:js] do
+      Capybara.predicates_wait = true
+      Capybara.default_max_wait_time = 2
+      @session.visit('/with_js')
+      @session.click_link('Click me')
+      expect(@session.has_css?("input[type='submit'][value='New Here']")).to be true
+    end
+  end
+
+  context 'with predicates_wait == false' do
+    it 'should not wait for content to appear', requires: [:js] do
+      Capybara.predicates_wait = false
+      Capybara.default_max_wait_time = 2
+      @session.visit('/with_js')
+      @session.click_link('Click me')
+      expect(@session.has_css?("input[type='submit'][value='New Here']")).to be false
+    end
+  end
+
   context 'with between' do
     it 'should be true if the content occurs within the range given' do
       expect(@session).to have_css('p', between: 1..4)

--- a/lib/capybara/spec/session/has_title_spec.rb
+++ b/lib/capybara/spec/session/has_title_spec.rb
@@ -7,6 +7,7 @@ Capybara::SpecHelper.spec '#has_title?' do
 
   it 'should be true if the page has the given title' do
     expect(@session).to have_title('with_js')
+    expect(@session.has_title?('with_js')).to be true
   end
 
   it 'should allow regexp matches' do
@@ -21,6 +22,7 @@ Capybara::SpecHelper.spec '#has_title?' do
 
   it 'should be false if the page has not the given title' do
     expect(@session).not_to have_title('monkey')
+    expect(@session.has_title?('monkey')).to be false
   end
 
   it 'should default to exact: false matching' do
@@ -31,6 +33,8 @@ Capybara::SpecHelper.spec '#has_title?' do
   it 'should match exactly if exact: true option passed' do
     expect(@session).to have_title('with_js', exact: true)
     expect(@session).not_to have_title('with_', exact: true)
+    expect(@session.has_title?('with_js', exact: true)).to be true
+    expect(@session.has_title?('with_', exact: true)).to be false
   end
 
   it 'should match partial if exact: false option passed' do
@@ -62,5 +66,6 @@ Capybara::SpecHelper.spec '#has_no_title?' do
 
   it 'should be true if the page has not the given title' do
     expect(@session).to have_no_title('monkey')
+    expect(@session.has_no_title?('monkey')).to be true
   end
 end

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -34,6 +34,7 @@ module Capybara
         Capybara.default_set_options = {}
         Capybara.disable_animation = false
         Capybara.test_id = nil
+        Capybara.predicates_wait = true
         reset_threadsafe
       end
 


### PR DESCRIPTION
All the finders wait by default for matching elements to exist, as do the predicate methods.  There's a reasonable argument that can be made that in some use cases waiting is not generally useful for the predicates.  This adds a setting that allows to default the predicate methods to non-waiting -  Still needs tests,  and a final decision on whether or not this is actually a good idea.