### PR TITLE
animation disabler can accept CSS as well as boolean

### DIFF
--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -86,9 +86,9 @@ module Capybara
     end
 
     remove_method :disable_animation=
-    def disable_animation=(bool)
-      warn 'Capybara.disable_animation is a beta feature - it may change/disappear in a future point version' if bool
-      @disable_animation = bool
+    def disable_animation=(bool_or_allowlist)
+      warn 'Capybara.disable_animation is a beta feature - it may change/disappear in a future point version' if bool_or_allowlist
+      @disable_animation = bool_or_allowlist
     end
 
     remove_method :test_id=


### PR DESCRIPTION
We use a similar disable animation feature in our test suite. I want to use the capybara version of the animation disabler but it's not quite versatile enough. This adds the ability to allowlist certain css classes.

If y'all are interested in accepting this, I'd be happy to actually fix the test here.

Thanks!