### PR TITLE
Fix macro on doc

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -3,19 +3,20 @@
 module Capybara
   module Node
     module Actions
-      ##
-      #
-      # Finds a button or link and clicks it.  See {Capybara::Node::Actions#click_button} and
-      # {Capybara::Node::Actions#click_link} for what locator will match against for each type of element
       # @!macro waiting_behavior
       #   If the driver is capable of executing JavaScript, this method will wait for a set amount of time
       #   and continuously retry finding the element until either the element is found or the time
       #   expires. The length of time +find+ will wait is controlled through {Capybara.default_max_wait_time}
       #
       #   @option options [false, Numeric] wait (Capybara.default_max_wait_time) Maximum time to wait for matching element to appear.
+
+      ##
       #
-      # @overload click_link_or_button([locator], options)
+      # Finds a button or link and clicks it.  See {Capybara::Node::Actions#click_button} and
+      # {Capybara::Node::Actions#click_link} for what locator will match against for each type of element
       #
+      # @overload click_link_or_button([locator], **options)
+      #   @macro waiting_behavior
       #   @param [String] locator      See {Capybara::Node::Actions#click_button} and {Capybara::Node::Actions#click_link}
       #
       # @return [Capybara::Node::Element]  The element clicked
@@ -30,9 +31,8 @@ module Capybara
       # Finds a link by id, Capybara.test_id attribute, text or title and clicks it. Also looks at image
       # alt text inside the link.
       #
-      # @macro waiting_behavior
-      #
-      # @overload click_link([locator], options)
+      # @overload click_link([locator], **options)
+      #   @macro waiting_behavior
       #   @param [String] locator         text, id, Capybara.test_id attribute, title or nested image's alt attribute
       #   @param options                  See {Capybara::Node::Finders#find_link}
       #
@@ -48,9 +48,8 @@ module Capybara
       # \<button> element. All buttons can be found by their id, Capybara.test_id attribute, value, or title. \<button> elements can also be found
       # by their text content, and image \<input> elements by their alt attribute
       #
-      # @macro waiting_behavior
-      #
       # @overload click_button([locator], **options)
+      #   @macro waiting_behavior
       #   @param [String] locator      Which button to find
       #   @param options     See {Capybara::Node::Finders#find_button}
       # @return [Capybara::Node::Element]  The element clicked

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -8,7 +8,7 @@ module Capybara
       # Finds a button or link and clicks it.  See {Capybara::Node::Actions#click_button} and
       # {Capybara::Node::Actions#click_link} for what locator will match against for each type of element
       # @!macro waiting_behavior
-      #   If the driver is capable of executing JavaScript, +$0+ will wait for a set amount of time
+      #   If the driver is capable of executing JavaScript, this method will wait for a set amount of time
       #   and continuously retry finding the element until either the element is found or the time
       #   expires. The length of time +find+ will wait is controlled through {Capybara.default_max_wait_time}
       #

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -9,7 +9,7 @@ module Capybara
       # is not found.
       #
       # @!macro waiting_behavior
-      #   If the driver is capable of executing JavaScript, +$0+ will wait for a set amount of time
+      #   If the driver is capable of executing JavaScript, this method will wait for a set amount of time
       #   and continuously retry finding the element until either the element is found or the time
       #   expires. The length of time +find+ will wait is controlled through {Capybara.default_max_wait_time}
       #   and defaults to 2 seconds.

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -15,9 +15,9 @@ module Capybara
       #   and defaults to 2 seconds.
       #   @option options [false, Numeric] wait (Capybara.default_max_wait_time) Maximum time to wait for matching element to appear.
       #
-      #     page.find('#foo').find('.bar')
-      #     page.find(:xpath, './/div[contains(., "bar")]')
-      #     page.find('li', text: 'Quox').click_link('Delete')
+      #  page.find('#foo').find('.bar')
+      #  page.find(:xpath, './/div[contains(., "bar")]')
+      #  page.find('li', text: 'Quox').click_link('Delete')
       #
       # @param (see Capybara::Node::Finders#all)
       #


### PR DESCRIPTION
Hi ✋ 

Document on rubydoc macro works wrong like below

https://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FNode%2FActions:check

Incorrect
![screen shot 2018-10-19 at 1 58 16](https://user-images.githubusercontent.com/731436/47506455-0df57f00-d8ab-11e8-894d-2c3bf9563f59.png)

correct
![screen shot 2018-10-19 at 1 57 17](https://user-images.githubusercontent.com/731436/47506450-0c2bbb80-d8ab-11e8-8408-ffcdd7cb2460.png)

It seems to incorrect indent cause it.

This PR fixes document macro indentation.
