### PR TITLE
Specify GitHub repository instead of the path

### DIFF
--- a/gemfiles/Gemfile.edge-firefox
+++ b/gemfiles/Gemfile.edge-firefox
@@ -5,7 +5,7 @@ gemspec path: '..'
 
 gem 'xpath', github: 'teamcapybara/xpath'
 
-gem 'selenium-webdriver', :path => '../../selenium/build/rb'
+gem 'selenium-webdriver', github: 'seleniumhq/selenium', glob: 'rb/*.gemspec'
 gem 'webdrivers', github: 'titusfortner/webdrivers', branch: 'edge_chrome'
 gem 'rack', github: 'rack/rack'
 gem 'sinatra', github: 'sinatra/sinatra', branch: 'master'


### PR DESCRIPTION
I fixed this because I want to work a test against ruby-head. 
https://travis-ci.org/teamcapybara/capybara/jobs/605383442 

But if the purpose of this Gemfile is to check the test locally, feel free to close this. Thanks.
