### PR TITLE
Support set default value for text predicates and matchers normalize whitespace behaviour

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ Release date: unreleased
 ### Added
 
 * `Capybara.disable_animation` can be set to a CSS selector to identify which elements will have animation disabled [Michael Glass]
+* `Capybara.default_normalize_ws` option which sets whether or not text predicates and matchers (`has_text?`, `has_content?`, `assert_text`, etc) use `normalize_ws` option by default
 
 # Version 3.6.0
 Release date: 2018-08-14

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -85,6 +85,7 @@ module Capybara
     # [default_set_options = Hash]  The default options passed to Node::set (Default: {})
     # [test_id = Symbol/String/nil] Optional attribute to match locator aginst with builtin selectors along with id (Default: nil)
     # [predicates_wait = Boolean]  Whether Capybaras predicate matchers use waiting behavior by default (Default: true)
+    # [default_normalize_ws = Boolean] Whether text predicates and matchers use normalize whitespace behaviour (Default: false)
     #
     # === DSL Options
     #
@@ -486,6 +487,7 @@ Capybara.configure do |config|
   config.default_set_options = {}
   config.test_id = nil
   config.predicates_wait = true
+  config.default_normalize_ws = false
 end
 
 Capybara.register_driver :rack_test do |app|

--- a/lib/capybara/queries/text_query.rb
+++ b/lib/capybara/queries/text_query.rb
@@ -90,7 +90,8 @@ module Capybara
       end
 
       def text(node: @node, query_type: @type)
-        node.text(query_type, normalize_ws: options[:normalize_ws])
+        normalize_ws = options.fetch(:normalize_ws, session_options.default_normalize_ws)
+        node.text(query_type, normalize_ws: normalize_ws)
       end
 
       def default_type

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -8,7 +8,7 @@ module Capybara
                  automatic_reload match exact exact_text raise_server_errors visible_text_only
                  automatic_label_click enable_aria_label save_path asset_host default_host app_host
                  server_host server_port server_errors default_set_options disable_animation test_id
-                 predicates_wait].freeze
+                 predicates_wait default_normalize_ws].freeze
 
     attr_accessor(*OPTIONS)
 
@@ -56,6 +56,8 @@ module Capybara
     # @!method disable_animation
     #   See {Capybara.configure}
     # @!method test_id
+    #   See {Capybara.configure}
+    # @!method default_normalize_ws
     #   See {Capybara.configure}
 
     remove_method :server_host

--- a/lib/capybara/spec/session/assert_text_spec.rb
+++ b/lib/capybara/spec/session/assert_text_spec.rb
@@ -15,6 +15,20 @@ Capybara::SpecHelper.spec '#assert_text' do
     expect(@session.assert_text('text with whitespace', normalize_ws: true)).to eq(true)
   end
 
+  context 'with enabled default collapsing whitespace' do
+    before { Capybara.default_normalize_ws = true }
+
+    it 'should be true if the given unnormalized text is on the page' do
+      @session.visit('/with_html')
+      expect(@session.assert_text('text with   whitespace', normalize_ws: false)).to eq(true)
+    end
+
+    it 'should support collapsing whitespace' do
+      @session.visit('/with_html')
+      expect(@session.assert_text('text with whitespace')).to eq(true)
+    end
+  end
+
   it 'should take scopes into account' do
     @session.visit('/with_html')
     @session.within("//a[@title='awesome title']") do

--- a/lib/capybara/spec/session/has_text_spec.rb
+++ b/lib/capybara/spec/session/has_text_spec.rb
@@ -39,6 +39,20 @@ Capybara::SpecHelper.spec '#has_text?' do
     expect(@session).to have_text('text with whitespace', normalize_ws: true)
   end
 
+  context 'with enabled default collapsing whitespace' do
+    before { Capybara.default_normalize_ws = true }
+
+    it 'should search unnormalized text' do
+      @session.visit('/with_html')
+      expect(@session).to have_text('text with   whitespace', normalize_ws: false)
+    end
+
+    it 'should search whitespace collapsed text' do
+      @session.visit('/with_html')
+      expect(@session).to have_text('text with whitespace')
+    end
+  end
+
   it 'should be false if the given text is not on the page' do
     @session.visit('/with_html')
     expect(@session).not_to have_text('xxxxyzzz')

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -35,6 +35,7 @@ module Capybara
         Capybara.disable_animation = false
         Capybara.test_id = nil
         Capybara.predicates_wait = true
+        Capybara.default_normalize_ws = false
         reset_threadsafe
       end
 


### PR DESCRIPTION
Parameter to support old (2.18.0) normalize whitespace behaviour