### PR TITLE
Optionally allow `all` results to be reloaded when stale

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,8 @@ Release date: unreleased
   any breaking changes, but due to the nature of the 2.7 changes and some selector types accepting
   Hashes as locators there are a lot of edge cases. If you find any broken cases please report
   them and I'll see if they're fixable.
+* Optionally allow `all` results to be reloaded when stable - Beta feature - may be removed in
+  future version
 
 # Version 3.30.0
 Release date: 2019-12-24

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -27,9 +27,11 @@ module Capybara
         @query_scope = query_scope
         @query = query
         @allow_reload = false
+        @query_idx = nil
       end
 
-      def allow_reload!
+      def allow_reload!(idx = nil)
+        @query_idx = idx
         @allow_reload = true
       end
 
@@ -545,14 +547,13 @@ module Capybara
 
       # @api private
       def reload
-        if @allow_reload
-          begin
-            reloaded = @query.resolve_for(query_scope.reload)&.first
+        return self unless @allow_reload
 
-            @base = reloaded.base if reloaded
-          rescue StandardError => e
-            raise e unless catch_error?(e)
-          end
+        begin
+          reloaded = @query.resolve_for(query_scope.reload)[@query_idx.to_i]
+          @base = reloaded.base if reloaded
+        rescue StandardError => e
+          raise e unless catch_error?(e)
         end
         self
       end

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -235,13 +235,16 @@ module Capybara
       # @option options [Integer] maximum          Maximum number of matches that are expected to be found
       # @option options [Integer] minimum          Minimum number of matches that are expected to be found
       # @option options [Range]   between          Number of matches found must be within the given range
+      # @option options [Boolean] allow_reload     Beta feature - May be removed in any version.
+      #   When `true` allows elements to be reloaded if they become stale. This is an advanced behavior and should only be used
+      #   if you fully understand the potential ramifications. The results can be confusing on dynamic pages. Defaults to `false`
       # @overload all([kind = Capybara.default_selector], locator = nil, **options)
       # @overload all([kind = Capybara.default_selector], locator = nil, **options, &filter_block)
       #   @yieldparam element [Capybara::Node::Element]  The element being considered for inclusion in the results
       #   @yieldreturn [Boolean]                     Should the element be considered in the results?
       # @return [Capybara::Result]                   A collection of found elements
       # @raise [Capybara::ExpectationNotMet]         The number of elements found doesn't match the specified conditions
-      def all(*args, **options, &optional_filter_block)
+      def all(*args, allow_reload: false, **options, &optional_filter_block)
         minimum_specified = options_include_minimum?(options)
         options = { minimum: 1 }.merge(options) unless minimum_specified
         options[:session_options] = session_options
@@ -250,6 +253,7 @@ module Capybara
         begin
           synchronize(query.wait) do
             result = query.resolve_for(self)
+            result.allow_reload! if allow_reload
             raise Capybara::ExpectationNotMet, result.failure_message unless result.matches_count?
 
             result

--- a/lib/capybara/node/simple.rb
+++ b/lib/capybara/node/simple.rb
@@ -152,7 +152,7 @@ module Capybara
         yield # simple nodes don't need to wait
       end
 
-      def allow_reload!
+      def allow_reload!(*)
         # no op
       end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -11,7 +11,7 @@
       <option>Miss</option>
       <option disabled="disabled">Other</option>
     </select>
-    </p>
+  </p>
 
   <p>
     <label for="customer_name">Customer Name


### PR DESCRIPTION
When running through a list of links on a page with code like

    all('#my_container a').each do |link|
      link.click
      expect(page).to have_text 'something'
      go_back
    end

it would be nice to allow the `all` results to be reloaded, otherwise the elements will be stale.  This should not be the default behavior because on dynamic pages or pages with changing sets of links between refreshes the results can be highly confusing.  
