### PR TITLE
Add missing doc of the `exact_text` option

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -90,6 +90,7 @@ module Capybara
     # [default_normalize_ws = Boolean] Whether text predicates and matchers use normalize whitespace behaviour (Default: false)
     # [allow_gumbo = Boolean] When `nokogumbo` is available, whether it will be used to parse HTML strings (Default: false)
     # [match = :one/:first/:prefer_exact/:smart] The matching strategy to find nodes (Default: :smart)
+    # [exact_text = Boolean] Whether text must be an exact match or is just a substring (Default: false)
     #
     # === DSL Options
     #

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -90,7 +90,7 @@ module Capybara
     # [default_normalize_ws = Boolean] Whether text predicates and matchers use normalize whitespace behaviour (Default: false)
     # [allow_gumbo = Boolean] When `nokogumbo` is available, whether it will be used to parse HTML strings (Default: false)
     # [match = :one/:first/:prefer_exact/:smart] The matching strategy to find nodes (Default: :smart)
-    # [exact_text = Boolean] Whether text must be an exact match or is just a substring (Default: false)
+    # [exact_text = Boolean] Whether the text matchers and `:text` filter match exactly or on substrings (Default: false)
     #
     # === DSL Options
     #


### PR DESCRIPTION
For the default value, see below:
https://github.com/teamcapybara/capybara/blob/101bb45ad674b1827fc43c625d8640447d0819cc/lib/capybara.rb#L490