### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,7 @@ end
       include Capybara::Minitest::Assertions
 
       # Reset sessions and driver between tests
-      # Use super wherever this method is redefined in your individual test classes
-      def teardown
+      teardown do
         Capybara.reset_sessions!
         Capybara.use_default_driver
       end


### PR DESCRIPTION
There is a `teardown` callback available in Rails and using it eliminates any chance that `super` will not be called in overridden `setup` method.