### PR TITLE
Add missing `match` option to `Capybara.configure` API doc

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -89,6 +89,7 @@ module Capybara
     # [predicates_wait = Boolean]  Whether Capybaras predicate matchers use waiting behavior by default (Default: true)
     # [default_normalize_ws = Boolean] Whether text predicates and matchers use normalize whitespace behaviour (Default: false)
     # [allow_gumbo = Boolean] When `nokogumbo` is available, whether it will be used to parse HTML strings (Default: false)
+    # [match = :one/:first/:prefer_exact/:smart] The matching strategy to find nodes (Default: :smart)
     #
     # === DSL Options
     #


### PR DESCRIPTION
This change is extracted from #2190.

For the default value:
https://github.com/teamcapybara/capybara/blob/2585c0ef6ad113e04e71b11ea9220f6ae8b9d978/lib/capybara.rb#L489

For the available values:
https://github.com/teamcapybara/capybara/blob/2585c0ef6ad113e04e71b11ea9220f6ae8b9d978/lib/capybara/queries/selector_query.rb#L9

See also:
https://github.com/teamcapybara/capybara/blob/2585c0ef6ad113e04e71b11ea9220f6ae8b9d978/lib/capybara/node/finders.rb#L314
https://github.com/teamcapybara/capybara/blob/2585c0ef6ad113e04e71b11ea9220f6ae8b9d978/lib/capybara/node/finders.rb#L318