### PR TITLE
Fix invalid class name in `Capybara::RSpec::Matchers#have_text` doc

### DIFF
--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -107,7 +107,7 @@ module Capybara
     #   See {Capybara::Node::Matchers#has_unchecked_field?}
 
     # RSpec matcher for text content
-    # See {Capybara::SessionMatchers#assert_text}
+    # See {Capybara::Node::Matchers#assert_text}
     def have_text(*args)
       Matchers::HaveText.new(*args)
     end


### PR DESCRIPTION
`Capybara::SessionMatchers#assert_text` -> `Capybara::Node::Matchers#assert_text`

https://github.com/teamcapybara/capybara/blob/a2552e2043753b3fb05b1d4db77f72ef2699187b/lib/capybara/node/matchers.rb#L666

#### Document screenshot

![image](https://user-images.githubusercontent.com/473530/55055375-1ba37080-50a6-11e9-999e-c679860c4812.png)

http://www.rubydoc.info/gems/capybara/3.15.0/Capybara/RSpecMatchers#have_text-instance_method