### PR TITLE
Support a retrying before block for assert_selector/assert_no_selector

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -723,6 +723,10 @@ module Capybara
         args.first.is_a?(Symbol) ? args.shift : session_options.default_selector
       end
 
+      def extract_before_block(args)
+        args.last.is_a?(Hash) ? args.last.delete(:before) : nil
+      end
+
       def _verify_multiple(*args, wait: nil, **options)
         wait = session_options.default_max_wait_time if wait.nil?
         selector = extract_selector(args)
@@ -733,8 +737,10 @@ module Capybara
 
       def _verify_selector_result(query_args, optional_filter_block)
         query_args = _set_query_session_options(*query_args)
+        before_block = extract_before_block(query_args)
         query = Capybara::Queries::SelectorQuery.new(*query_args, &optional_filter_block)
         synchronize(query.wait) do
+          before_block&.call(self)
           yield query.resolve_for(self), query
         end
         true

--- a/lib/capybara/spec/session/has_selector_spec.rb
+++ b/lib/capybara/spec/session/has_selector_spec.rb
@@ -34,6 +34,18 @@ Capybara::SpecHelper.spec '#has_selector?' do
     expect(@session).to have_selector(:css, 'a', count: 1) { |el| el[:id] == 'foo' }
   end
 
+  context 'with a before block' do
+    it 'should run before the check' do
+      expect(@session).to have_selector(:field, 'test_field', with: '5', before: proc { |el| el.fill_in('test_field', with: '5') })
+    end
+
+    it 'should run before rechecks', requires: [:js] do
+      i = 0
+      bl = ->(el) { el.fill_in('test_field', with: (i += 1).to_s) }
+      expect(@session).to have_selector(:field, 'test_field', with: '5', before: bl)
+    end
+  end
+
   context 'with count' do
     it 'should be true if the content is on the page the given number of times' do
       expect(@session).to have_selector('//p', count: 3)


### PR DESCRIPTION
This is a potential addition to provide an easier solution to an issue that arose with chromedriver/chrome and hover (Firefox works fine).  The issue was that chromedriver doesn't appear to process mouse location as elements on the page are removed meaning CSS :hover doesn't appear to get processed if the call to `hover` occurs during animation.  This PR would add a `:before` option to assert_selector/assert_no_selector and all methods based on them.  The option takes a block which is executed before every time the assertion/expectation is checked
 
    el = find('#an_element')
    expect(page).to have_selector(:css, '.popup', before: { el.hover })

That would repeatedly call `el.hover` each time `have_selector` retries finding the popup element.  

I'm not fully sold on this approach yet since it really is only a way to work around browser deficiencies.  If I anyone can come up with non browser bug instances where this would be useful that would be helpful.