### PR TITLE
Simulate file/external data drop in chrome and firefox

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -69,6 +69,10 @@ module Capybara
         raise NotImplementedError
       end
 
+      def drop(*args)
+        raise NotImplementedError
+      end
+
       def scroll_by(x, y)
         raise NotImplementedError
       end

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -392,6 +392,16 @@ module Capybara
         self
       end
 
+      def drop(*args)
+        options = args.map do |arg|
+          return arg.to_path if arg.respond_to?(:to_path)
+
+          arg
+        end
+        synchronize { base.drop(*options) }
+        self
+      end
+
       ##
       #
       # Scroll the page or element

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -137,6 +137,10 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
     element.scroll_if_needed { browser_action.move_to(element.native).release.perform }
   end
 
+  def drop(*_)
+    raise NotImplementedError, 'Out of browser drop emulation is not implemented for the current browser'
+  end
+
   def tag_name
     @tag_name ||= native.tag_name.downcase
   end

--- a/lib/capybara/selenium/nodes/chrome_node.rb
+++ b/lib/capybara/selenium/nodes/chrome_node.rb
@@ -34,6 +34,10 @@ class Capybara::Selenium::ChromeNode < Capybara::Selenium::Node
     html5_drag_to(element)
   end
 
+  def drop(*args)
+    html5_drop(*args)
+  end
+
   def click(*)
     super
   rescue ::Selenium::WebDriver::Error::WebDriverError => e

--- a/lib/capybara/selenium/nodes/firefox_node.rb
+++ b/lib/capybara/selenium/nodes/firefox_node.rb
@@ -52,6 +52,10 @@ class Capybara::Selenium::FirefoxNode < Capybara::Selenium::Node
     html5_drag_to(element)
   end
 
+  def drop(*args)
+    html5_drop(*args)
+  end
+
   def hover
     return super unless browser_version >= 65.0
 

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -18,7 +18,33 @@ $(function() {
   });
   $('#drop_html5, #drop_html5_scroll').on('drop', function(ev){
     ev.preventDefault();
-    $(this).html('HTML5 Dropped ' + ev.originalEvent.dataTransfer.getData("text"));
+    var oev = ev.originalEvent;
+    if (oev.dataTransfer.items) {
+      for (var i = 0; i < oev.dataTransfer.items.length; i++){
+        var item = oev.dataTransfer.items[i];
+        if (item.kind === 'file'){
+          var file = item.getAsFile();
+          $(this).append('HTML5 Dropped file: ' + file.name);
+        } else {
+          var _this = this;
+          var callback = (function(type){
+            return function(s){
+              $(_this).append('HTML5 Dropped string: ' + type + ' ' + s)
+            }
+          })(item.type);
+          item.getAsString(callback);
+        }
+      }
+    } else {
+      $(this).html('HTML5 Dropped ' + oev.dataTransfer.getData("text"));
+      for (var i = 0; i < oev.dataTransfer.files.length; i++) {
+        $(this).append('HTML5 Dropped file: ' + oev.dataTransfer.files[i].name);
+      }
+      for (var i = 0; i < oev.dataTransfer.types.length; i++) {
+        var type = oev.dataTransfer.types[i];
+        $(this).append('HTML5 Dropped string: ' + type + ' ' + oev.dataTransfer.getData(type));
+      }
+    }
   });
   $('#clickable').click(function(e) {
     var link = $(this);

--- a/lib/capybara/spec/session/attach_file_spec.rb
+++ b/lib/capybara/spec/session/attach_file_spec.rb
@@ -199,10 +199,4 @@ Capybara::SpecHelper.spec '#attach_file' do
       expect(extract_results(@session)['hidden_image']).to end_with(File.basename(__FILE__))
     end
   end
-
-private
-
-  def with_os_path_separators(path)
-    Gem.win_platform? ? path.to_s.tr('/', '\\') : path.to_s
-  end
 end

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -124,6 +124,10 @@ module Capybara
     def be_an_invalid_element_error(session)
       satisfy { |error| session.driver.invalid_element_errors.any? { |e| error.is_a? e } }
     end
+
+    def with_os_path_separators(path)
+      Gem.win_platform? ? path.to_s.tr('/', '\\') : path.to_s
+    end
   end
 end
 

--- a/spec/selenium_spec_firefox.rb
+++ b/spec/selenium_spec_firefox.rb
@@ -64,6 +64,8 @@ Capybara::SpecHelper.run_specs TestSessions::SeleniumFirefox, 'selenium', capyba
     pending "Geckodriver doesn't provide a way to remove cookies outside the current domain"
   when 'Capybara::Session selenium #attach_file with a block can upload by clicking the file input'
     pending "Geckodriver doesn't allow clicking on file inputs"
+  when /drag_to.*HTML5/
+    pending "Firefox < 62 doesn't support a DataTransfer constuctor" if firefox_lt?(62.0, @session)
   end
 end
 

--- a/spec/selenium_spec_ie.rb
+++ b/spec/selenium_spec_ie.rb
@@ -110,6 +110,8 @@ Capybara::SpecHelper.run_specs TestSessions::SeleniumIE, 'selenium', capybara_sk
     pending 'IE treats blank href as a parent request (against HTML spec)'
   when /#attach_file with a block/
     skip 'Hangs IE testing for unknown reason'
+  when /drag_to.*HTML5/
+    pending "IE doesn't support a DataTransfer constuctor"
   end
 end
 

--- a/spec/selenium_spec_safari.rb
+++ b/spec/selenium_spec_safari.rb
@@ -73,6 +73,8 @@ Capybara::SpecHelper.run_specs TestSessions::Safari, SAFARI_DRIVER.to_s, capybar
   when 'Capybara::Session selenium_safari #go_back should fetch a response from the driver from the previous page',
        'Capybara::Session selenium_safari #go_forward should fetch a response from the driver from the previous page'
     skip 'safaridriver loses the ability to find elements in the document after `go_back`'
+  when /drag_to.*HTML5/
+    pending "Safari doesn't support"
   end
 end
 

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -303,57 +303,6 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
       end
     end
 
-    describe 'Element#drag_to' do
-      before do
-        skip "Firefox < 62 doesn't support a DataTransfer constuctor" if firefox_lt?(62.0, session)
-        skip "IE doesn't support a DataTransfer constuctor" if ie?(session)
-        skip "Safari doesn't support" if safari?(session)
-      end
-
-      it 'should HTML5 drag and drop an object' do
-        session.visit('/with_js')
-        element = session.find('//div[@id="drag_html5"]')
-        target = session.find('//div[@id="drop_html5"]')
-        element.drag_to(target)
-        expect(session).to have_xpath('//div[contains(., "HTML5 Dropped drag_html5")]')
-      end
-
-      it 'should set clientX/Y in dragover events' do
-        session.visit('/with_js')
-        element = session.find('//div[@id="drag_html5"]')
-        target = session.find('//div[@id="drop_html5"]')
-        element.drag_to(target)
-        session.all(:css, 'div.log').each { |el| puts el.text }
-        expect(session).to have_css('div.log', text: /DragOver with client position: [1-9]\d*,[1-9]\d*/, count: 2)
-      end
-
-      it 'should not HTML5 drag and drop on a non HTML5 drop element' do
-        session.visit('/with_js')
-        element = session.find('//div[@id="drag_html5"]')
-        target = session.find('//div[@id="drop_html5"]')
-        target.execute_script("$(this).removeClass('drop');")
-        element.drag_to(target)
-        sleep 1
-        expect(session).not_to have_xpath('//div[contains(., "HTML5 Dropped drag_html5")]')
-      end
-
-      it 'should HTML5 drag and drop when scrolling needed' do
-        session.visit('/with_js')
-        element = session.find('//div[@id="drag_html5_scroll"]')
-        target = session.find('//div[@id="drop_html5_scroll"]')
-        element.drag_to(target)
-        expect(session).to have_xpath('//div[contains(., "HTML5 Dropped drag_html5_scroll")]')
-      end
-
-      it 'should drag HTML5 default draggable elements' do
-        session.visit('/with_js')
-        link = session.find_link('drag_link_html5')
-        target = session.find(:id, 'drop_html5')
-        link.drag_to target
-        expect(session).to have_xpath('//div[contains(., "HTML5 Dropped")]')
-      end
-    end
-
     describe 'Capybara#Node#attach_file' do
       it 'can attach a directory' do
         pending "Geckodriver doesn't support uploading a directory" if firefox?(session)


### PR DESCRIPTION
I tried to simulate this for Safari as well, but there are two issues. It doesn't provide a `DataTransfer` constructor, however even if I worked around that by triggering a cut event to get access to a system built `DataTransfer` instance that object won't allow me to add files to it (just silently ignores).