### PR TITLE
Fix eaddrinuse

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -105,10 +105,23 @@ module Capybara
     end
 
     def find_available_port(host)
-      server = TCPServer.new(host, 0)
-      server.addr[1]
-    ensure
-      server&.close
+      port = 0
+      while port.zero?
+        begin
+          server = TCPServer.new(host, port)
+          port = server.addr[1]
+        ensure
+          server&.close
+        end
+        begin
+          server = TCPServer.new(host, port)
+        rescue Errno::EADDRINUSE
+          port = 0
+        ensure
+          server&.close
+        end
+      end
+      port
     end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -74,6 +74,21 @@ RSpec.describe Capybara::Server do
     end
   end
 
+  def use_port(host, port)
+    server = TCPServer.new(host, port)
+  ensure
+    server&.close
+  end
+
+  it 'should handle that getting available ports fails randomly' do
+    expect {
+      100000.times do |count|
+        port = Capybara::Server.new(Object.new).send(:find_available_port, "0.0.0.0")
+        use_port("0.0.0.0", port)
+      end
+    }.not_to raise_error
+  end
+
   it 'should return its #base_url' do
     app = proc { |_env| [200, {}, ['Hello Server!']] }
     server = described_class.new(app).boot

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -81,12 +81,12 @@ RSpec.describe Capybara::Server do
   end
 
   it 'should handle that getting available ports fails randomly' do
-    expect {
-      100000.times do |count|
-        port = Capybara::Server.new(Object.new).send(:find_available_port, "0.0.0.0")
-        use_port("0.0.0.0", port)
+    expect do
+      100000.times do
+        port = described_class.new(Object.new).send(:find_available_port, '0.0.0.0')
+        use_port('0.0.0.0', port)
       end
-    }.not_to raise_error
+    end.not_to raise_error
   end
 
   it 'should return its #base_url' do


### PR DESCRIPTION
This fixes a problem where Capybara is trying to boot a server and throws an `Errno::EADDRINUSE` exception.

I know the test is calling a private method, however, I don't know how you would like that to be dealt with, or if it is OK.