### PR TITLE
Use `@see` tag of YARD instead of plain text "see"

### DIFF
--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -9,38 +9,38 @@ module Capybara
       ## Assert text exists
       #
       # @!method assert_text
-      #  see {Capybara::Node::Matchers#assert_text}
+      #   @see Capybara::Node::Matchers#assert_text
 
       ## Assert text does not exist
       #
       # @!method assert_no_text
-      #  see {Capybara::Node::Matchers#assert_no_text}
+      #   @see Capybara::Node::Matchers#assert_no_text
 
       ##
       # Assertion that page title does match
       #
       # @!method assert_title
-      #   see {Capybara::Node::DocumentMatchers#assert_title}
+      #   @see Capybara::Node::DocumentMatchers#assert_title
 
       ##
       # Assertion that page title does not match
       #
       # @!method refute_title
       # @!method assert_no_title
-      #   see {Capybara::Node::DocumentMatchers#assert_no_title}
+      #   @see Capybara::Node::DocumentMatchers#assert_no_title
 
       ##
       # Assertion that current path matches
       #
       # @!method assert_current_path
-      #   see {Capybara::SessionMatchers#assert_current_path}
+      #   @see Capybara::SessionMatchers#assert_current_path
 
       ##
       # Assertion that current page does not match
       #
       # @!method refute_current_path
       # @!method assert_no_current_path
-      #   see {Capybara::SessionMatchers#assert_no_current_path}
+      #   @see Capybara::SessionMatchers#assert_no_current_path
 
       %w[text no_text title no_title current_path no_current_path].each do |assertion_name|
         class_eval <<-ASSERTION, __FILE__, __LINE__ + 1
@@ -64,37 +64,37 @@ module Capybara
       ## Assert selector exists on page
       #
       # @!method assert_selector
-      #   see {Capybara::Node::Matchers#assert_selector}
+      #   @see Capybara::Node::Matchers#assert_selector
 
       ## Assert selector does not exist on page
       #
       # @!method assert_no_selector
-      #   see {Capybara::Node::Matchers#assert_no_selector}
+      #   @see Capybara::Node::Matchers#assert_no_selector
 
       ## Assert element matches selector
       #
       # @!method assert_matches_selector
-      #   see {Capybara::Node::Matchers#assert_matches_selector}
+      #   @see Capybara::Node::Matchers#assert_matches_selector
 
       ## Assert element does not match selector
       #
       # @!method assert_xpath
-      #   see {Capybara::Node::Matchers#assert_not_matches_selector}
+      #   @see Capybara::Node::Matchers#assert_not_matches_selector
 
       ## Assert element has the provided CSS styles
       #
       # @!method assert_matches_style
-      #   see {Capybara::Node::Matchers#assert_matches_style}
+      #   @see Capybara::Node::Matchers#assert_matches_style
 
       ## Assert element has a matching sibling
       #
       # @!method assert_sibling
-      #   see {Capybara::Node::Matchers#assert_sibling}
+      #   @see Capybara::Node::Matchers#assert_sibling
 
       ## Assert element has a matching ancestor
       #
       # @!method assert_ancestor
-      #   see {Capybara::Node::Matchers#assert_ancestor}
+      #   @see Capybara::Node::Matchers#assert_ancestor
 
       %w[selector no_selector matches_style
          all_of_selectors none_of_selectors any_of_selectors
@@ -163,72 +163,72 @@ module Capybara
     # Assertion that there is xpath
     #
     # @!method assert_xpath
-    #   see {Capybara::Node::Matchers#has_xpath?}
+    #   @see Capybara::Node::Matchers#has_xpath?
 
     ##
     # Assertion that there is no xpath
     #
     # @!method refute_xpath
     # @!method assert_no_xpath
-    #   see {Capybara::Node::Matchers#has_no_xpath?}
+    #   @see Capybara::Node::Matchers#has_no_xpath?
 
     ##
     # Assertion that there is css
     #
     # @!method assert_css
-    #   see {Capybara::Node::Matchers#has_css?}
+    #   @see Capybara::Node::Matchers#has_css?
 
     ##
     # Assertion that there is no css
     #
     # @!method refute_css
     # @!method assert_no_css
-    #   see {Capybara::Node::Matchers#has_no_css?}
+    #   @see Capybara::Node::Matchers#has_no_css?
 
     ##
     # Assertion that there is link
     #
     # @!method assert_link
-    #   see {Capybara::Node::Matchers#has_link?}
+    #   @see Capybara::Node::Matchers#has_link?
 
     ##
     # Assertion that there is no link
     #
     # @!method assert_no_link
     # @!method refute_link
-    # see {Capybara::Node::Matchers#has_no_link?}
+    #   @see Capybara::Node::Matchers#has_no_link?
 
     ##
     # Assertion that there is button
     #
     # @!method assert_button
-    #   see {Capybara::Node::Matchers#has_button?}
+    #   @see Capybara::Node::Matchers#has_button?
 
     ##
     # Assertion that there is no button
     #
     # @!method refute_button
     # @!method assert_no_button
-    #   see {Capybara::Node::Matchers#has_no_button?}
+    #   @see Capybara::Node::Matchers#has_no_button?
 
     ##
     # Assertion that there is field
     #
     # @!method assert_field
-    #   see {Capybara::Node::Matchers#has_field?}
+    #   @see Capybara::Node::Matchers#has_field?
 
     ##
     # Assertion that there is no field
     #
     # @!method refute_field
     # @!method assert_no_field
-    #   see {Capybara::Node::Matchers#has_no_field?}
+    #   @see Capybara::Node::Matchers#has_no_field?
 
     ##
     # Assertion that there is checked_field
     #
     # @!method assert_checked_field
-    #   see {Capybara::Node::Matchers#has_checked_field?}
+    #   @see Capybara::Node::Matchers#has_checked_field?
 
     ##
     # Assertion that there is no checked_field
@@ -240,7 +240,7 @@ module Capybara
     # Assertion that there is unchecked_field
     #
     # @!method assert_unchecked_field
-    #   see {Capybara::Node::Matchers#has_unchecked_field?}
+    #   @see Capybara::Node::Matchers#has_unchecked_field?
 
     ##
     # Assertion that there is no unchecked_field
@@ -252,27 +252,27 @@ module Capybara
     # Assertion that there is select
     #
     # @!method assert_select
-    #   see {Capybara::Node::Matchers#has_select?}
+    #   @see Capybara::Node::Matchers#has_select?
 
     ##
     # Assertion that there is no select
     #
     # @!method refute_select
     # @!method assert_no_select
-    #   see {Capybara::Node::Matchers#has_no_select?}
+    #   @see Capybara::Node::Matchers#has_no_select?
 
     ##
     # Assertion that there is table
     #
     # @!method assert_table
-    #   see {Capybara::Node::Matchers#has_table?}
+    #   @see Capybara::Node::Matchers#has_table?
 
     ##
     # Assertion that there is no table
     #
     # @!method refute_table
     # @!method assert_no_table
-    #   see {Capybara::Node::Matchers#has_no_table?}
+    #   @see Capybara::Node::Matchers#has_no_table?
 
     private
 


### PR DESCRIPTION
Current doc: <http://www.rubydoc.info/gems/capybara/3.26.0/Capybara/Minitest/Assertions>

About `@see` tag: <https://www.rubydoc.info/gems/yard/file/docs/Tags.md#see>

[skip ci]