### PR TITLE
Fix ruby warning

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -393,7 +393,7 @@ module Capybara
       if threadsafe
         Thread.current['capybara_specified_session']
       else
-        @specified_session
+        @specified_session ||= nil
       end
     end
 


### PR DESCRIPTION
This fixes following warning:

```
capybara/lib/capybara.rb:396: warning: instance variable @specified_session not initialized
```