### PR TITLE
Fix :button selector evaluating :link_or_button expression filters

### DIFF
--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -161,11 +161,9 @@ Capybara.add_selector(:button) do
       image_btn_xpath = image_btn_xpath[alt_matches]
     end
 
-    res_xpath = input_btn_xpath.union(btn_xpath).union(image_btn_xpath)
-
-    res_xpath = expression_filters.keys.inject(res_xpath) { |memo, ef| memo[find_by_attr(ef, options[ef])] }
-
-    res_xpath
+    %i[value title type].inject(input_btn_xpath.union(btn_xpath).union(image_btn_xpath)) do |memo, ef|
+      memo[find_by_attr(ef, options[ef])]
+    end
   end
 
   node_filter(:disabled, :boolean, default: false, skip_if: :all) { |node, value| !(value ^ node.disabled?) }

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -416,6 +416,22 @@ RSpec.describe Capybara do
           expect(string.find(:element, 'input', title: XPath.contains_word('button 1'))[:type]).to eq 'button'
         end
       end
+
+      describe ':link_or_button selector' do
+        around(:all) do |example|
+          Capybara.modify_selector(:link_or_button) do
+            expression_filter(:random) { |xpath, _| xpath } # do nothing filter
+          end
+          example.run
+          Capybara::Selector.all[:link_or_button].expression_filters.delete(:random)
+        end
+
+        context 'when modified' do
+          it 'should still work' do
+            expect(string.find(:link_or_button, 'click me', random: 'blah').value).to eq 'click me'
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fix for issue mentioned in https://groups.google.com/forum/#!topic/ruby-capybara/-RBMNqYvEuo .

When the link_or_button selector combines the link and button selectors expression_filters refers to the link_or_button selector which ends up creating incorrect attribute matchers.  This fixes it by limiting to only expected attributes.
