### PR TITLE
Fix doc on result

### DIFF
--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -7,7 +7,7 @@ module Capybara
   # A {Capybara::Result} represents a collection of {Capybara::Node::Element} on the page. It is possible to interact with this
   # collection similar to an Array because it implements Enumerable and offers the following Array methods through delegation:
   #
-  # * []
+  # * \[\]
   # * each()
   # * at()
   # * size()


### PR DESCRIPTION
Hi ✋ 

I found wrong point on capybara/result doc.
This PR fix it

## before
<img width="411" alt="screen shot 2018-10-31 at 14 41 08" src="https://user-images.githubusercontent.com/731436/47833133-98267180-dddc-11e8-8605-58cfd54ee264.png">


## after

<img width="325" alt="screen shot 2018-10-31 at 14 41 29" src="https://user-images.githubusercontent.com/731436/47833135-9ceb2580-dddc-11e8-8f9a-b487a4ef7648.png">
