### PR TITLE
HTML5 emulation continuation

### DIFF
--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -29,8 +29,11 @@ class Capybara::Selenium::Node
     HTML5_DRAG_DROP_SCRIPT = <<~JS
       var source = arguments[0];
       var target = arguments[1];
+      var sourceRect = source.getBoundingClientRect();
+      var targetRect = target.getBoundingClientRect();
 
       var dt = new DataTransfer();
+
       var opts = { cancelable: true, bubbles: true, dataTransfer: dt };
 
       if (source.tagName == 'A'){
@@ -44,8 +47,19 @@ class Capybara::Selenium::Node
       var dragEvent = new DragEvent('dragstart', opts);
       source.dispatchEvent(dragEvent);
       target.scrollIntoView({behavior: 'instant', block: 'center', inline: 'center'});
-      var dragOverEvent = new DragEvent('dragover', opts);
+
+      // fire 2 dragover events to simulate dragging with a direction
+      var dragOverX = sourceRect.x + source.clientWidth / 2;
+      var dragOverY = sourceRect.y + source.clientHeight / 2;
+      var dragOverOpts = Object.assign({clientX: dragOverX, clientY: dragOverY}, opts);
+      var dragOverEvent = new DragEvent('dragover', dragOverOpts);
       target.dispatchEvent(dragOverEvent);
+      dragOverX = targetRect.x + target.clientWidth / 2;
+      dragOverY = targetRect.y + target.clientHeight / 2;
+      dragOverOpts = Object.assign({clientX: dragOverX, clientY: dragOverY}, opts);
+      dragOverEvent = new DragEvent('dragover', dragOverOpts);
+      target.dispatchEvent(dragOverEvent);
+
       var dragLeaveEvent = new DragEvent('dragleave', opts);
       target.dispatchEvent(dragLeaveEvent);
       if (dragOverEvent.defaultPrevented) {

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -12,6 +12,7 @@ $(function() {
     ev.originalEvent.dataTransfer.setData("text", ev.target.id);
   });
   $('#drop_html5, #drop_html5_scroll').on('dragover', function(ev){
+    $(this).after('<div class="log">DragOver with client position: ' + ev.clientX + ',' + ev.clientY)
     if ($(this).hasClass('drop')) { ev.preventDefault(); }
   });
   $('#drop_html5, #drop_html5_scroll').on('drop', function(ev){

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -307,6 +307,15 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
         expect(session).to have_xpath('//div[contains(., "HTML5 Dropped drag_html5")]')
       end
 
+      it 'should set clientX/Y in dragover events' do
+        session.visit('/with_js')
+        element = session.find('//div[@id="drag_html5"]')
+        target = session.find('//div[@id="drop_html5"]')
+        element.drag_to(target)
+        session.all(:css, 'div.log').each { |el| puts el.text }
+        expect(session).to have_css('div.log', text: /DragOver with client position: [1-9]\d*,[1-9]\d*/, count: 2)
+      end
+
       it 'should not HTML5 drag and drop on a non HTML5 drop element' do
         session.visit('/with_js')
         element = session.find('//div[@id="drag_html5"]')


### PR DESCRIPTION
This builds on PR #2138 but changes the first dragover event clientX/Y to be the entry point to the target rect on the line joining the source center and target center.  It also adds a test to ensure clientX/Y locations are set.