### PR TITLE
Add `no-sandbox` option for selenium_chrome_headless

### DIFF
--- a/lib/capybara/registrations/drivers.rb
+++ b/lib/capybara/registrations/drivers.rb
@@ -28,6 +28,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.args << '--headless'
+    opts.args << "--no-sandbox"
     opts.args << '--disable-gpu' if Gem.win_platform?
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.args << '--disable-site-isolation-trials'


### PR DESCRIPTION
## Issue

When I tried to run RSpec on my docker environment, I ran into an error:

```
     Selenium::WebDriver::Error::UnknownError:
       unknown error: Chrome failed to start: exited abnormally
         (unknown error: DevToolsActivePort file doesn't exist)
         (The process started from chrome location /usr/bin/chromium is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

## Cause

Enabling Chrome sandbox causes this error.

> Passing '--no-sandbox' flag when creating your WebDriver session. Special test environments sometimes cause Chrome to crash when the sandbox is enabled.

via. [Chrome doesn't start or crashes immediately - ChromeDriver - WebDriver for Chrome](https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start)

## Solution

Adding `--no-sandbox` option fixed the issue.

## Environment

My `Dockerfile` is:

```dockerfile
FROM ruby:2.6
RUN apt-get update -qq && apt-get install -y nodejs chromium-driver
```

Base image is `ryby:2.6` and `chromium-driver` is installed.