### PR TITLE
Fix compatibility issue with puma version < 3.8.0

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -453,7 +453,12 @@ Capybara.register_server :puma do |app, port, host, **options|
   # Therefore construct and run the Server instance ourselves.
   # Rack::Handler::Puma.run(app, { Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false }.merge(options))
 
-  conf = Rack::Handler::Puma.config(app, { Host: host, Port: port, Threads: '0:4', workers: 0, daemon: false }.merge(options))
+  conf = if Rack::Handler::Puma.respond_to?(:config)
+    Rack::Handler::Puma.config(app, { Host: host, Port: port, Threads: '0:4', workers: 0, daemon: false }.merge(options))
+  else
+    Rack::Handler::Puma.run(app, { Host: host, Port: port, Threads: '0:4', workers: 0, daemon: false }.merge(options))
+  end
+
   events = conf.options[:Silent] ? ::Puma::Events.strings : ::Puma::Events.stdio
 
   events.log 'Capybara starting Puma...'


### PR DESCRIPTION
`Rack::Handler::Puma.config` is only added in [puma version 3.8.0](https://github.com/puma/puma/releases/tag/v3.8.0). Therefore, the tests will crash if I use puma version less than 3.8.0.

This PR adds a check to see if `.config` is defined. If it isn't, `Rack::Handler::Puma` will use `.run` instead. I'm not sure how to add tests for check different Puma versions, any advices would be very appreciated.