### PR TITLE
Display pending requests

### DIFF
--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -61,9 +61,7 @@ module Capybara
     def wait_for_pending_requests
       timer = Capybara::Helpers.timer(expire_in: 60)
       while pending_requests?
-        if timer.expired?
-          raise "Requests did not finish in 60 seconds: #{middleware.pending_requests}"
-        end
+        raise "Requests did not finish in 60 seconds: #{middleware.pending_requests}" if timer.expired?
 
         sleep 0.01
       end

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -61,7 +61,9 @@ module Capybara
     def wait_for_pending_requests(wait_time = 60)
       timer = Capybara::Helpers.timer(expire_in: wait_time)
       while pending_requests?
-        raise 'Requests did not finish in 60 seconds' if timer.expired?
+        if timer.expired?
+          raise "Requests did not finish in 60 seconds: #{middleware.pending_requests}"
+        end
 
         sleep 0.01
       end

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -58,8 +58,8 @@ module Capybara
       false
     end
 
-    def wait_for_pending_requests(wait_time = 60)
-      timer = Capybara::Helpers.timer(expire_in: wait_time)
+    def wait_for_pending_requests
+      timer = Capybara::Helpers.timer(expire_in: 60)
       while pending_requests?
         if timer.expired?
           raise "Requests did not finish in 60 seconds: #{middleware.pending_requests}"

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -58,8 +58,8 @@ module Capybara
       false
     end
 
-    def wait_for_pending_requests
-      timer = Capybara::Helpers.timer(expire_in: 60)
+    def wait_for_pending_requests(wait_time = 60)
+      timer = Capybara::Helpers.timer(expire_in: wait_time)
       while pending_requests?
         raise 'Requests did not finish in 60 seconds' if timer.expired?
 

--- a/lib/capybara/server/middleware.rb
+++ b/lib/capybara/server/middleware.rb
@@ -18,6 +18,14 @@ module Capybara
         def decrement(env)
           @mutex.synchronize { @value.delete_at(@value.index(env) || @value.length) }
         end
+
+        def positive?
+          @mutex.synchronize { @value.length.positive? }
+        end
+
+        def value
+          @mutex.synchronize { @value }
+        end
       end
 
       attr_reader :error
@@ -36,7 +44,7 @@ module Capybara
       end
 
       def pending_requests?
-        @counter.value.length.positive?
+        @counter.positive?
       end
 
       def clear_error

--- a/lib/capybara/server/middleware.rb
+++ b/lib/capybara/server/middleware.rb
@@ -4,8 +4,6 @@ module Capybara
   class Server
     class Middleware
       class Counter
-        attr_reader :value
-
         def initialize
           @value = []
           @mutex = Mutex.new

--- a/lib/capybara/server/middleware.rb
+++ b/lib/capybara/server/middleware.rb
@@ -31,6 +31,10 @@ module Capybara
         @server_errors = server_errors
       end
 
+      def pending_requests
+        @counter.value.map { |env| env["REQUEST_URI"] }
+      end
+
       def pending_requests?
         @counter.value.length.positive?
       end

--- a/lib/capybara/server/middleware.rb
+++ b/lib/capybara/server/middleware.rb
@@ -16,7 +16,7 @@ module Capybara
         end
 
         def decrement(env)
-          @mutex.synchronize { @value.delete_at(@value.index(env)) }
+          @mutex.synchronize { @value.delete_at(@value.index(env) || @value.length) }
         end
       end
 

--- a/lib/capybara/server/middleware.rb
+++ b/lib/capybara/server/middleware.rb
@@ -53,14 +53,14 @@ module Capybara
         if env['PATH_INFO'] == '/__identify__'
           [200, {}, [@app.object_id.to_s]]
         else
-          @counter.increment(env["REQUEST_URI"])
+          @counter.increment(env['REQUEST_URI'])
           begin
             @extended_app.call(env)
           rescue *@server_errors => e
             @error ||= e
             raise e
           ensure
-            @counter.decrement(env["REQUEST_URI"])
+            @counter.decrement(env['REQUEST_URI'])
           end
         end
       end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -249,13 +249,13 @@ RSpec.describe Capybara::Server do
     server = described_class.new(app).boot
 
     expect do
-      start_request(server, 59.0)
-      server.wait_for_pending_requests
+      start_request(server, 1.0)
+      server.wait_for_pending_requests(2)
     end.not_to raise_error
 
     expect do
-      start_request(server, 61.0)
-      server.wait_for_pending_requests
+      start_request(server, 2.0)
+      server.wait_for_pending_requests(1)
     end.to raise_error('Requests did not finish in 60 seconds')
   end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -249,14 +249,14 @@ RSpec.describe Capybara::Server do
     server = described_class.new(app).boot
 
     expect do
-      start_request(server, 1.0)
-      server.wait_for_pending_requests(2)
+      start_request(server, 59.0)
+      server.wait_for_pending_requests
     end.not_to raise_error
 
     expect do
-      start_request(server, 2.0)
-      server.wait_for_pending_requests(1)
-    end.to raise_error('Requests did not finish in 60 seconds: ["/?wait_time=2.0"]')
+      start_request(server, 61.0)
+      server.wait_for_pending_requests
+    end.to raise_error('Requests did not finish in 60 seconds: ["/?wait_time=61.0"]')
   end
 
   it 'is not #responsive? when Net::HTTP raises a SystemCallError' do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Capybara::Server do
     expect do
       start_request(server, 2.0)
       server.wait_for_pending_requests(1)
-    end.to raise_error('Requests did not finish in 60 seconds')
+    end.to raise_error('Requests did not finish in 60 seconds: ["/?wait_time=2.0"]')
   end
 
   it 'is not #responsive? when Net::HTTP raises a SystemCallError' do


### PR DESCRIPTION
Closes: https://github.com/teamcapybara/capybara/issues/2249

# Motivation

Displays more information about pending requests to developers. It can be useful to see the URI of a pending request in the test stack trace instead of following the test logs.

# Change log and testing strategy

- Backfills tests for pending requests behavior
- Add additional information on error message
