### PR TITLE
Matches matcher scope - Fix for Issue #2073

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -726,7 +726,7 @@ module Capybara
         query_args = _set_query_session_options(*query_args)
         query = Capybara::Queries::MatchQuery.new(*query_args, &optional_filter_block)
         synchronize(query.wait) do
-          yield query.resolve_for(query_scope)
+          yield query.resolve_for(self.first(:xpath, './parent::*', minimum: 0) || query_scope)
         end
         true
       end

--- a/lib/capybara/spec/session/element/matches_selector_spec.rb
+++ b/lib/capybara/spec/session/element/matches_selector_spec.rb
@@ -24,6 +24,17 @@ Capybara::SpecHelper.spec '#match_selector?' do
     expect(@element).to match_selector('span.number')
   end
 
+  it 'should work with elements located via a sibling selector' do
+    sibling = @element.sibling(:css, 'span', text: 'Other span')
+    expect(sibling).to match_selector(:xpath, '//span')
+    expect(sibling).to match_selector(:css, 'span')
+  end
+
+  it 'should work with the html element' do
+    html = @session.find('/html')
+    expect(html).to match_selector(:css, 'html')
+  end
+
   context 'with text' do
     it 'should discard all matches where the given string is not contained' do
       expect(@element).to match_selector('//span', text: '42')


### PR DESCRIPTION
This fixes an issue when using any `matches` matcher if the current elements query_scope is not an ancestor (ie - found using sibling, etc)