### PR TITLE
Add Selenium Firefox Headless driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ and add it to your Gemfile if you're using bundler.
 Capybara pre-registers a number of named drives that use Selenium - they are:
 
   * :selenium                 => Selenium driving Firefox
+  * :selenium_headless        => Selenium driving Firefox in a headless configuration
   * :selenium_chrome          => Selenium driving Chrome
   * :selenium_chrome_headless => Selenium driving Chrome in a headless configuration
 

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -532,6 +532,13 @@ Capybara.register_driver :selenium do |app|
   Capybara::Selenium::Driver.new(app)
 end
 
+Capybara.register_driver :selenium_headless do |app|
+  Capybara::Selenium::Driver.load_selenium
+  browser_options = ::Selenium::WebDriver::Firefox::Options.new
+  browser_options.args << '-headless'
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: browser_options)
+end
+
 Capybara.register_driver :selenium_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome)
 end


### PR DESCRIPTION
Since Firefox is the default browser when using Selenium, and it's easy to get started using, it would be nice to include a headless configuration for Firefox. So that's what I've done in this PR. Now we can simply set our driver to `:selenium_firefox_headless` to use it.