### PR TITLE
Fix parameter type[ci skip]

### DIFF
--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -62,7 +62,7 @@ module Capybara
       #
       # @macro waiting_behavior
       #
-      # @option options [Boolean] match        The matching strategy to use.
+      # @option options [Symbol] match        The matching strategy to use.
       #
       # @return [Capybara::Node::Element]      The found element
       # @raise  [Capybara::ElementNotFound]    If the element can't be found before time expires
@@ -88,7 +88,7 @@ module Capybara
       #
       # @macro waiting_behavior
       #
-      # @option options [Boolean] match        The matching strategy to use.
+      # @option options [Symbol] match        The matching strategy to use.
       #
       # @return [Capybara::Node::Element]      The found element
       # @raise  [Capybara::ElementNotFound]    If the element can't be found before time expires


### PR DESCRIPTION
Hi ✋ 

I found some wrong points in doc.
It seems `match` parameter get symbol not boolean, I fixed it.
