### PR TITLE
set datetimes via keystrokes based on detected locale in Selenium driver

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,7 @@ Naming/UncommunicativeMethodParamName:
     - 'x'
     - 'y'
     - 'on'
+    - 'dt'
 
 Style/ParallelAssignment:
   Enabled: false

--- a/lib/capybara/selenium/nodes/marionette_node.rb
+++ b/lib/capybara/selenium/nodes/marionette_node.rb
@@ -67,6 +67,12 @@ private
     super
   end
 
+  def set_as_keystrokes(val, type)
+    # send_keys doesn't work for datetime widgets in FF - use Actions API
+    click(x: 5, y: 5)
+    _send_keys(keystrokes_for_datetime(val, type)).perform
+  end
+
   def _send_keys(keys, actions = browser_action, down_keys = ModifierKeysStack.new)
     case keys
     when :control, :left_control, :right_control,

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -69,11 +69,26 @@ Capybara::SpecHelper.spec '#fill_in' do
       expect(Time.parse(results).strftime('%r')).to eq time.strftime('%r')
     end
 
+    it 'should fill in a time input with seconds' do
+      time = Time.new(2018, 3, 9, 15, 26, 19)
+      @session.fill_in('form_time_with_seconds', with: time)
+      @session.click_button('awesome')
+      results = extract_results(@session)['time_with_seconds']
+      expect(Time.parse(results).strftime('%r')).to eq time.strftime('%r')
+    end
+
     it 'should fill in a datetime input' do
       dt = Time.new(2018, 3, 13, 9, 53)
       @session.fill_in('form_datetime', with: dt)
       @session.click_button('awesome')
       expect(Time.parse(extract_results(@session)['datetime'])).to eq dt
+    end
+
+    it 'should fill in a datetime input with seconds' do
+      dt = Time.new(2018, 3, 13, 9, 53, 13)
+      @session.fill_in('form_datetime_with_seconds', with: dt)
+      @session.click_button('awesome')
+      expect(Time.parse(extract_results(@session)['datetime_with_seconds'])).to eq dt
     end
   end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -449,6 +449,8 @@ New line after and before textarea tag
     <input type="date" name="form[date]" id="form_date"/>
     <input type="time" name="form[time]" id="form_time"/>
     <input type="datetime-local" name="form[datetime]" id="form_datetime">
+    <input type="time" name="form[time_with_seconds]" id="form_time_with_seconds" step="1">
+    <input type="datetime-local" name="form[datetime_with_seconds]" id="form_datetime_with_seconds" step="1">
   </p>
 
   <p>


### PR DESCRIPTION
@hron Since you were working on something around setting of date/time entries previously could you take a look at this and see whether it gets your locale correctly and what format strings/lambdas would need to be added to LOCALE_KEYSTROKES for that locale? I would really like to get to a point where date/time inputs can be set via keystrokes in most cases.

Note: this is very preliminary code and will be refactored many times before it is (if ever) merged