### PR TITLE
Allow check/uncheck/choose/attach_file/fill_in to work on element called on when no locator specified

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,10 +6,13 @@ Release date: unreleased
 * `Capybara.disable_animation` can be set to a CSS selector to identify which elements will have animation disabled [Michael Glass]
 * `Capybara.default_normalize_ws` option which sets whether or not text predicates and matchers (`has_text?`, `has_content?`, `assert_text`, etc) use `normalize_ws` option by default. Defaults to false. [Stegalin Ivan]
 * Selector based predicates, matchers, and finders now support the `:normalize_ws` option for the `:text`/`:exact_text` filters. Defaults to the `Capybara.default_normalize_ws`setting above.
+* Element `choose`/`check`/`uncheck`/`attach_file`/`fill_in` can now operate on the element they're called on or a descendant if no locator is passed.
 
 ### Fixed
 
-* All CSS styles applied by the `Element#attach_file` `:make_visible` option will now have `!important` priority set to ensure they override any other specified style
+* All CSS styles applied by the `Element#attach_file` `:make_visible` option will now have `!important` priority set to ensure they override any other specified style.
+* Firefox file inputs are only manually cleared when necessary.
+*
 
 # Version 3.6.0
 Release date: 2018-08-14

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -58,6 +58,7 @@ module Capybara
       end
 
       def matches_filters?(node)
+        return true if (@resolved_node&.== node) && options[:allow_self]
         @applied_filters ||= :system
         return false unless matches_text_filter?(node) && matches_exact_text_filter?(node) && matches_visible_filter?(node)
         @applied_filters = :node
@@ -210,7 +211,7 @@ module Capybara
 
         return if unhandled_options.empty?
         invalid_names = unhandled_options.map(&:inspect).join(', ')
-        valid_names = valid_keys.map(&:inspect).join(', ')
+        valid_names = (valid_keys - [:allow_self]).map(&:inspect).join(', ')
         raise ArgumentError, "invalid keys #{invalid_names}, should be one of #{valid_names}"
       end
 

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -194,8 +194,12 @@ end
 Capybara.add_selector(:fillable_field) do
   label 'field'
 
-  xpath do |locator, **options|
-    xpath = XPath.descendant(:input, :textarea)[!XPath.attr(:type).one_of('submit', 'image', 'radio', 'checkbox', 'hidden', 'file')]
+  xpath(:allow_self) do |locator, **options|
+    xpath = if options[:allow_self]
+      XPath.descendant_or_self(:input, :textarea)
+    else
+      XPath.descendant(:input, :textarea)
+    end[!XPath.attr(:type).one_of('submit', 'image', 'radio', 'checkbox', 'hidden', 'file')]
     locate_field(xpath, locator, options)
   end
 
@@ -223,8 +227,12 @@ end
 Capybara.add_selector(:radio_button) do
   label 'radio button'
 
-  xpath do |locator, **options|
-    xpath = XPath.descendant(:input)[XPath.attr(:type) == 'radio']
+  xpath(:allow_self) do |locator, **options|
+    xpath = if options[:allow_self]
+      XPath.descendant_or_self(:input)
+    else
+      XPath.descendant(:input)
+    end[XPath.attr(:type) == 'radio']
     locate_field(xpath, locator, options)
   end
 
@@ -239,8 +247,12 @@ Capybara.add_selector(:radio_button) do
 end
 
 Capybara.add_selector(:checkbox) do
-  xpath do |locator, **options|
-    xpath = XPath.descendant(:input)[XPath.attr(:type) == 'checkbox']
+  xpath(:allow_self) do |locator, **options|
+    xpath = if options[:allow_self]
+      XPath.descendant_or_self(:input)
+    else
+      XPath.descendant(:input)
+    end[XPath.attr(:type) == 'checkbox']
     locate_field(xpath, locator, options)
   end
 
@@ -375,8 +387,12 @@ end
 
 Capybara.add_selector(:file_field) do
   label 'file field'
-  xpath do |locator, options|
-    xpath = XPath.descendant(:input)[XPath.attr(:type) == 'file']
+  xpath(:allow_self) do |locator, options|
+    xpath = if options[:allow_self]
+      XPath.descendant_or_self(:input)
+    else
+      XPath.descendant(:input)
+    end[XPath.attr(:type) == 'file']
     locate_field(xpath, locator, options)
   end
 

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -85,11 +85,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   def click(keys = [], **options)
     click_options = ClickOptions.new(keys, options)
     return native.click if click_options.empty?
-    scroll_if_needed do
-      action_with_modifiers(click_options) do |action|
-        click_options.coords? ? action.click : action.click(native)
-      end
-    end
+    click_with_options(click_options)
   rescue StandardError => err
     if err.is_a?(::Selenium::WebDriver::Error::ElementClickInterceptedError) ||
        err.message =~ /Other element would receive the click/
@@ -101,19 +97,15 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
 
   def right_click(keys = [], **options)
     click_options = ClickOptions.new(keys, options)
-    scroll_if_needed do
-      action_with_modifiers(click_options) do |action|
-        click_options.coords? ? action.context_click : action.context_click(native)
-      end
+    click_with_options(click_options) do |action|
+      click_options.coords? ? action.context_click : action.context_click(native)
     end
   end
 
   def double_click(keys = [], **options)
     click_options = ClickOptions.new(keys, options)
-    scroll_if_needed do
-      action_with_modifiers(click_options) do |action|
-        click_options.coords? ? action.double_click : action.double_click(native)
-      end
+    click_with_options(click_options) do |action|
+      click_options.coords? ? action.double_click : action.double_click(native)
     end
   end
 
@@ -230,6 +222,18 @@ private
       # don't execute if readonly.
       driver.execute_script "arguments[0].value = ''", self unless clear == :none
       send_keys(value)
+    end
+  end
+
+  def click_with_options(click_options)
+    scroll_if_needed do
+      action_with_modifiers(click_options) do |action|
+        if block_given?
+          yield action
+        else
+          click_options.coords? ? action.click : action.click(native)
+        end
+      end
     end
   end
 

--- a/lib/capybara/selenium/nodes/marionette_node.rb
+++ b/lib/capybara/selenium/nodes/marionette_node.rb
@@ -7,7 +7,7 @@ class Capybara::Selenium::MarionetteNode < Capybara::Selenium::Node
     if tag_name == 'tr'
       warn 'You are attempting to click a table row which has issues in geckodriver/marionette - see https://github.com/mozilla/geckodriver/issues/1228. ' \
            'Your test should probably be clicking on a table cell like a user would. Clicking the first cell in the row instead.'
-      return find_css('th:first-child,td:first-child')[0].click
+      return find_css('th:first-child,td:first-child')[0].click(keys, options)
     end
     raise
   end
@@ -61,6 +61,13 @@ class Capybara::Selenium::MarionetteNode < Capybara::Selenium::Node
   end
 
 private
+
+  def click_with_options(click_options)
+    # Firefox/marionette has an issue clicking with offset near viewport edge
+    # scroll element to middle just in case
+    scroll_to_center if click_options.coords?
+    super
+  end
 
   def _send_keys(keys, actions, down_keys = nil)
     case keys

--- a/lib/capybara/selenium/nodes/marionette_node.rb
+++ b/lib/capybara/selenium/nodes/marionette_node.rb
@@ -27,7 +27,7 @@ class Capybara::Selenium::MarionetteNode < Capybara::Selenium::Node
 
   def set_file(value) # rubocop:disable Naming/AccessorMethodName
     # By default files are appended so we have to clear here if its multiple and already set
-    native.clear if multiple? && driver.evaluate_script("arguments[0].files", self).any?
+    native.clear if multiple? && driver.evaluate_script('arguments[0].files', self).any?
     return super if browser_version >= 62.0
 
     # Workaround lack of support for multiple upload by uploading one at a time

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -22,6 +22,13 @@ Capybara::SpecHelper.spec '#attach_file' do
       expect(extract_results(@session)['image']).to eq(File.basename(__FILE__))
     end
 
+    it 'should be able to set on element if no locator passed' do
+      ff = @session.find(:file_field, 'Image')
+      ff.attach_file(with_os_path_separators(__FILE__))
+      @session.click_button('awesome')
+      expect(extract_results(@session)['image']).to eq(File.basename(__FILE__))
+    end
+
     it 'casts to string' do
       @session.attach_file :form_image, with_os_path_separators(__FILE__)
       @session.click_button('awesome')

--- a/lib/capybara/spec/session/check_spec.rb
+++ b/lib/capybara/spec/session/check_spec.rb
@@ -68,6 +68,13 @@ Capybara::SpecHelper.spec '#check' do
     expect(extract_results(@session)['pets']).to include('dog', 'cat', 'hamster')
   end
 
+  it 'should be able to check itself if no locator specified' do
+    cb = @session.find(:id, 'form_pets_cat')
+    cb.check
+    @session.click_button('awesome')
+    expect(extract_results(@session)['pets']).to include('dog', 'cat', 'hamster')
+  end
+
   it 'casts to string' do
     @session.check(:form_pets_cat)
     @session.click_button('awesome')
@@ -138,6 +145,20 @@ Capybara::SpecHelper.spec '#check' do
       it 'should check via clicking the wrapping label if possible' do
         expect(@session.find(:checkbox, 'form_cars_mclaren', unchecked: true, visible: :hidden)).to be_truthy
         @session.check('form_cars_mclaren')
+        @session.click_button('awesome')
+        expect(extract_results(@session)['cars']).to include('mclaren')
+      end
+
+      it 'should check via clicking the label with :for attribute if locator nil' do
+        cb = @session.find(:checkbox, 'form_cars_tesla', unchecked: true, visible: :hidden)
+        cb.check
+        @session.click_button('awesome')
+        expect(extract_results(@session)['cars']).to include('tesla')
+      end
+
+      it 'should check self via clicking the wrapping label if locator nil' do
+        cb = @session.find(:checkbox, 'form_cars_mclaren', unchecked: true, visible: :hidden)
+        cb.check
         @session.click_button('awesome')
         expect(extract_results(@session)['cars']).to include('mclaren')
       end

--- a/lib/capybara/spec/session/choose_spec.rb
+++ b/lib/capybara/spec/session/choose_spec.rb
@@ -23,6 +23,13 @@ Capybara::SpecHelper.spec '#choose' do
     expect(extract_results(@session)['gender']).to eq('male')
   end
 
+  it 'should be able to choose self when no locator string specified' do
+    rb = @session.find(:id, 'gender_male')
+    rb.choose
+    @session.click_button('awesome')
+    expect(extract_results(@session)['gender']).to eq('male')
+  end
+
   it 'casts to string' do
     @session.choose('Both')
     @session.click_button(:awesome)
@@ -82,8 +89,15 @@ Capybara::SpecHelper.spec '#choose' do
         Capybara.automatic_label_click = old_click_label
       end
 
-      it 'should select by clicking the link if available' do
+      it 'should select by clicking the label if available' do
         @session.choose('party_democrat')
+        @session.click_button('awesome')
+        expect(extract_results(@session)['party']).to eq('democrat')
+      end
+
+      it 'should select self by clicking the label if no locator specified' do
+        cb = @session.find(:id, 'party_democrat', visible: :hidden)
+        cb.choose
         @session.click_button('awesome')
         expect(extract_results(@session)['party']).to eq('democrat')
       end

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -137,6 +137,13 @@ Capybara::SpecHelper.spec '#fill_in' do
     expect(extract_results(@session)['schmooo']).to eq('Schmooo for all')
   end
 
+  it 'should be able to fill in element called on when no locator passed' do
+    field = @session.find(:fillable_field, 'form[password]')
+    field.fill_in(with: 'supasikrit')
+    @session.click_button('awesome')
+    expect(extract_results(@session)['password']).to eq('supasikrit')
+  end
+
   it "should throw an exception if a hash containing 'with' is not provided" do
     expect { @session.fill_in 'Name' }.to raise_error(ArgumentError, /with/)
   end

--- a/lib/capybara/spec/session/uncheck_spec.rb
+++ b/lib/capybara/spec/session/uncheck_spec.rb
@@ -26,6 +26,14 @@ Capybara::SpecHelper.spec '#uncheck' do
     expect(extract_results(@session)['pets']).not_to include('hamster')
   end
 
+  it 'should be able to uncheck itself if no locator specified' do
+    cb = @session.find(:id, 'form_pets_hamster')
+    cb.uncheck
+    @session.click_button('awesome')
+    expect(extract_results(@session)['pets']).to include('dog')
+    expect(extract_results(@session)['pets']).not_to include('hamster')
+  end
+
   it 'casts to string' do
     @session.uncheck(:form_pets_hamster)
     @session.click_button('awesome')


### PR DESCRIPTION
Experiment to allow calling `check`/`uncheck`/`choose` to operate on the element they're called on when no locator is specified.