### PR TITLE
Fix date and time field string entry

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -355,6 +355,10 @@ private
       @value = value
     end
 
+    def to_s
+      value.to_s
+    end
+
     def dateable?
       !value.is_a?(String) && value.respond_to?(:to_date)
     end

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -84,4 +84,32 @@ RSpec.describe 'Capybara::Session with chrome' do
       end
     end
   end
+
+  describe 'filling in Chrome-specific date and time fields with keystrokes' do
+    let(:datetime) { Time.new(1983, 6, 19, 6, 30) }
+
+    before do
+      @session = TestSessions::Chrome
+      @session.visit('/form')
+    end
+
+    it 'should fill in a date input with a String' do
+      @session.fill_in('form_date', with: "06/19/1983")
+      @session.click_button('awesome')
+      expect(Date.parse(extract_results(@session)['date'])).to eq datetime.to_date
+    end
+
+    it 'should fill in a time input with a String' do
+      @session.fill_in('form_time', with: "06:30A")
+      @session.click_button('awesome')
+      results = extract_results(@session)['time']
+      expect(Time.parse(results).strftime('%r')).to eq datetime.strftime('%r')
+    end
+
+    it 'should fill in a datetime input with a String' do
+      @session.fill_in('form_datetime', with: "06/19/1983\t06:30A")
+      @session.click_button('awesome')
+      expect(Time.parse(extract_results(@session)['datetime'])).to eq datetime
+    end
+  end
 end


### PR DESCRIPTION
Fixes a regression introduced in 744e990 where `input[type=date]`, `input[type=datetime]`, and `input[type=datetime-local]` can no longer be set by `String` value.

Below is a heavily-edited version of `capybara/selenium/node.rb` to illustrate the issue.
If `#set` is called with `String` value, `#set_text` is ultimately called with a `SettableValue` value, where `#to_s` is immediately called upon it, resulting in a String value of e.g. `"#<SettableValue:0x00000000008a0138>"`, which is then subsequently entered into the date field via `#send_keys`, resulting in a garbage value in the date field.

```ruby
  def set(value, **options)
    # ...
    case self[:type]
    when 'date'
      set_date(value)
    end
  end

  def set_date(value)
    value = SettableValue.new(value)
    return set_text(value) unless value.dateable?
    # ...
  end

  def set_text(value, clear: nil, **_unused)
    value = value.to_s
    # ...
    send_keys(value)
  end
```

Potential fixes:
1. Implement `#to_s` on SettableValue as an alias of `#value`, or something similar.
2. Replace the `value` variable mutation in `#set_date` and friends, and use the original value if we fall back to `#set_text`. This is the path I have gone with in this PR.

What do you think?