### PR TITLE
Fix missing constant when using :selenium_chrome

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -544,6 +544,7 @@ Capybara.register_driver :selenium_headless do |app|
 end
 
 Capybara.register_driver :selenium_chrome do |app|
+  Capybara::Selenium::Driver.load_selenium
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.args << '--disable-site-isolation-trials'


### PR DESCRIPTION
In versions 3.14+, this "uninitialized constant Selenium" error occurs when using the :selenium_chrome driver:

```
     2.2) Failure/Error:
            browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
              # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
              opts.args << '--disable-site-isolation-trials'
            end

          NameError:
            uninitialized constant Selenium
          # /Library/Ruby/Gems/2.3.0/gems/capybara-3.14.0/lib/capybara.rb:547:in `block in <top (required)>'
```
I believe that this error was introduced by this commit: https://github.com/teamcapybara/capybara/commit/b28912ff9764670fe400582b18e4390048cd37a0#diff-f6aa6c79750a9a5bd39ee17f3ade2974
