### PR TITLE
Improve `waiting_behavior` YARD macro

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -6,9 +6,10 @@ module Capybara
       # @!macro waiting_behavior
       #   If the driver is capable of executing JavaScript, this method will wait for a set amount of time
       #   and continuously retry finding the element until either the element is found or the time
-      #   expires. The length of time +find+ will wait is controlled through {Capybara.default_max_wait_time}
+      #   expires. The length of time this method will wait is controlled through {Capybara.configure default_max_wait_time}.
       #
-      #   @option options [false, true, Numeric] wait (Capybara.default_max_wait_time) Maximum time to wait for matching element to appear.
+      #   @option options [false, true, Numeric] wait
+      #     Maximum time to wait for matching element to appear. Defaults to {Capybara.configure default_max_wait_time}.
 
       ##
       #

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -8,18 +8,13 @@ module Capybara
       # Find an {Capybara::Node::Element} based on the given arguments. +find+ will raise an error if the element
       # is not found.
       #
-      # @!macro waiting_behavior
-      #   If the driver is capable of executing JavaScript, this method will wait for a set amount of time
-      #   and continuously retry finding the element until either the element is found or the time
-      #   expires. The length of time +find+ will wait is controlled through {Capybara.default_max_wait_time}
-      #   and defaults to 2 seconds.
-      #   @option options [false, true, Numeric] wait (Capybara.default_max_wait_time) Maximum time to wait for matching element to appear.
-      #
       #  page.find('#foo').find('.bar')
       #  page.find(:xpath, './/div[contains(., "bar")]')
       #  page.find('li', text: 'Quox').click_link('Delete')
       #
       # @param (see Capybara::Node::Finders#all)
+      #
+      # @macro waiting_behavior
       #
       # @!macro system_filters
       #   @option options [String, Regexp] text      Only find elements which contain this text or match this regexp


### PR DESCRIPTION
## Summary

- Unify the almost same macro definitions defined both in `Capybara::Node::Actions` and `Capybara::Node::Finders`.
- ~~The new macro definition is in `Capybara::Node::Base`.~~
  - ~~Please give me help if anyone knows a better place! 🙏~~
  - **→Resolved. See <https://github.com/teamcapybara/capybara/pull/2199#issuecomment-495012213>.**
- Change the `+find+` word in the macro to `this method`.
  - See <https://github.com/teamcapybara/capybara/pull/2190/files#r285646233>.

This change is extracted from #2190.