### PR TITLE
Remove spec files from final gem

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = 'Capybara is an integration testing tool for rack based web applications. '\
                   'It simulates how a user would interact with a website'
 
-  s.files = Dir.glob('{lib,spec}/**/*') + %w[README.md History.md License.txt .yardopts]
+  s.files = Dir.glob('lib/**/*') + %w[README.md History.md License.txt .yardopts]
 
   s.homepage = 'https://github.com/teamcapybara/capybara'
   s.metadata = {


### PR DESCRIPTION
This reduces the compiled gem by 40 kb.

The main reason I want to do this is because I have started scanning my docker image with a vulnerability scanner, and it is complaining that there's a private key in there, which is coming from capybara (`spec/fixtures/key.pem`).

Disclaimer: I have not done any testing other than building the gem after the change.

Thanks!