### PR TITLE
Improve `Capybara::Driver::Node#set` API doc

### DIFF
--- a/lib/capybara/driver/node.rb
+++ b/lib/capybara/driver/node.rb
@@ -31,8 +31,8 @@ module Capybara
         raise NotImplementedError
       end
 
-      # @param value String or Array. Array is only allowed if node has 'multiple' attribute
-      # @param options [Hash{}] Driver specific options for how to set a value on a node
+      # @param value [String, Array] Array is only allowed if node has 'multiple' attribute
+      # @param options [Hash] Driver specific options for how to set a value on a node
       def set(value, **options)
         raise NotImplementedError
       end


### PR DESCRIPTION
This fixes just `@param` types of the `#set` method. It's a small fix.
Also, this omits the `options` parameter's default value. It's explicit from the method signature.

[skip ci]

<img width="666" alt="image" src="https://user-images.githubusercontent.com/473530/58379143-d387c800-7fda-11e9-95e0-1c51a6c239ce.png">
