### PR TITLE
Fix `Capybara` and `Selector` docs a bit [skip ci]

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -95,7 +95,7 @@ module Capybara
     # - **server** (Symbol = `:default` (which uses puma)) - The name of the registered server to use when running the app under test.
     # - **server_errors** (Array\<Class> = `[Exception]`) - Error classes that should be raised in the tests if they are raised in the server
     #   and {configure raise_server_errors} is `true`.
-    # - **test_id** (`Symbol`, `String`, `nil` = `nil`) - Optional attribute to match locator against with built-in selectors along with id.
+    # - **test_id** (Symbol, String, `nil` = `nil`) - Optional attribute to match locator against with built-in selectors along with id.
     # - **threadsafe** (Boolean = `false`) - Whether sessions can be configured individually.
     #
     # #### DSL Options

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -8,7 +8,7 @@ require 'capybara/selector/definition'
 # All Selectors below support the listed selector specific filters in addition to the following system-wide filters
 #   * :id (String, Regexp, XPath::Expression) - Matches the id attribute
 #   * :class (String, Array<String>, Regexp, XPath::Expression) - Matches the class(es) provided
-#   * :style (String, Regexp, Hash<String,String>) - Match on elements style
+#   * :style (String, Regexp, Hash<String, String>) - Match on elements style
 #
 # ### Built-in Selectors
 #
@@ -146,7 +146,7 @@ require 'capybara/selector/definition'
 #       * :cols (Array<Array<String>>) - Match all `<td>`s - visibility of `<td>` elements is not considered
 #
 # * **:table_row** - Find table row
-#   * Locator: Array<String>, Hash<String,String> table row `<td>` contents - visibility of `<td>` elements is not considered
+#   * Locator: Array<String>, Hash<String, String> table row `<td>` contents - visibility of `<td>` elements is not considered
 #
 # * **:frame** - Find frame/iframe elements
 #   * Locator: Match id or name
@@ -156,7 +156,7 @@ require 'capybara/selector/definition'
 # * **:element**
 #   * Locator: Type of element ('div', 'a', etc) - if not specified defaults to '*'
 #   * Filters:
-#       * :&lt;any> (String, Regexp) - Match on any specified element attribute
+#       * :\<any> (String, Regexp) - Match on any specified element attribute
 #
 class Capybara::Selector; end
 


### PR DESCRIPTION
The current docs (v3.22.0):
- [`Capybara.configure`](https://www.rubydoc.info/gems/capybara/3.22.0/Capybara#configure-class_method)
- [`Capybara::Selector`](https://www.rubydoc.info/gems/capybara/3.22.0/Capybara/Selector)
