### PR TITLE
Handle element id being returned as empty string when non-existent in label selector

### DIFF
--- a/lib/capybara/selector/definition/label.rb
+++ b/lib/capybara/selector/definition/label.rb
@@ -10,7 +10,9 @@ Capybara.add_selector(:label, locator_type: [String, Symbol]) do
       xpath = xpath[locator_matchers]
     end
     if options.key?(:for)
-      if (for_option = options[:for].is_a?(Capybara::Node::Element) ? options[:for][:id] : options[:for])
+      for_option = options[:for]
+      for_option = for_option[:id] if for_option.is_a?(Capybara::Node::Element)
+      if for_option && (for_option != "")
         with_attr = builder(XPath.self).add_attribute_conditions(for: for_option)
         wrapped = !XPath.attr(:for) &
                   builder(XPath.self.descendant(*labelable_elements)).add_attribute_conditions(id: for_option)

--- a/lib/capybara/spec/session/selectors_spec.rb
+++ b/lib/capybara/spec/session/selectors_spec.rb
@@ -31,6 +31,11 @@ Capybara::SpecHelper.spec Capybara::Selector do
       expect(@session.find(:label, for: input).text).to eq 'Nested Label'
     end
 
+    it 'finds a label from nested input using :for filter with element when no id on label' do
+      input = @session.find(:css, '#wrapper_label').find(:css, 'input')
+      expect(@session.find(:label, for: input).text).to eq 'Wrapper Label'
+    end
+
     it 'finds the label for an non-nested element when using :for filter' do
       select = @session.find(:id, 'form_other_title')
       expect(@session.find(:label, for: select)['for']).to eq 'form_other_title'

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -474,6 +474,11 @@ New line after and before textarea tag
   <input type="text" name="nested_label" id="nested_label"/>
 </label>
 
+<label id="wrapper_label">
+  Wrapper Label
+  <input type="checkbox"/>
+</label>
+
 <form id="form1" action="/form" method="post">
   <input type="text" name="form[which_form]" value="form1" id="form_which_form"/>
   <input type="text" name="form[for_form2]" value="for_form2" form="form2"/>


### PR DESCRIPTION
Fix for issue #2260