### PR TITLE
Fix required Ruby version [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ GitHub): http://groups.google.com/group/ruby-capybara
 
 ## <a name="setup"></a>Setup
 
-Capybara requires Ruby 2.2.2 or later. To install, add this line to your
+Capybara requires Ruby 2.3.0 or later. To install, add this line to your
 `Gemfile` and run `bundle install`:
 
 ```ruby


### PR DESCRIPTION
Since baabfa5d675a1765d572421427eb41d36472c054, Capybara requires Ruby 2.3.0 or later.