### PR TITLE
Remove needless parameter[ci skip]

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -187,10 +187,11 @@ module Capybara
       #
       #     page.select 'March', from: 'Month'
       #
-      # @macro waiting_behavior
+      # @overload select(value = nil, from: nil, **options)
+      #   @macro waiting_behavior
       #
-      # @param value [String] Which option to select
-      # @param from [String]  The id, Capybara.test_id atrtribute, name or label of the select box
+      #   @param value [String] Which option to select
+      #   @param from [String]  The id, Capybara.test_id atrtribute, name or label of the select box
       #
       # @return [Capybara::Node::Element]  The option element selected
       def select(value = nil, from: nil, **options)
@@ -211,10 +212,12 @@ module Capybara
       #
       #     page.unselect 'March', from: 'Month'
       #
-      # @macro waiting_behavior
+      # @overload unselect(value = nil, from: nil, **options)
+      #   @macro waiting_behavior
       #
-      # @param value [String]     Which option to unselect
-      # @param from [String]      The id, Capybara.test_id attribute, name or label of the select box
+      #   @param value [String]     Which option to unselect
+      #   @param from [String]      The id, Capybara.test_id attribute, name or label of the select box
+      #
       #
       # @return [Capybara::Node::Element]  The option element unselected
       def unselect(value = nil, from: nil, **options)


### PR DESCRIPTION
Hi ✋ 
In `capybara/node/action.rb`, there is duplicated parameter about options hash, one in `Parameter` section and one is `Options 
 Hash (**options)` section.
This PR remove first one with @oveload directive.

## before
<img width="960" alt="screen shot 2018-11-01 at 1 29 42" src="https://user-images.githubusercontent.com/731436/47891450-a769f580-de96-11e8-913e-03d236a7b888.png">


## after
<img width="967" alt="screen shot 2018-11-01 at 1 29 35" src="https://user-images.githubusercontent.com/731436/47891455-aafd7c80-de96-11e8-8667-4761f2acf82e.png">
