### PR TITLE
Deal with race condition when reseting between tests

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -386,6 +386,11 @@ private
       raise Capybara::ExpectationNotMet, 'Timed out waiting for Selenium session reset' if timer.expired?
 
       sleep 0.01
+
+      # It has been observed that it is possible that asynchronous JS code in
+      # the application under test can navigate the browser away from about:blank
+      # if the timing is just right. Ensure we are still at about:blank... 
+      @browser.navigate.to('about:blank') if current_url != 'about:blank'
     end
   end
 

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -390,7 +390,7 @@ private
       # It has been observed that it is possible that asynchronous JS code in
       # the application under test can navigate the browser away from about:blank
       # if the timing is just right. Ensure we are still at about:blank... 
-      @browser.navigate.to('about:blank') if current_url != 'about:blank'
+      @browser.navigate.to('about:blank') unless current_url == 'about:blank'
     end
   end
 


### PR DESCRIPTION
Hello,

A while ago we were experiencing annoying intermittent test failures with "Timed out waiting for Selenium session reset"

After painstaking investigation I determined that our (Ember) application was reacting to the session being cleared and navigating the browser to our login page. 

This created a race condition where sometimes this happened *after* capybara had issued @browser.navigate.to('about:blank') but before the browser had actually gone there.

Thus the loop waiting for the page to be empty timed out because the browser was not at about:blank.

I monkey patched Capybara in our code base to add this check that we are actually at about:blank inside the loop, and navigate there again if we are not.

Since I did this, we have not encountered the problem again for 4 months.

It seems to me that there is a general problem here where JS applications under test could trigger a race condition by triggering a navigation at the wrong time, so I submit this change for consideration.

I could not see any specs that covered this area/behaviour so this is a change to production code only, but please let me know if there are specs somewhere I should have updated