### PR TITLE
Preserve clientX/clientY in HTML5 drag and drop events

### DIFF
--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -166,17 +166,18 @@ class Capybara::Selenium::Node
         var dragOverOpts = Object.assign({clientX: targetCenter.x, clientY: targetCenter.y}, opts);
         var dragOverEvent = new DragEvent('dragover', dragOverOpts);
         target.dispatchEvent(dragOverEvent);
-        window.setTimeout(dragLeave, step_delay, dragOverEvent.defaultPrevented);
+        window.setTimeout(dragLeave, step_delay, dragOverEvent.defaultPrevented, dragOverOpts);
       }
 
-      function dragLeave(drop) {
-        var dragLeaveEvent = new DragEvent('dragleave', opts);
+      function dragLeave(drop, dragOverOpts) {
+        var dragLeaveOptions = Object.assign({}, opts, dragOverOpts);
+        var dragLeaveEvent = new DragEvent('dragleave', dragLeaveOptions);
         target.dispatchEvent(dragLeaveEvent);
         if (drop) {
-          var dropEvent = new DragEvent('drop', opts);
+          var dropEvent = new DragEvent('drop', dragLeaveOptions);
           target.dispatchEvent(dropEvent);
         }
-        var dragEndEvent = new DragEvent('dragend', opts);
+        var dragEndEvent = new DragEvent('dragend', dragLeaveOptions);
         source.dispatchEvent(dragEndEvent);
         callback.call(true);
       }

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -12,8 +12,19 @@ $(function() {
   $('#drag_html5, #drag_html5_scroll').on('dragstart', function(ev){
     ev.originalEvent.dataTransfer.setData("text", ev.target.id);
   });
+  $('#drag_html5, #drag_html5_scroll').on('dragend', function(ev){
+    $(this).after('<div class="log">DragEnd with client position: ' + ev.clientX + ',' + ev.clientY)
+  });
   $('#drop_html5, #drop_html5_scroll').on('dragover', function(ev){
     $(this).after('<div class="log">DragOver with client position: ' + ev.clientX + ',' + ev.clientY)
+    if ($(this).hasClass('drop')) { ev.preventDefault(); }
+  });
+  $('#drop_html5, #drop_html5_scroll').on('dragleave', function(ev){
+    $(this).after('<div class="log">DragLeave with client position: ' + ev.clientX + ',' + ev.clientY)
+    if ($(this).hasClass('drop')) { ev.preventDefault(); }
+  });
+  $('#drop_html5, #drop_html5_scroll').on('drop', function(ev){
+    $(this).after('<div class="log">Drop with client position: ' + ev.clientX + ',' + ev.clientY)
     if ($(this).hasClass('drop')) { ev.preventDefault(); }
   });
   $('#drop_html5, #drop_html5_scroll').on('drop', function(ev){

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -493,6 +493,21 @@ Capybara::SpecHelper.spec 'node' do
         expect(@session).to have_css('div.log', text: /DragOver with client position: [1-9]\d*,[1-9]\d*/, count: 2)
       end
 
+      it 'should preserve clientX/Y from last dragover event' do
+        @session.visit('/with_js')
+        element = @session.find('//div[@id="drag_html5"]')
+        target = @session.find('//div[@id="drop_html5"]')
+        element.drag_to(target)
+
+        # The first "DragOver" div is inserted by the last dragover event dispatched
+        drag_over_div = @session.find('//div[@class="log" and starts-with(text(), "DragOver")]', match: :first)
+        position = drag_over_div.text.sub('DragOver ', '')
+
+        expect(@session).to have_css('div.log', text: /DragLeave #{position}/, count: 1)
+        expect(@session).to have_css('div.log', text: /Drop #{position}/, count: 1)
+        expect(@session).to have_css('div.log', text: /DragEnd #{position}/, count: 1)
+      end
+
       it 'should not HTML5 drag and drop on a non HTML5 drop element' do
         @session.visit('/with_js')
         element = @session.find('//div[@id="drag_html5"]')


### PR DESCRIPTION
Hey Capybara team :wave:

First of all, thanks for the amazing work that you have done so far, we use `Capybara` on our daily job and rely on it for building and testing our web applications :bow:

---

### Context:

HTML5 Drag and Drop.

### Issue:

When using HTML5 drag and drop to drag an object onto a target, the object is always dropped in the top left corner of the window (x: 0, y: 0) instead of the previously computed position within the target.

Background: HTML5 drag and drop is currently implemented via simulating a series of HTML5 events with pre-computed values for the mouse pointer position `clientX` and `clientY`. For the last events in this series (`dragleave`, `drop`, `dragend`), the previously computed position is lost on the way. Instead of carrying it along, the events use the default options without a `clientX` and `clientY` property, which makes them default to 0.

### Expected Behavior:

The object should be dropped in the center of the target.

For the `dragleave`, `drop` and `dragend` events the mousepointer position (`clientX`, `clientY`) should no longer change. They should be the same as the last `dragover` event.

### Further details

This PR fixes this by changing how HTML5 drag and drop is mimicked. We propagate down the previously computed `clientX` and `clientY` coordinates from the last `dragover` event (initially meant as dropping position for the object) to the following events: `dragleave`, `drop` and `dragend`.

Here is a screenshot from the changed spec to give you an idea of the series of events and their mouse position. 

![screen](https://user-images.githubusercontent.com/3228071/68856156-2287fd80-06e0-11ea-9d59-55ee181c2174.png)

---

We are looking forward to hearing from you, have a great day!