### PR TITLE
Use `@example` YARD tag for `Capybara.string` API doc

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -201,15 +201,13 @@ module Capybara
     # any string containing HTML in the exact same way you would query the current document in a Capybara
     # session.
     #
-    # Example: A single element
-    #
+    # @example A single element
     #     node = Capybara.string('<a href="foo">bar</a>')
     #     anchor = node.first('a')
     #     anchor[:href] #=> 'foo'
     #     anchor.text #=> 'bar'
     #
-    # Example: Multiple elements
-    #
+    # @example Multiple elements
     #     node = Capybara.string <<-HTML
     #       <ul>
     #         <li id="home">Home</li>


### PR DESCRIPTION
The YARD `@example` tag (which can take an optional title) makes a generated HTML a bit more readable.
See the [YARD doc](https://www.rubydoc.info/gems/yard/file/docs/Tags.md#example).

This change is extracted from #2190.

## Before

![image](https://user-images.githubusercontent.com/473530/58137968-51f90880-7c6f-11e9-9b9d-c5c1c5f9a59c.png)

## After

![image](https://user-images.githubusercontent.com/473530/58137978-5d4c3400-7c6f-11e9-846b-c764c879a592.png)
