### PR TITLE
Small improvements for `Capybara::Helpers` API doc

### DIFF
--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -41,7 +41,7 @@ module Capybara
     ##
     #
     # Injects a `<base>` tag into the given HTML code, pointing to
-    # `Capybara.asset_host`.
+    # {Capybara.configure asset_host}.
     #
     # @param [String] html     HTML code to inject into
     # @param [URL] host (Capybara.asset_host) The host from which assets should be loaded


### PR DESCRIPTION
- Change plain-text references to links.
- ~~Use the YARD syntax for inline code, instead of the Markdown syntax.~~ See https://github.com/teamcapybara/capybara/pull/2198#discussion_r286291677.

This change is extracted from #2190.