### PR TITLE
Handle case where element has gone away while building `path`

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -181,7 +181,9 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
         when 1
           '' # index not necessary when only one matching element
         else
-          "[#{siblings.index(node) + 1}]"
+          idx = siblings.index(node)
+          # Element may not be found in the siblings if it has gone away
+          idx.nil? ? '[ERROR]' : "[#{idx + 1}]"
         end
       end
       result.push selector

--- a/lib/capybara/spec/session/has_css_spec.rb
+++ b/lib/capybara/spec/session/has_css_spec.rb
@@ -39,10 +39,29 @@ Capybara::SpecHelper.spec '#has_css?' do
     expect(@session).to have_css('h2', id: /2ON/i)
   end
 
-  it 'should respect scopes' do
-    @session.within "//p[@id='first']" do
-      expect(@session).to have_css('a#foo')
-      expect(@session).not_to have_css('a#red')
+  context 'when scoped' do
+    it 'should look in the scope' do
+      @session.within "//p[@id='first']" do
+        expect(@session).to have_css('a#foo')
+        expect(@session).not_to have_css('a#red')
+      end
+    end
+
+    it 'should be able to generate an error message if the scope is a sibling', :focus_ do
+      el = @session.find(:css, '#first')
+      @session.within el.sibling(:css, '#second') do
+        expect {
+          expect(@session).to have_css('a#not_on_page')
+        }.to raise_error /there were no matches/
+      end
+    end
+
+    it 'should be able to generate an error message if the scope is a sibling from XPath', :focus_ do
+      el = @session.find(:css, '#first').find(:xpath, './following-sibling::*[1]') do
+        expect {
+          expect(el).to have_css('a#not_on_page')
+        }.to raise_error /there were no matches/
+      end
     end
   end
 


### PR DESCRIPTION
Possible fix for Issue #2120 