### PR TITLE
Fix keyword argument separation warnings on Ruby master

### DIFF
--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -23,7 +23,7 @@ module Capybara
       # @return [Capybara::Node::Element]  The element clicked
       #
       def click_link_or_button(locator = nil, **options)
-        find(:link_or_button, locator, options).click
+        find(:link_or_button, locator, **options).click
       end
       alias_method :click_on, :click_link_or_button
 
@@ -39,7 +39,7 @@ module Capybara
       #
       # @return [Capybara::Node::Element]  The element clicked
       def click_link(locator = nil, **options)
-        find(:link, locator, options).click
+        find(:link, locator, **options).click
       end
 
       ##
@@ -55,7 +55,7 @@ module Capybara
       #   @param [Hash] options        See {Capybara::Node::Finders#find_button}
       # @return [Capybara::Node::Element]  The element clicked
       def click_button(locator = nil, **options)
-        find(:button, locator, options).click
+        find(:button, locator, **options).click
       end
 
       ##
@@ -88,7 +88,7 @@ module Capybara
       def fill_in(locator = nil, with:, currently_with: nil, fill_options: {}, **find_options)
         find_options[:with] = currently_with if currently_with
         find_options[:allow_self] = true if locator.nil?
-        find(:fillable_field, locator, find_options).set(with, fill_options)
+        find(:fillable_field, locator, **find_options).set(with, **fill_options)
       end
 
       # @!macro label_click
@@ -119,7 +119,7 @@ module Capybara
       #
       # @return [Capybara::Node::Element]  The element chosen or the label clicked
       def choose(locator = nil, **options)
-        _check_with_label(:radio_button, true, locator, options)
+        _check_with_label(:radio_button, true, locator, **options)
       end
 
       ##
@@ -147,7 +147,7 @@ module Capybara
       #
       # @return [Capybara::Node::Element]  The element checked or the label clicked
       def check(locator = nil, **options)
-        _check_with_label(:checkbox, true, locator, options)
+        _check_with_label(:checkbox, true, locator, **options)
       end
 
       ##
@@ -175,7 +175,7 @@ module Capybara
       #
       # @return [Capybara::Node::Element]  The element unchecked or the label clicked
       def uncheck(locator = nil, **options)
-        _check_with_label(:checkbox, false, locator, options)
+        _check_with_label(:checkbox, false, locator, **options)
       end
 
       ##
@@ -205,7 +205,7 @@ module Capybara
         if el.respond_to?(:tag_name) && (el.tag_name == 'input')
           select_datalist_option(el, value)
         else
-          el.find(:option, value, options).select_option
+          el.find(:option, value, **options).select_option
         end
       end
 
@@ -229,8 +229,8 @@ module Capybara
       def unselect(value = nil, from: nil, **options)
         raise ArgumentError, 'The :from option does not take an element' if from.is_a? Capybara::Node::Element
 
-        scope = from ? find(:select, from, options) : self
-        scope.find(:option, value, options).unselect_option
+        scope = from ? find(:select, from, **options) : self
+        scope.find(:option, value, **options).unselect_option
       end
 
       ##
@@ -295,10 +295,10 @@ module Capybara
         end
         # Allow user to update the CSS style of the file input since they are so often hidden on a page
         if make_visible
-          ff = file_field || find(:file_field, locator, options.merge(visible: :all))
+          ff = file_field || find(:file_field, locator, **options.merge(visible: :all))
           while_visible(ff, make_visible) { |el| el.set(paths) }
         else
-          (file_field || find(:file_field, locator, options)).set(paths)
+          (file_field || find(:file_field, locator, **options)).set(paths)
         end
       end
 
@@ -307,12 +307,12 @@ module Capybara
       def find_select_or_datalist_input(from, options)
         synchronize(Capybara::Queries::BaseQuery.wait(options, session_options.default_max_wait_time)) do
           begin
-            find(:select, from, options)
+            find(:select, from,** options)
           rescue Capybara::ElementNotFound => select_error # rubocop:disable Naming/RescuedExceptionsVariableName
             raise if %i[selected with_selected multiple].any? { |option| options.key?(option) }
 
             begin
-              find(:datalist_input, from, options)
+              find(:datalist_input, from, **options)
             rescue Capybara::ElementNotFound => dlinput_error # rubocop:disable Naming/RescuedExceptionsVariableName
               raise Capybara::ElementNotFound, "#{select_error.message} and #{dlinput_error.message}"
             end
@@ -337,7 +337,7 @@ module Capybara
         if visible_css == true
           visible_css = { opacity: 1, display: 'block', visibility: 'visible', width: 'auto', height: 'auto' }
         end
-        _update_style(element, visible_css)
+        _update_style(element, **visible_css)
         raise ExpectationNotMet, 'The style changes in :make_visible did not make the file input visible' unless element.visible?
 
         begin
@@ -364,13 +364,13 @@ module Capybara
 
         synchronize(Capybara::Queries::BaseQuery.wait(options, session_options.default_max_wait_time)) do
           begin
-            el = find(selector, locator, options)
+            el = find(selector, locator, **options)
             el.set(checked)
           rescue StandardError => e
             raise unless allow_label_click && catch_error?(e)
 
             begin
-              el ||= find(selector, locator, options.merge(visible: :all))
+              el ||= find(selector, locator, **options.merge(visible: :all))
               el.session.find(:label, for: el, visible: true).click unless el.checked? == checked
             rescue StandardError # swallow extra errors - raise original
               raise e

--- a/lib/capybara/node/actions.rb
+++ b/lib/capybara/node/actions.rb
@@ -307,7 +307,7 @@ module Capybara
       def find_select_or_datalist_input(from, options)
         synchronize(Capybara::Queries::BaseQuery.wait(options, session_options.default_max_wait_time)) do
           begin
-            find(:select, from,** options)
+            find(:select, from, **options)
           rescue Capybara::ElementNotFound => select_error # rubocop:disable Naming/RescuedExceptionsVariableName
             raise if %i[selected with_selected multiple].any? { |option| options.key?(option) }
 

--- a/lib/capybara/node/document.rb
+++ b/lib/capybara/node/document.rb
@@ -28,7 +28,7 @@ module Capybara
       #
       # @return [String]    The title of the document
       #
-      def title
+      def title(**)
         session.driver.title
       end
 

--- a/lib/capybara/node/document.rb
+++ b/lib/capybara/node/document.rb
@@ -28,7 +28,7 @@ module Capybara
       #
       # @return [String]    The title of the document
       #
-      def title(**)
+      def title
         session.driver.title
       end
 

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -163,8 +163,8 @@ module Capybara
       #       offset will be from the element center, otherwise it will be from the top left corner of the element
       # @return [Capybara::Node::Element]  The element
       def click(*keys, **options)
-        perform_click_action(keys, options) do |k, opts|
-          base.click(k, opts)
+        perform_click_action(keys, **options) do |k, **opts|
+          base.click(k, **opts)
         end
       end
 
@@ -176,8 +176,8 @@ module Capybara
       # @macro click_modifiers
       # @return [Capybara::Node::Element]  The element
       def right_click(*keys, **options)
-        perform_click_action(keys, options) do |k, opts|
-          base.right_click(k, opts)
+        perform_click_action(keys, **options) do |k, **opts|
+          base.right_click(k, **opts)
         end
       end
 
@@ -189,8 +189,8 @@ module Capybara
       # @macro click_modifiers
       # @return [Capybara::Node::Element]  The element
       def double_click(*keys, **options)
-        perform_click_action(keys, options) do |k, opts|
-          base.double_click(k, opts)
+        perform_click_action(keys, **options) do |k, **opts|
+          base.double_click(k, **opts)
         end
       end
 
@@ -591,7 +591,7 @@ module Capybara
         raise ArgumentError, 'You must specify both x: and y: for a click offset' if nil ^ options[:x] ^ options[:y]
 
         options[:offset] ||= :center if session_options.w3c_click_offset
-        synchronize(wait) { yield keys, options }
+        synchronize(wait) { yield keys, **options }
         self
       end
     end

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -49,7 +49,7 @@ module Capybara
       #
       def find(*args, **options, &optional_filter_block)
         options[:session_options] = session_options
-        synced_resolve Capybara::Queries::SelectorQuery.new(*args, options, &optional_filter_block)
+        synced_resolve Capybara::Queries::SelectorQuery.new(*args, **options, &optional_filter_block)
       end
 
       ##
@@ -72,7 +72,7 @@ module Capybara
       #
       def ancestor(*args, **options, &optional_filter_block)
         options[:session_options] = session_options
-        synced_resolve Capybara::Queries::AncestorQuery.new(*args, options, &optional_filter_block)
+        synced_resolve Capybara::Queries::AncestorQuery.new(*args, **options, &optional_filter_block)
       end
 
       ##
@@ -95,7 +95,7 @@ module Capybara
       #
       def sibling(*args, **options, &optional_filter_block)
         options[:session_options] = session_options
-        synced_resolve Capybara::Queries::SiblingQuery.new(*args, options, &optional_filter_block)
+        synced_resolve Capybara::Queries::SiblingQuery.new(*args, **options, &optional_filter_block)
       end
 
       ##
@@ -125,7 +125,7 @@ module Capybara
       # @return [Capybara::Node::Element]   The found element
       #
       def find_field(locator = nil, **options, &optional_filter_block)
-        find(:field, locator, options, &optional_filter_block)
+        find(:field, locator, **options, &optional_filter_block)
       end
 
       ##
@@ -145,7 +145,7 @@ module Capybara
       # @return [Capybara::Node::Element]   The found element
       #
       def find_link(locator = nil, **options, &optional_filter_block)
-        find(:link, locator, options, &optional_filter_block)
+        find(:link, locator, **options, &optional_filter_block)
       end
 
       ##
@@ -172,7 +172,7 @@ module Capybara
       # @return [Capybara::Node::Element]   The found element
       #
       def find_button(locator = nil, **options, &optional_filter_block)
-        find(:button, locator, options, &optional_filter_block)
+        find(:button, locator, **options, &optional_filter_block)
       end
 
       ##
@@ -186,7 +186,7 @@ module Capybara
       # @return [Capybara::Node::Element]   The found element
       #
       def find_by_id(id, **options, &optional_filter_block)
-        find(:id, id, options, &optional_filter_block)
+        find(:id, id, **options, &optional_filter_block)
       end
 
       ##
@@ -245,7 +245,7 @@ module Capybara
         minimum_specified = options_include_minimum?(options)
         options = { minimum: 1 }.merge(options) unless minimum_specified
         options[:session_options] = session_options
-        query = Capybara::Queries::SelectorQuery.new(*args, options, &optional_filter_block)
+        query = Capybara::Queries::SelectorQuery.new(*args, **options, &optional_filter_block)
         result = nil
         begin
           synchronize(query.wait) do
@@ -278,7 +278,7 @@ module Capybara
       #
       def first(*args, **options, &optional_filter_block)
         options = { minimum: 1 }.merge(options) unless options_include_minimum?(options)
-        all(*args, options, &optional_filter_block).first
+        all(*args, **options, &optional_filter_block).first
       end
 
     private

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -37,7 +37,7 @@ module Capybara
 
         raise ArgumentError, "Unused parameters passed to #{self.class.name} : #{args}" unless args.empty?
 
-        @expression = selector.call(@locator, @options)
+        @expression = selector.call(@locator, **@options)
 
         warn_exact_usage
 
@@ -338,7 +338,7 @@ module Capybara
         conditions[:id] = options[:id] if use_default_id_filter?
         conditions[:class] = options[:class] if use_default_class_filter?
         conditions[:style] = options[:style] if use_default_style_filter? && !options[:style].is_a?(Hash)
-        builder(expr).add_attribute_conditions(conditions)
+        builder(expr).add_attribute_conditions(**conditions)
       end
 
       def use_default_id_filter?

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -42,7 +42,7 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
   end
 
   def visit(path, **attributes)
-    browser.visit(path, attributes)
+    browser.visit(path, **attributes)
   end
 
   def refresh
@@ -54,7 +54,7 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
   end
 
   def follow(method, path, **attributes)
-    browser.follow(method, path, attributes)
+    browser.follow(method, path, **attributes)
   end
 
   def current_url

--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -5,7 +5,7 @@ require 'capybara/rack_test/errors'
 class Capybara::RackTest::Node < Capybara::Driver::Node
   BLOCK_ELEMENTS = %w[p h1 h2 h3 h4 h5 h6 ol ul pre address blockquote dl div fieldset form hr noscript table].freeze
 
-  def all_text(**)
+  def all_text
     native.text
           .gsub(/[\u200b\u200e\u200f]/, '')
           .gsub(/[\ \n\f\t\v\u2028\u2029]+/, ' ')
@@ -14,7 +14,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
           .tr("\u00a0", ' ')
   end
 
-  def visible_text(**)
+  def visible_text
     displayed_text.gsub(/\ +/, ' ')
                   .gsub(/[\ \n]*\n[\ \n]*/, "\n")
                   .gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
@@ -22,7 +22,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
                   .tr("\u00a0", ' ')
   end
 
-  def [](name, **)
+  def [](name)
     string_node[name]
   end
 
@@ -30,7 +30,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     raise NotImplementedError, 'The rack_test driver does not process CSS'
   end
 
-  def value(**)
+  def value
     string_node.value
   end
 
@@ -50,14 +50,14 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     end
   end
 
-  def select_option(**)
+  def select_option
     return if disabled?
 
     deselect_options unless select_node.multiple?
     native['selected'] = 'selected'
   end
 
-  def unselect_option(**)
+  def unselect_option
     raise Capybara::UnselectNotAllowed, 'Cannot unselect option from single select box.' unless select_node.multiple?
 
     native.remove_attribute('selected')
@@ -81,23 +81,23 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     end
   end
 
-  def tag_name(**)
+  def tag_name
     native.node_name
   end
 
-  def visible?(**)
+  def visible?
     string_node.visible?
   end
 
-  def checked?(**)
+  def checked?
     string_node.checked?
   end
 
-  def selected?(**)
+  def selected?
     string_node.selected?
   end
 
-  def disabled?(**)
+  def disabled?
     return true if string_node.disabled?
 
     if %w[option optgroup].include? tag_name
@@ -107,7 +107,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     end
   end
 
-  def path(**)
+  def path
     native.path
   end
 
@@ -125,7 +125,11 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
 
     define_method meth_name do |*args, **kw|
       stale_check
-      send("unchecked_#{meth_name}", *args, **kw)
+      if kw.empty?
+        send("unchecked_#{meth_name}", *args)
+      else
+        send("unchecked_#{meth_name}", *args, **kw)
+      end
     end
   end
 

--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -5,7 +5,7 @@ require 'capybara/rack_test/errors'
 class Capybara::RackTest::Node < Capybara::Driver::Node
   BLOCK_ELEMENTS = %w[p h1 h2 h3 h4 h5 h6 ol ul pre address blockquote dl div fieldset form hr noscript table].freeze
 
-  def all_text
+  def all_text(**)
     native.text
           .gsub(/[\u200b\u200e\u200f]/, '')
           .gsub(/[\ \n\f\t\v\u2028\u2029]+/, ' ')
@@ -14,7 +14,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
           .tr("\u00a0", ' ')
   end
 
-  def visible_text
+  def visible_text(**)
     displayed_text.gsub(/\ +/, ' ')
                   .gsub(/[\ \n]*\n[\ \n]*/, "\n")
                   .gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
@@ -22,7 +22,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
                   .tr("\u00a0", ' ')
   end
 
-  def [](name)
+  def [](name, **)
     string_node[name]
   end
 
@@ -30,7 +30,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     raise NotImplementedError, 'The rack_test driver does not process CSS'
   end
 
-  def value
+  def value(**)
     string_node.value
   end
 
@@ -50,14 +50,14 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     end
   end
 
-  def select_option
+  def select_option(**)
     return if disabled?
 
     deselect_options unless select_node.multiple?
     native['selected'] = 'selected'
   end
 
-  def unselect_option
+  def unselect_option(**)
     raise Capybara::UnselectNotAllowed, 'Cannot unselect option from single select box.' unless select_node.multiple?
 
     native.remove_attribute('selected')
@@ -81,23 +81,23 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     end
   end
 
-  def tag_name
+  def tag_name(**)
     native.node_name
   end
 
-  def visible?
+  def visible?(**)
     string_node.visible?
   end
 
-  def checked?
+  def checked?(**)
     string_node.checked?
   end
 
-  def selected?
+  def selected?(**)
     string_node.selected?
   end
 
-  def disabled?
+  def disabled?(**)
     return true if string_node.disabled?
 
     if %w[option optgroup].include? tag_name
@@ -107,7 +107,7 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     end
   end
 
-  def path
+  def path(**)
     native.path
   end
 
@@ -123,9 +123,9 @@ class Capybara::RackTest::Node < Capybara::Driver::Node
     alias_method "unchecked_#{meth_name}", meth_name
     private "unchecked_#{meth_name}" # rubocop:disable Style/AccessModifierDeclarations
 
-    define_method meth_name do |*args|
+    define_method meth_name do |*args, **kw|
       stale_check
-      send("unchecked_#{meth_name}", *args)
+      send("unchecked_#{meth_name}", *args, **kw)
     end
   end
 

--- a/lib/capybara/selector/definition.rb
+++ b/lib/capybara/selector/definition.rb
@@ -166,7 +166,7 @@ module Capybara
 
       def locator_filter(*types, **options, &block)
         types.each { |type| options[type] = true }
-        @locator_filter = Capybara::Selector::Filters::LocatorFilter.new(block, options) if block
+        @locator_filter = Capybara::Selector::Filters::LocatorFilter.new(block, **options) if block
         @locator_filter
       end
 

--- a/lib/capybara/selector/definition/checkbox.rb
+++ b/lib/capybara/selector/definition/checkbox.rb
@@ -5,7 +5,7 @@ Capybara.add_selector(:checkbox, locator_type: [String, Symbol]) do
     xpath = XPath.axis(allow_self ? :"descendant-or-self" : :descendant, :input)[
       XPath.attr(:type) == 'checkbox'
     ]
-    locate_field(xpath, locator, options)
+    locate_field(xpath, locator, **options)
   end
 
   filter_set(:_field, %i[checked unchecked disabled name])

--- a/lib/capybara/selector/definition/fillable_field.rb
+++ b/lib/capybara/selector/definition/fillable_field.rb
@@ -6,7 +6,7 @@ Capybara.add_selector(:fillable_field, locator_type: [String, Symbol]) do
     xpath = XPath.axis(allow_self ? :"descendant-or-self" : :descendant, :input, :textarea)[
       !XPath.attr(:type).one_of('submit', 'image', 'radio', 'checkbox', 'hidden', 'file')
     ]
-    locate_field(xpath, locator, options)
+    locate_field(xpath, locator, **options)
   end
 
   expression_filter(:type) do |expr, type|

--- a/lib/capybara/selector/definition/radio_button.rb
+++ b/lib/capybara/selector/definition/radio_button.rb
@@ -6,7 +6,7 @@ Capybara.add_selector(:radio_button, locator_type: [String, Symbol]) do
     xpath = XPath.axis(allow_self ? :"descendant-or-self" : :descendant, :input)[
       XPath.attr(:type) == 'radio'
     ]
-    locate_field(xpath, locator, options)
+    locate_field(xpath, locator, **options)
   end
 
   filter_set(:_field, %i[checked unchecked disabled name])

--- a/lib/capybara/selector/definition/select.rb
+++ b/lib/capybara/selector/definition/select.rb
@@ -5,7 +5,7 @@ Capybara.add_selector(:select, locator_type: [String, Symbol]) do
 
   xpath do |locator, **options|
     xpath = XPath.descendant(:select)
-    locate_field(xpath, locator, options)
+    locate_field(xpath, locator, **options)
   end
 
   filter_set(:_field, %i[disabled multiple name placeholder])

--- a/lib/capybara/selector/filter_set.rb
+++ b/lib/capybara/selector/filter_set.rb
@@ -15,15 +15,15 @@ module Capybara
         instance_eval(&block)
       end
 
-      def node_filter(names, *types_and_options, &block)
+      def node_filter(names, *types_and_options, **options, &block)
         Array(names).each do |name|
-          add_filter(name, Filters::NodeFilter, *types_and_options, &block)
+          add_filter(name, Filters::NodeFilter, *types_and_options, **options, &block)
         end
       end
       alias_method :filter, :node_filter
 
-      def expression_filter(name, *types_and_options, &block)
-        add_filter(name, Filters::ExpressionFilter, *types_and_options, &block)
+      def expression_filter(name, *types_and_options, **options, &block)
+        add_filter(name, Filters::ExpressionFilter, *types_and_options, **options, &block)
       end
 
       def describe(what = nil, &block)
@@ -114,7 +114,7 @@ module Capybara
         types.each { |type| options[type] = true }
         raise 'ArgumentError', ':default option is not supported for filters with a :matcher option' if matcher && options[:default]
 
-        filter = filter_class.new(name, matcher, block, options)
+        filter = filter_class.new(name, matcher, block, **options)
         (filter_class <= Filters::ExpressionFilter ? @expression_filters : @node_filters)[name] = filter
       end
     end

--- a/lib/capybara/selector/filters/locator_filter.rb
+++ b/lib/capybara/selector/filters/locator_filter.rb
@@ -7,7 +7,7 @@ module Capybara
     module Filters
       class LocatorFilter < NodeFilter
         def initialize(block, **options)
-          super(nil, nil, block, options)
+          super(nil, nil, block, **options)
         end
 
         def matches?(node, value, context = nil, exact:)

--- a/lib/capybara/selenium/nodes/firefox_node.rb
+++ b/lib/capybara/selenium/nodes/firefox_node.rb
@@ -14,7 +14,7 @@ class Capybara::Selenium::FirefoxNode < Capybara::Selenium::Node
       warn 'You are attempting to click a table row which has issues in geckodriver/marionette - '\
            'see https://github.com/mozilla/geckodriver/issues/1228. Your test should probably be '\
            'clicking on a table cell like a user would. Clicking the first cell in the row instead.'
-      return find_css('th:first-child,td:first-child')[0].click(keys, options)
+      return find_css('th:first-child,td:first-child')[0].click(keys, **options)
     end
     raise
   end

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -744,15 +744,15 @@ module Capybara
     end
 
     NODE_METHODS.each do |method|
-      define_method method do |*args, &block|
+      define_method method do |*args, **kw, &block|
         @touched = true
-        current_scope.send(method, *args, &block)
+        current_scope.send(method, *args, **kw, &block)
       end
     end
 
     DOCUMENT_METHODS.each do |method|
-      define_method method do |*args, &block|
-        document.send(method, *args, &block)
+      define_method method do |*args, **kw, &block|
+        document.send(method, *args, **kw, &block)
       end
     end
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -827,11 +827,11 @@ module Capybara
     end
 
     def accept_modal(type, text_or_options, options, &blk)
-      driver.accept_modal(type, modal_options(text_or_options, options), &blk)
+      driver.accept_modal(type, **modal_options(text_or_options, **options), &blk)
     end
 
     def dismiss_modal(type, text_or_options, options, &blk)
-      driver.dismiss_modal(type, modal_options(text_or_options, options), &blk)
+      driver.dismiss_modal(type, **modal_options(text_or_options, **options), &blk)
     end
 
     def modal_options(text = nil, **options)

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -746,13 +746,21 @@ module Capybara
     NODE_METHODS.each do |method|
       define_method method do |*args, **kw, &block|
         @touched = true
-        current_scope.send(method, *args, **kw, &block)
+        if kw.empty?
+          current_scope.send(method, *args, &block)
+        else
+          current_scope.send(method, *args, **kw, &block)
+        end
       end
     end
 
     DOCUMENT_METHODS.each do |method|
       define_method method do |*args, **kw, &block|
-        document.send(method, *args, **kw, &block)
+        if kw.empty?
+          document.send(method, *args, &block)
+        else
+          document.send(method, *args, **kw, &block)
+        end
       end
     end
 


### PR DESCRIPTION
Ruby 2.7 will warn if converting a final hash positional argument
to keyword arguments, and Ruby 3 will no longer do such conversion.

This attempts to fix the warnings, mostly by adding ** when calling
methods that accept keyword arguments.  Unfortunately, that is not
backwards compatible on Ruby <2.7 if the method being called does
not accept keyword arguments.  So to enable backwards compatibility,
allow such methods to accept keyword arguments, even though they
don't actually use the keyword arguments.

I'm guessing this commit doesn't handle all cases it needs to handle,
and it may break on !ruby-head because some additional methods need
to accept keyword arguments.  I'll monitor CI for this PR and attempt to
fix the remaining issues.

Ruby master forwardable also needs to be modified to fix some of these
warnings, I have a patch for that which I will submit upstream later today.