### PR TITLE
Fix code example indentations in YARD

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -141,8 +141,8 @@ module Capybara
       # or descendants of the current node.  If options are provided, the assertion
       # will check that each locator is present with those options as well (other than `:wait`).
       #
-      #   page.assert_all_of_selectors(:custom, 'Tom', 'Joe', visible: all)
-      #   page.assert_all_of_selectors(:css, '#my_div', 'a.not_clicked')
+      #     page.assert_all_of_selectors(:custom, 'Tom', 'Joe', visible: all)
+      #     page.assert_all_of_selectors(:css, '#my_div', 'a.not_clicked')
       #
       # It accepts all options that {Capybara::Node::Finders#all} accepts,
       # such as `:text` and `:visible`.
@@ -162,8 +162,8 @@ module Capybara
       # or descendants of the current node. If options are provided, the assertion
       # will check that each locator is not present with those options as well (other than `:wait`).
       #
-      #   page.assert_none_of_selectors(:custom, 'Tom', 'Joe', visible: all)
-      #   page.assert_none_of_selectors(:css, '#my_div', 'a.not_clicked')
+      #     page.assert_none_of_selectors(:custom, 'Tom', 'Joe', visible: all)
+      #     page.assert_none_of_selectors(:css, '#my_div', 'a.not_clicked')
       #
       # It accepts all options that {Capybara::Node::Finders#all} accepts,
       # such as `:text` and `:visible`.
@@ -183,8 +183,8 @@ module Capybara
       # or descendants of the current node. If options are provided, the assertion
       # will check that each locator is present with those options as well (other than `:wait`).
       #
-      #   page.assert_any_of_selectors(:custom, 'Tom', 'Joe', visible: all)
-      #   page.assert_any_of_selectors(:css, '#my_div', 'a.not_clicked')
+      #     page.assert_any_of_selectors(:custom, 'Tom', 'Joe', visible: all)
+      #     page.assert_any_of_selectors(:css, '#my_div', 'a.not_clicked')
       #
       # It accepts all options that {Capybara::Node::Finders#all} accepts,
       # such as `:text` and `:visible`.


### PR DESCRIPTION
Because the YARD option `--markup markdown` has been given since PR #2210, **4** spaces is needed for code snippet (code example) instead of 2 spaces.

For example, see <https://www.rubydoc.info/gems/capybara/3.26.0/Capybara/Node/Matchers#assert_all_of_selectors-instance_method>.

![image](https://user-images.githubusercontent.com/473530/61424710-5e3bd200-a94f-11e9-9acb-77e48c6bd440.png)

See also the [Markdown spec](https://daringfireball.net/projects/markdown/syntax#precode) below:

> To produce a code block in Markdown, simply indent every line of the block by at least 4 spaces or 1 tab.

[skip ci]