### PR TITLE
Workaround jruby prepend issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 rvm:
   - 2.5.1
-  - jruby-9.1.16.0
+  - jruby-9.2.0.0
 gemfile:
   - Gemfile
 env:

--- a/History.md
+++ b/History.md
@@ -1,6 +1,10 @@
 # Version 3.10.0
 Release date: unreleased
 
+### Fixed
+
+* Workaround installation of rspec matcher proxies under jruby by reverting to the old solution not using prepend, so jruby bugs are not hit - Issue #2115
+
 ### Added
 
 * :class filter can now check for class names starting with !

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -111,6 +111,26 @@ RSpec.describe 'capybara/rspec' do
           expect(@test_class_instance.find(:css, 'span.number').text.to_i).to @test_class_instance.within(1).of(41)
         end
       end
+
+      context 'when `match_when_negated` is not defined in a matcher' do
+        before do
+          RSpec::Matchers.define :only_match_matcher do |expected|
+            match do |actual|
+              !(actual ^ expected)
+            end
+          end
+        end
+
+        it "can be called with `not_to`" do
+          # This test is for a bug in jruby where `super` isn't defined correctly - https://github.com/jruby/jruby/issues/4678
+          # Reported in https://github.com/teamcapybara/capybara/issues/2115
+          @test_class_instance.instance_eval do
+            expect do
+              expect(true).not_to only_match_matcher(false)
+            end.not_to raise_error
+          end
+        end
+      end
     end
 
     it 'should not include Capybara' do


### PR DESCRIPTION
This is a workaround to fix #2115. It reverts https://github.com/teamcapybara/capybara/commit/df010d79a5c7b3418b67e1aabd570d62036f4f29 conditionally on jruby. Also picked up the regression spec written by @twalpole.