### PR TITLE
Optimize attribute checking for :element selector

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -75,6 +75,10 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
 
   def find_css(selector)
     browser.find(:css, selector)
+  rescue Nokogiri::CSS::SyntaxError
+    raise unless selector.include?(' i]')
+
+    raise ArgumentError, "This driver doesn't support case insensitive attribute matching when using CSS base selectors"
   end
 
   def html

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -97,7 +97,7 @@ Capybara.add_selector(:link) do
               when true
                 XPath.attr(:href)
               when Regexp
-                XPath.attr(:href)[regexp_to_conditions(href)]
+                XPath.attr(:href)[regexp_to_xpath_conditions(href)]
               else
                 XPath.attr(:href) == href.to_s
               end
@@ -138,7 +138,7 @@ Capybara.add_selector(:link) do
     if (href = options[:href])
       if !href.is_a?(Regexp)
         desc << " with href #{href.inspect}"
-      elsif regexp_to_conditions(href)
+      elsif regexp_to_xpath_conditions(href)
         desc << " with href matching #{href.inspect}"
       end
     end
@@ -147,7 +147,7 @@ Capybara.add_selector(:link) do
   end
 
   describe_node_filters do |href: nil, **|
-    " with href matching #{href.inspect}" if href.is_a?(Regexp) && regexp_to_conditions(href).nil?
+    " with href matching #{href.inspect}" if href.is_a?(Regexp) && regexp_to_xpath_conditions(href).nil?
   end
 end
 
@@ -483,7 +483,7 @@ Capybara.add_selector(:element) do
   expression_filter(:attributes, matcher: /.+/) do |xpath, name, val|
     case val
     when Regexp
-      xpath[XPath.attr(name)[regexp_to_conditions(val)]]
+      xpath[XPath.attr(name)[regexp_to_xpath_conditions(val)]]
     when true
       xpath[XPath.attr(name)]
     when false

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -97,9 +97,7 @@ Capybara.add_selector(:link) do
               when true
                 XPath.attr(:href)
               when Regexp
-                regexp_to_substrings(href).map do |str|
-                  XPath.attr(:href).contains(str)
-                end.reduce(&:&)
+                XPath.attr(:href)[regexp_to_conditions(href)]
               else
                 XPath.attr(:href) == href.to_s
               end
@@ -140,7 +138,7 @@ Capybara.add_selector(:link) do
     if (href = options[:href])
       if !href.is_a?(Regexp)
         desc << " with href #{href.inspect}"
-      elsif regexp_to_substrings(href).any?
+      elsif regexp_to_conditions(href)
         desc << " with href matching #{href.inspect}"
       end
     end
@@ -149,7 +147,7 @@ Capybara.add_selector(:link) do
   end
 
   describe_node_filters do |href: nil, **|
-    " with href matching #{href.inspect}" if href.is_a?(Regexp) && regexp_to_substrings(href).empty?
+    " with href matching #{href.inspect}" if href.is_a?(Regexp) && regexp_to_conditions(href).nil?
   end
 end
 
@@ -485,9 +483,7 @@ Capybara.add_selector(:element) do
   expression_filter(:attributes, matcher: /.+/) do |xpath, name, val|
     case val
     when Regexp
-      regexp_to_substrings(val).inject(xpath) do |xp, str|
-        xp[XPath.attr(name).contains(str)]
-      end
+      xpath[XPath.attr(name)[regexp_to_conditions(val)]]
     when true
       xpath[XPath.attr(name)]
     when false

--- a/lib/capybara/selector/builders/css_builder.rb
+++ b/lib/capybara/selector/builders/css_builder.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'xpath'
+
+module Capybara
+  class Selector
+    # @api private
+    class CSSBuilder
+      class << self
+        def attribute_conditions(attributes)
+          attributes.map do |attribute, value|
+            case value
+            when XPath::Expression
+              raise ArgumentError, "XPath expressions are not supported for the :#{attribute} filter with CSS based selectors"
+            when Regexp
+              Selector::RegexpDisassembler.new(value).substrings.map do |str|
+                "[#{attribute}*='#{str}'#{' i' if value.casefold?}]"
+              end.join
+            when true
+              "[#{attribute}]"
+            when false
+              ':not([attribute])'
+            else
+              if attribute == :id
+                "##{::Capybara::Selector::CSS.escape(value)}"
+              else
+                "[#{attribute}='#{value}']"
+              end
+            end
+          end.join
+        end
+
+        def class_conditions(classes)
+          case classes
+          when XPath::Expression
+            raise ArgumentError, 'XPath expressions are not supported for the :class filter with CSS based selectors'
+          when Regexp
+            strs = Selector::RegexpDisassembler.new(classes).substrings
+            strs.map { |str| "[class*='#{str}'#{' i' if classes.casefold?}]" }.join
+          else
+            cls = Array(classes).group_by { |cl| cl.start_with? '!' }
+            (cls[false].to_a.map { |cl| ".#{Capybara::Selector::CSS.escape(cl)}" } +
+            cls[true].to_a.map { |cl| ":not(.#{Capybara::Selector::CSS.escape(cl.slice(1..-1))})" }).join
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/capybara/selector/builders/xpath_builder.rb
+++ b/lib/capybara/selector/builders/xpath_builder.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'xpath'
+
+module Capybara
+  class Selector
+    # @api private
+    class XPathBuilder
+      class << self
+        def attribute_conditions(attributes)
+          attributes.map do |attribute, value|
+            case value
+            when XPath::Expression
+              XPath.attr(attribute)[value]
+            when Regexp
+              XPath.attr(attribute)[regexp_to_xpath_conditions(value)]
+            when true
+              XPath.attr(attribute)
+            when false, nil
+              !XPath.attr(attribute)
+            else
+              XPath.attr(attribute) == value.to_s
+            end
+          end.reduce(:&)
+        end
+
+        def class_conditions(classes)
+          case classes
+          when XPath::Expression
+            XPath.attr(:class)[classes]
+          when Regexp
+            XPath.attr(:class)[regexp_to_xpath_conditions(classes)]
+          else
+            Array(classes).map do |klass|
+              if klass.start_with?('!')
+                !XPath.attr(:class).contains_word(klass.slice(1..-1))
+              else
+                XPath.attr(:class).contains_word(klass)
+              end
+            end.reduce(:&)
+          end
+        end
+
+      private
+
+        def regexp_to_xpath_conditions(regexp)
+          condition = XPath.current
+          condition = condition.uppercase if regexp.casefold?
+          Selector::RegexpDisassembler.new(regexp).substrings.map do |str|
+            condition.contains(str)
+          end.reduce(:&)
+        end
+      end
+    end
+  end
+end

--- a/lib/capybara/selector/regexp_disassembler.rb
+++ b/lib/capybara/selector/regexp_disassembler.rb
@@ -1,21 +1,11 @@
 # frozen_string_literal: true
 
-require 'xpath'
-
 module Capybara
   class Selector
     class RegexpDisassembler
       def initialize(regexp)
         @regexp = regexp
         @regexp_source = regexp.source
-      end
-
-      def conditions
-        condition = XPath.current
-        condition = condition.uppercase if @regexp.casefold?
-        substrings.map do |str|
-          condition.contains(@regexp.casefold? ? str.upcase : str)
-        end.reduce(:&)
       end
 
       def substrings
@@ -37,7 +27,9 @@ module Capybara
           end
           return [] if source.include?('|') # can't handle alternation here
 
-          source.match(/\A\^?(.*?)\$?\Z/).captures[0].split('.').reject(&:empty?).uniq
+          strs = source.match(/\A\^?(.*?)\$?\Z/).captures[0].split('.').reject(&:empty?).uniq
+          strs = strs.map(&:upcase) if @regexp.casefold?
+          strs
         end
       end
 

--- a/lib/capybara/selector/regexp_disassembler.rb
+++ b/lib/capybara/selector/regexp_disassembler.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'xpath'
+
+module Capybara
+  class Selector
+    class RegexpDisassembler
+      def initialize(regexp)
+        @regexp = regexp
+        @regexp_source = regexp.source
+      end
+
+      def conditions
+        condition = XPath.current
+        condition = condition.uppercase if @regexp.casefold?
+        substrings.map do |str|
+          condition.contains(@regexp.casefold? ? str.upcase : str)
+        end.reduce(:&)
+      end
+
+      def substrings
+        @substrings ||= begin
+          source = @regexp_source.dup
+          source.gsub!(/\\[^pgk]/, '.') # replace escaped characters with wildcard
+          source.gsub!(/\\p\{[[:alpha:]]+\}/, '.') # replace character properties with wildcard
+          source.gsub!(/\[\[:[a-z]+:\]\]/, '.') # replace posix classes with wildcard
+          while source.gsub!(/\[(?:[^\[\]]+)\]/, '.'); end # replace character classes with wildcard
+          source.gsub!(/\(\?<?[=!][^)]*\)/, '') # remove lookahead/lookbehind assertions
+          source.gsub!(/\(\?(?:<[^>]+>|>|:)/, '(') # replace named, atomic, and non-matching groups with unnamed matching groups
+
+          orig_source = nil
+          while source != orig_source
+            orig_source = source.dup
+            while source.gsub!(/\([^())]*\)[*?]/, '.'); end # replace optional groups with wildcard
+            while source.gsub!(/(\([^())]*\))\{(\d*)\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) }; end # replace fixed count groups with copies
+            while source.gsub!(/(\([^())]*\))\{(\d*)(?:,\d*)\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' }; end # replace counted groups with minimum copies and wildcard
+            while source.gsub!(/\([^())]*\|[^)]*\)/, '.'); end # replace groups containing alternation with wildcard
+            while source.gsub!(/\(([^())]*)\)\+/, '\1.'); end # replace one or more repeating groups with text followed by wildcard
+            while source.gsub!(/\(([^())]*)\)(?![+{?*])/, '\1'); end # replace non repeating groups with text
+          end
+          source.gsub!(/.[*?]/, '.') # replace optional character with wildcard
+          source.gsub!(/(.)\+/, '\1.') # replace one or more with character plus wildcard
+          source.gsub!(/(.)\{(\d*)(?:,\d*)?\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' } # replace counted character with with minimum copies and wildcard
+          return [] if source.include?('|') # can't handle alternation here
+
+          source.match(/\A\^?(.*?)\$?\Z/).captures[0].split('.').reject(&:empty?).uniq
+        end
+      end
+    end
+  end
+end

--- a/lib/capybara/selector/regexp_disassembler.rb
+++ b/lib/capybara/selector/regexp_disassembler.rb
@@ -2,6 +2,7 @@
 
 module Capybara
   class Selector
+    # @api private
     class RegexpDisassembler
       def initialize(regexp)
         @regexp = regexp

--- a/lib/capybara/selector/regexp_disassembler.rb
+++ b/lib/capybara/selector/regexp_disassembler.rb
@@ -31,15 +31,15 @@ module Capybara
           orig_source = nil
           while source != orig_source
             orig_source = source.dup
-            while source.gsub!(/\([^())]*\)[*?]/, '.'); end # replace optional groups with wildcard
-            while source.gsub!(/(\([^())]*\))\{(\d*)\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) }; end # replace fixed count groups with copies
-            while source.gsub!(/(\([^())]*\))\{(\d*)(?:,\d*)\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' }; end # replace counted groups with minimum copies and wildcard
-            while source.gsub!(/\([^())]*\|[^)]*\)/, '.'); end # replace groups containing alternation with wildcard
-            while source.gsub!(/\(([^())]*)\)\+/, '\1.'); end # replace one or more repeating groups with text followed by wildcard
-            while source.gsub!(/\(([^())]*)\)(?![+{?*])/, '\1'); end # replace non repeating groups with text
+            while source.gsub!(/\([^()]*\)[*?]\??/, '.'); end # replace optional groups with wildcard
+            while source.gsub!(/(\([^()]*\))\{(\d*)\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) }; end # replace fixed count groups with copies
+            while source.gsub!(/(\([^()]*\))\{(\d*)(?:,\d*)\}\??/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' }; end # replace counted groups with minimum copies and wildcard
+            while source.gsub!(/\([^()]*\|[^)]*\)/, '.'); end # replace groups containing alternation with wildcard
+            while source.gsub!(/\(([^()]*)\)\+\??/, '\1.'); end # replace one or more repeating groups with text followed by wildcard
+            while source.gsub!(/\(([^()]*)\)(?![+{?*])/, '\1'); end # replace non repeating groups with text
           end
-          source.gsub!(/.[*?]/, '.') # replace optional character with wildcard
-          source.gsub!(/(.)\+/, '\1.') # replace one or more with character plus wildcard
+          source.gsub!(/.[*?]\??/, '.') # replace optional character with wildcard
+          source.gsub!(/(.)\+\??/, '\1.') # replace one or more with character plus wildcard
           source.gsub!(/(.)\{(\d*)(?:,\d*)?\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' } # replace counted character with with minimum copies and wildcard
           return [] if source.include?('|') # can't handle alternation here
 

--- a/lib/capybara/selector/regexp_disassembler.rb
+++ b/lib/capybara/selector/regexp_disassembler.rb
@@ -22,7 +22,8 @@ module Capybara
         @substrings ||= begin
           source = @regexp_source.dup
           source.gsub!(/\\[^pgk]/, '.') # replace escaped characters with wildcard
-          source.gsub!(/\\p\{[[:alpha:]]+\}/, '.') # replace character properties with wildcard
+          source.gsub!(/\\[gk](?:<[^>]*>)?/, '.') # replace sub expressions and back references with wildcard
+          source.gsub!(/\\p\{[[:alpha:]]+\}?/, '.') # replace character properties with wildcard
           source.gsub!(/\[\[:[a-z]+:\]\]/, '.') # replace posix classes with wildcard
           while source.gsub!(/\[(?:[^\[\]]+)\]/, '.'); end # replace character classes with wildcard
           source.gsub!(/\(\?<?[=!][^)]*\)/, '') # remove lookahead/lookbehind assertions

--- a/lib/capybara/selector/regexp_disassembler.rb
+++ b/lib/capybara/selector/regexp_disassembler.rb
@@ -28,24 +28,45 @@ module Capybara
           source.gsub!(/\(\?<?[=!][^)]*\)/, '') # remove lookahead/lookbehind assertions
           source.gsub!(/\(\?(?:<[^>]+>|>|:)/, '(') # replace named, atomic, and non-matching groups with unnamed matching groups
 
-          orig_source = nil
-          while source != orig_source
-            orig_source = source.dup
-            while source.gsub!(/\([^()]*\)[*?]\??/, '.'); end # replace optional groups with wildcard
-            while source.gsub!(/(\([^()]*\))\{(\d*)\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) }; end # replace fixed count groups with copies
-            while source.gsub!(/(\([^()]*\))\{(\d*)(?:,\d*)\}\??/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' }; end # replace counted groups with minimum copies and wildcard
-            while source.gsub!(/\([^()]*\|[^)]*\)/, '.'); end # replace groups containing alternation with wildcard
-            while source.gsub!(/\(([^()]*)\)\+\??/, '\1.'); end # replace one or more repeating groups with text followed by wildcard
-            while source.gsub!(/\(([^()]*)\)(?![+{?*])/, '\1'); end # replace non repeating groups with text
-          end
+          while source.gsub!(GROUP_REGEX) { |_m| simplify_group(Regexp.last_match) }; end
           source.gsub!(/.[*?]\??/, '.') # replace optional character with wildcard
           source.gsub!(/(.)\+\??/, '\1.') # replace one or more with character plus wildcard
-          source.gsub!(/(.)\{(\d*)(?:,\d*)?\}/) { |_m| (Regexp.last_match(1) * Regexp.last_match(2).to_i) + '.' } # replace counted character with with minimum copies and wildcard
+          source.gsub!(/(?<char>.)#{COUNTED_REP_REGEX.source}/) do |_m| # repeat counted characters
+            (Regexp.last_match[:char] * Regexp.last_match[:min_rep].to_i).tap { |str| str << '.' if Regexp.last_match[:max_rep] }
+          end
           return [] if source.include?('|') # can't handle alternation here
 
           source.match(/\A\^?(.*?)\$?\Z/).captures[0].split('.').reject(&:empty?).uniq
         end
       end
+
+    private
+
+      def simplify_group(matches)
+        if matches[:group].include?('|') # no support for alternation in groups
+          '.'
+        elsif matches[:one_or_more] # required but may repeat becomes text + wildcard
+          matches[:group][1..-2] + '.'
+        elsif matches[:optional] # optional group becomes wildcard
+          '.'
+        elsif matches[:min_rep]
+          (matches[:group] * matches[:min_rep].to_i).tap { |r| r << '.' if matches[:max_rep] }
+        else
+          matches[:group][1..-2]
+        end
+      end
+
+      COUNTED_REP_REGEX = /\{(?<min_rep>\d*)(?:,(?<max_rep>\d*))?\}/
+      GROUP_REGEX = /
+        (?<group>\([^()]*\))
+          (?:
+            (?:
+             (?<optional>[*?]) |
+             (?<one_or_more>\+) |
+             (?:#{COUNTED_REP_REGEX.source})
+            )\??
+          )?
+      /x
     end
   end
 end

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -4,6 +4,7 @@
 
 require 'capybara/selector/filter_set'
 require 'capybara/selector/css'
+require 'capybara/selector/regexp_disassembler'
 
 module Capybara
   #
@@ -445,24 +446,9 @@ module Capybara
       Array(classes).map { |klass| XPath.attr(:class).contains_word(klass) }.reduce(:&)
     end
 
-    def regexp_to_substrings(regexp)
-      return [] unless regexp.options.zero?
-
-      regexp.source.match(CONVERTIBLE_REGEXP) do |match|
-        match.captures.reject(&:empty?)
-      end || []
+    def regexp_to_conditions(regexp)
+      RegexpDisassembler.new(regexp).conditions
     end
-
-    CONVERTIBLE_REGEXP = /
-      \A
-        \^?                   # start
-        ([^\[\]\\^$.|?*+()]*) # leading literal characters
-        [^|]*?                # do not try to convert expressions with alternates
-        (?<!\\)               # skip metacharacters - ie has preceding slash
-        ([^\[\]\\^$.|?*+()]*) # trailing literal characters
-        \$?                   # end
-      \z
-    /x
   end
 end
 

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -444,6 +444,25 @@ module Capybara
     def find_by_class_attr(classes)
       Array(classes).map { |klass| XPath.attr(:class).contains_word(klass) }.reduce(:&)
     end
+
+    def regexp_to_substrings(regexp)
+      return [] unless regexp.options.zero?
+
+      regexp.source.match(CONVERTIBLE_REGEXP) do |match|
+        match.captures.reject(&:empty?)
+      end || []
+    end
+
+    CONVERTIBLE_REGEXP = /
+      \A
+        \^?                   # start
+        ([^\[\]\\^$.|?*+()]*) # leading literal characters
+        [^|]*?                # do not try to convert expressions with alternates
+        (?<!\\)               # skip metacharacters - ie has preceding slash
+        ([^\[\]\\^$.|?*+()]*) # trailing literal characters
+        \$?                   # end
+      \z
+    /x
   end
 end
 

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -5,6 +5,8 @@
 require 'capybara/selector/filter_set'
 require 'capybara/selector/css'
 require 'capybara/selector/regexp_disassembler'
+require 'capybara/selector/builders/xpath_builder'
+require 'capybara/selector/builders/css_builder'
 
 module Capybara
   #
@@ -395,6 +397,18 @@ module Capybara
       vis.nil? ? fallback : vis
     end
 
+    # @api private
+    def builder
+      case format
+      when :css
+        Capybara::Selector::CSSBuilder
+      when :xpath
+        Capybara::Selector::XPathBuilder
+      else
+        raise NotImplementedError, "No builder exists for selector of type #{format}"
+      end
+    end
+
   private
 
     def enable_aria_label
@@ -444,14 +458,6 @@ module Capybara
 
     def find_by_class_attr(classes)
       Array(classes).map { |klass| XPath.attr(:class).contains_word(klass) }.reduce(:&)
-    end
-
-    def regexp_to_xpath_conditions(regexp)
-      condition = XPath.current
-      condition = condition.uppercase if regexp.casefold?
-      RegexpDisassembler.new(regexp).substrings.map do |str|
-        condition.contains(str)
-      end.reduce(:&)
     end
   end
 end

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -446,8 +446,12 @@ module Capybara
       Array(classes).map { |klass| XPath.attr(:class).contains_word(klass) }.reduce(:&)
     end
 
-    def regexp_to_conditions(regexp)
-      RegexpDisassembler.new(regexp).conditions
+    def regexp_to_xpath_conditions(regexp)
+      condition = XPath.current
+      condition = condition.uppercase if regexp.casefold?
+      RegexpDisassembler.new(regexp).substrings.map do |str|
+        condition.contains(str)
+      end.reduce(:&)
     end
   end
 end

--- a/lib/capybara/spec/session/has_css_spec.rb
+++ b/lib/capybara/spec/session/has_css_spec.rb
@@ -23,6 +23,22 @@ Capybara::SpecHelper.spec '#has_css?' do
     expect(@session).not_to have_css('p.nosuchclass')
   end
 
+  it 'should support :id option' do
+    expect(@session).to have_css('h2', id: 'h2one')
+    expect(@session).to have_css('h2')
+    expect(@session).to have_css('h2', id: /h2o/)
+  end
+
+  it 'should support :class option' do
+    expect(@session).to have_css('li', class: 'guitarist')
+    expect(@session).to have_css('li', class: /guitar/)
+  end
+
+  it 'should support case insensitive :class and :id options' do
+    expect(@session).to have_css('li', class: /UiTaRI/i)
+    expect(@session).to have_css('h2', id: /2ON/i)
+  end
+
   it 'should respect scopes' do
     @session.within "//p[@id='first']" do
       expect(@session).to have_css('a#foo')

--- a/lib/capybara/spec/session/node_wrapper_spec.rb
+++ b/lib/capybara/spec/session/node_wrapper_spec.rb
@@ -34,6 +34,6 @@ Capybara::SpecHelper.spec '#to_capybara_node' do
     end.to raise_error(/^expected to find css "#second" within #<Capybara::Node::Element/)
     expect do
       expect(para).to have_link(href: %r{/without_simple_html})
-    end.to raise_error(%r{^expected to find visible link nil with href matching /\\/without_simple_html/ within #<Capybara::Node::Element})
+    end.to raise_error(%r{^expected to find link nil with href matching /\\/without_simple_html/ within #<Capybara::Node::Element})
   end
 end

--- a/lib/capybara/spec/session/selectors_spec.rb
+++ b/lib/capybara/spec/session/selectors_spec.rb
@@ -40,8 +40,14 @@ Capybara::SpecHelper.spec Capybara::Selector do
   end
 
   describe 'field selectors' do
-    it 'can find specifically by id' do
-      expect(@session.find(:field, id: 'customer_email').value).to eq 'ben@ben.com'
+    context "with :id option" do
+      it 'can find specifically by id' do
+        expect(@session.find(:field, id: 'customer_email').value).to eq 'ben@ben.com'
+      end
+
+      it 'can find by regex' do
+        expect(@session.find(:field, id: /ustomer.emai/).value).to eq 'ben@ben.com'
+      end
     end
 
     it 'can find specifically by name' do

--- a/lib/capybara/spec/session/selectors_spec.rb
+++ b/lib/capybara/spec/session/selectors_spec.rb
@@ -40,13 +40,17 @@ Capybara::SpecHelper.spec Capybara::Selector do
   end
 
   describe 'field selectors' do
-    context "with :id option" do
+    context 'with :id option' do
       it 'can find specifically by id' do
         expect(@session.find(:field, id: 'customer_email').value).to eq 'ben@ben.com'
       end
 
       it 'can find by regex' do
         expect(@session.find(:field, id: /ustomer.emai/).value).to eq 'ben@ben.com'
+      end
+
+      it 'can find by case-insensitive id' do
+        expect(@session.find(:field, id: /StOmer.emAI/i).value).to eq 'ben@ben.com'
       end
     end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -26,6 +26,12 @@
   </p>
 
   <p>
+    <label for="customer_other_email">Customer Other Email
+      <input type="text" name="form[customer_other_email]" value="notben@notben.com" id="customer_other_email"/>
+    </label>
+  </p>
+
+  <p>
     <label for="form_other_title">Other title</label>
     <select name="form[other_title]" id="form_other_title">
       <option>Mrs</option>

--- a/lib/capybara/xpath_patches.rb
+++ b/lib/capybara/xpath_patches.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+module XPath
+  module DSL
+    def lowercase
+      method(:translate, 'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸŽŠŒ', 'abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿžšœ')
+    end
+
+    def uppercase
+      method(:translate, 'abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿžšœ', 'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸŽŠŒ')
+    end
+  end
+end
+
 module Capybara
   module XPathPatches
     module Renderer

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -9,7 +9,12 @@ end
 
 Capybara::SpecHelper.run_specs TestClass.new, 'DSL', capybara_skip: %i[
   js modals screenshot frames windows send_keys server hover about_scheme psc download css driver
-]
+] do |example|
+  case example.metadata[:full_description]
+  when /has_css\? should support case insensitive :class and :id options/
+    pending "Nokogiri doesn't support case insensitive CSS attribute matchers"
+  end
+end
 
 RSpec.describe Capybara::DSL do
   after do

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -19,7 +19,12 @@ skipped_tests = %i[
   download
   css
 ]
-Capybara::SpecHelper.run_specs TestSessions::RackTest, 'RackTest', capybara_skip: skipped_tests
+Capybara::SpecHelper.run_specs TestSessions::RackTest, 'RackTest', capybara_skip: skipped_tests do |example|
+  case example.metadata[:full_description]
+  when /has_css\? should support case insensitive :class and :id options/
+    pending "Nokogiri doesn't support case insensitive CSS attribute matchers"
+  end
+end
 
 RSpec.describe Capybara::Session do # rubocop:disable RSpec/MultipleDescribes
   context 'with rack test driver' do

--- a/spec/regexp_dissassembler_spec.rb
+++ b/spec/regexp_dissassembler_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Capybara::Selector::RegexpDisassembler do
+  it 'handles strings' do
+    verify_strings(
+      /abcdef/ => %w[abcdef],
+      /abc def/ => ['abc def']
+    )
+  end
+
+  it 'handles escaped characters' do
+    verify_strings(
+      /abc\\def/ => %w[abc def],
+      /\nabc/ => %w[abc],
+      %r{abc/} => %w[abc/]
+    )
+  end
+
+  it 'handles wildcards' do
+    verify_strings(
+      /abc.*def/ => %w[abc def],
+      /.*def/ => %w[def],
+      /abc./ => %w[abc],
+      /abc.*/ => %w[abc],
+      /abc.def/ => %w[abc def],
+      /abc.def.ghi/ => %w[abc def ghi]
+    )
+  end
+
+  it 'handles optional characters' do
+    verify_strings(
+      /abc*def/ => %w[ab def],
+      /abc*/ => %w[ab],
+      /abc?def/ => %w[ab def],
+      /abc?/ => %w[ab],
+      /abc?def?/ => %w[ab de],
+      /abc?def?g/ => %w[ab de g]
+    )
+  end
+
+  it 'handles character classes' do
+    verify_strings(
+      /abc[a-z]/ => %w[abc],
+      /abc[a-z]def[0-9]g/ => %w[abc def g],
+      /[0-9]abc/ => %w[abc],
+      /[0-9]+/ => %w[],
+      /abc[0-9&&[^7]]/ => %w[abc]
+    )
+  end
+
+  it 'handles posix bracket expressions' do
+    verify_strings(
+      /abc[[:alpha:]]/ => %w[abc],
+      /[[:digit:]]abc/ => %w[abc],
+      /abc[[:print:]]def/ => %w[abc def]
+    )
+  end
+
+  it 'handles repitition' do
+    verify_strings(
+      /abc{3}/ => %w[abccc],
+      /abc{0}/ => %w[ab],
+      /abc{,2}/ => %w[ab],
+      /abc{2,}/ => %w[abcc],
+      /def{1,5}/ => %w[def],
+      /abc+def/ => %w[abc def],
+      /ab(cde){,4}/ => %w[ab],
+      /(ab){,2}cd/ => %w[cd],
+      /(abc){2,3}/ => %w[abcabc],
+      /(abc){3}/ => %w[abcabcabc]
+    )
+  end
+
+  it 'handles alternation' do
+    verify_strings(
+      /abc|def/ => [],
+      /ab(?:c|d)/ => %w[ab],
+      /ab(c|d)ef/ => %w[ab ef]
+    )
+  end
+
+  it 'handles grouping' do
+    verify_strings(
+      /(abc)/ => %w[abc],
+      /(abc)?/ => [],
+      /ab(cde)/ => %w[abcde],
+      /(abc)de/ => %w[abcde],
+      /ab(cde)fg/ => %w[abcdefg],
+      /ab(?<name>cd)ef/ => %w[abcdef],
+      /gh(?>ij)kl/ => %w[ghijkl],
+      /m(n.*p)q/ => %w[mn pq],
+      /(?:ab(cd)*){2,3}/ => %w[ab],
+      /(ab(cd){3})?/ => [],
+      /(ab(cd)+){2}/ => %w[abcd]
+    )
+  end
+
+  it 'handles meta characters' do
+    verify_strings(
+      /abc\d/ => %w[abc],
+      /abc\wdef/ => %w[abc def],
+      /\habc/ => %w[abc]
+    )
+  end
+
+  it 'handles character properties' do
+    verify_strings(
+      /ab\p{Alpha}cd/ => %w[ab cd],
+      /ab\p{Blank}/ => %w[ab],
+      /\p{Digit}cd/ => %w[cd]
+    )
+  end
+
+  it 'handles anchors' do
+    verify_strings(
+      /^abc/ => %w[abc],
+      /def$/ => %w[def],
+      /^abc$/ => %w[abc]
+    )
+  end
+
+  def verify_strings(hsh)
+    hsh.each do |regexp, expected|
+      expect(Capybara::Selector::RegexpDisassembler.new(regexp).substrings).to eq expected
+    end
+  end
+end

--- a/spec/regexp_dissassembler_spec.rb
+++ b/spec/regexp_dissassembler_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Capybara::Selector::RegexpDisassembler do
     )
   end
 
+  it 'handles non-greedy repetition' do
+    verify_strings(
+      /abc.*?/ => %w[abc],
+      /abc+?/ => %w[abc],
+      /abc*?cde/ => %w[ab cde],
+      /(abc)+?def/ => %w[abc def],
+      /ab(cde)*?fg/ => %w[ab fg]
+    )
+  end
+
   it 'handles alternation' do
     verify_strings(
       /abc|def/ => [],

--- a/spec/regexp_dissassembler_spec.rb
+++ b/spec/regexp_dissassembler_spec.rb
@@ -126,6 +126,18 @@ RSpec.describe Capybara::Selector::RegexpDisassembler do
     )
   end
 
+  it 'handles backreferences' do
+    verify_strings(
+      /a(?<group>abc).\k<group>.+/ => %w[aabc]
+    )
+  end
+
+  it 'handles subexpressions' do
+    verify_strings(
+      /\A(?<paren>a\g<paren>*b)+\z/ => %w[a b]
+    )
+  end
+
   it 'handles anchors' do
     verify_strings(
       /^abc/ => %w[abc],

--- a/spec/regexp_dissassembler_spec.rb
+++ b/spec/regexp_dissassembler_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe Capybara::Selector::RegexpDisassembler do
   it 'handles repitition' do
     verify_strings(
       /abc{3}/ => %w[abccc],
+      /abc{3}d/ => %w[abcccd],
       /abc{0}/ => %w[ab],
       /abc{,2}/ => %w[ab],
       /abc{2,}/ => %w[abcc],
@@ -69,7 +70,9 @@ RSpec.describe Capybara::Selector::RegexpDisassembler do
       /ab(cde){,4}/ => %w[ab],
       /(ab){,2}cd/ => %w[cd],
       /(abc){2,3}/ => %w[abcabc],
-      /(abc){3}/ => %w[abcabcabc]
+      /(abc){3}/ => %w[abcabcabc],
+      /ab{2,3}cd/ => %w[abb cd],
+      /(ab){2,3}cd/ => %w[abab cd]
     )
   end
 

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe Capybara do
 
         it 'accepts Regexp for xpath based selectors' do
           expect(string.find(:custom_xpath_selector, './/div', id: /peci/)[:id]).to eq '#special'
+          expect(string.find(:custom_xpath_selector, './/div', id: /pEcI/i)[:id]).to eq '#special'
         end
 
         it 'accepts Regexp for css based selectors' do
@@ -188,6 +189,7 @@ RSpec.describe Capybara do
 
         it 'accepts Regexp for XPath based selectors' do
           expect(string.find(:custom_xpath_selector, './/div', class: /dom wor/)[:id]).to eq 'random_words'
+          expect(string.find(:custom_xpath_selector, './/div', class: /dOm WoR/i)[:id]).to eq 'random_words'
         end
 
         it 'accepts Regexp for CSS base selectors' do

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe Capybara do
           expect { string.find(:custom_css_selector, 'div', id: XPath.contains('peci')) }
             .to raise_error(ArgumentError, /not supported/)
         end
+
+        it 'accepts Regexp for xpath based selectors' do
+          expect(string.find(:custom_xpath_selector, './/div', id: /peci/)[:id]).to eq '#special'
+        end
+
+        it 'accepts Regexp for css based selectors' do
+          expect(string.find(:custom_css_selector, 'div', id: /sp.*al/)[:id]).to eq '#special'
+        end
       end
 
       context 'with :class option' do
@@ -207,8 +215,12 @@ RSpec.describe Capybara do
           expect(string.find(:field, 'form[my_text_input]')[:id]).to eq 'my_text_input'
         end
 
-        it 'finds by id' do
+        it 'finds by id string' do
           expect(string.find(:field, id: 'my_text_input')[:name]).to eq 'form[my_text_input]'
+        end
+
+        it 'finds by id regexp' do
+          expect(string.find(:field, id: /my_text_inp/)[:name]).to eq 'form[my_text_input]'
         end
 
         it 'finds by name' do

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -257,6 +257,16 @@ RSpec.describe Capybara do
           expect(string.find(:element, 'input', type: 'submit').value).to eq 'click me'
         end
 
+        it 'supports regexp matching' do
+          expect(string.find(:element, 'input', type: /sub/).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /sub\w.*button/).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /sub.* b.*ton/).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /sub.*mit.*/).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /^submit button$/).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /^(?:submit|other) button$/).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /SuBmIt/i).value).to eq 'click me'
+        end
+
         it 'still works with system keys' do
           expect { string.all(:element, 'input', type: 'submit', count: 1) }.not_to raise_error
         end

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Capybara do
             <input type="file" id="file" class=".special file"/>
             <input type="hidden" id="hidden_field" value="this is hidden"/>
             <input type="submit" value="click me" title="submit button"/>
+            <input type="button" value="don't click me" title="Other button 1"/>
             <a href="#">link</a>
             <fieldset></fieldset>
             <select id="select">
@@ -264,7 +265,9 @@ RSpec.describe Capybara do
           expect(string.find(:element, 'input', title: /sub.*mit.*/).value).to eq 'click me'
           expect(string.find(:element, 'input', title: /^submit button$/).value).to eq 'click me'
           expect(string.find(:element, 'input', title: /^(?:submit|other) button$/).value).to eq 'click me'
-          expect(string.find(:element, 'input', title: /SuBmIt/i).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /SuB.*mIt/i).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /^Su.*Bm.*It/i).value).to eq 'click me'
+          expect(string.find(:element, 'input', title: /^Ot.*he.*r b.*\d/i).value).to eq "don't click me"
         end
 
         it 'still works with system keys' do
@@ -299,7 +302,7 @@ RSpec.describe Capybara do
           expect(string.find(:element, 'input', type: XPath.ends_with('ext'))[:type]).to eq 'text'
           expect(string.find(:element, 'input', type: XPath.contains('ckb'))[:type]).to eq 'checkbox'
           expect(string.find(:element, 'input', title: XPath.contains_word('submit'))[:type]).to eq 'submit'
-          expect(string.find(:element, 'input', title: XPath.contains_word('button'))[:type]).to eq 'submit'
+          expect(string.find(:element, 'input', title: XPath.contains_word('button 1'))[:type]).to eq 'button'
         end
       end
     end

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe Capybara do
           expect { string.find(:custom_css_selector, 'div', class: XPath.contains('random')) }
             .to raise_error(ArgumentError, /not supported/)
         end
+
+        it 'accepts Regexp for XPath based selectors' do
+          expect(string.find(:custom_xpath_selector, './/div', class: /dom wor/)[:id]).to eq 'random_words'
+        end
+
+        it 'accepts Regexp for CSS base selectors' do
+          expect(string.find(:custom_css_selector, 'div', class: /random/)[:id]).to eq 'random_words'
+        end
       end
 
       # :css, :xpath, :id, :field, :fieldset, :link, :button, :link_or_button, :fillable_field, :radio_button, :checkbox, :select,


### PR DESCRIPTION
This parses attribute value regexes to do substring matching in the XPath in order to limit the number of returned elements that need to be checked - ~~stolen~~ borrowed from Watir