### PR TITLE
Description was wrong

### DIFF
--- a/History.md
+++ b/History.md
@@ -14,7 +14,7 @@ Release date: 2019-05-09
 ### Added
 
 
-* Syntactic sugar `#once`, `#twice`, `#thrice`, `#excatly`, `#at_least`, `#at_most` to
+* Syntactic sugar `#once`, `#twice`, `#thrice`, `#exactly`, `#at_least`, `#at_most` to
   `have_selector`, `have_css`, `have_xpath`, and `have_text` RSpec matchers
 * Support for multiple expression types in Selector definitions
 * Reduced wirecalls for common actions in Selenium driver


### PR DESCRIPTION
I see no such method as `excatly`. Rather, I found `exactly`.