### PR TITLE
Fix Selenium Webdriver deprecation warnings on v2

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -131,7 +131,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
                 warn "localStorage clear requested but is not available for this driver"
               end
             end
-          rescue Selenium::WebDriver::Error::UnhandledError
+          rescue Selenium::WebDriver::Error::UnknownError
             # delete_all_cookies fails when we've previously gone
             # to about:blank, so we rescue this error and do nothing
             # instead.
@@ -265,13 +265,10 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def invalid_element_errors
     [::Selenium::WebDriver::Error::StaleElementReferenceError,
-     ::Selenium::WebDriver::Error::UnhandledError,
-     ::Selenium::WebDriver::Error::ElementNotVisibleError,
-     ::Selenium::WebDriver::Error::InvalidSelectorError, # Work around a race condition that can occur with chromedriver and #go_back/#go_forward
+     ::Selenium::WebDriver::Error::UnknownError,
      ::Selenium::WebDriver::Error::ElementNotInteractableError,
+     ::Selenium::WebDriver::Error::InvalidSelectorError, # Work around a race condition that can occur with chromedriver and #go_back/#go_forward
      ::Selenium::WebDriver::Error::ElementClickInterceptedError,
-     ::Selenium::WebDriver::Error::InvalidElementStateError,
-     ::Selenium::WebDriver::Error::ElementNotSelectableError,
     ]
   end
 
@@ -409,7 +406,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
         regexp = options[:text].is_a?(Regexp) ? options[:text] : Regexp.escape(options[:text].to_s)
         alert.text.match(regexp) ? alert : nil
       end
-    rescue Selenium::WebDriver::Error::TimeOutError
+    rescue Selenium::WebDriver::Error::TimeoutError
       raise Capybara::ModalNotFound.new("Unable to find modal dialog#{" with #{options[:text]}" if options[:text]}")
     end
   end
@@ -439,7 +436,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
           nil
         end
       end
-    rescue Selenium::WebDriver::Error::TimeOutError
+    rescue Selenium::WebDriver::Error::TimeoutError
       raise Capybara::ModalNotFound.new("Unable to find modal dialog#{" with #{options[:text]}" if options[:text]}")
     end
   end


### PR DESCRIPTION
Capybara 2.x with the latest `selenium-webdriver` (currently 3.142.4) spits out
a *lot* of deprecation warnings (see below).

```
WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::ElementNotSelectableError is deprecated. Use Selenium::WebDriver::Error::ElementNotInteractableError (ensure the driver supports W3C WebDriver specification) instead.
WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::ElementNotVisibleError is deprecated. Use Selenium::WebDriver::Error::ElementNotInteractableError (ensure the driver supports W3C WebDriver specification) instead.
WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::InvalidElementStateError is deprecated. Use Selenium::WebDriver::Error::ElementNotInteractableError (ensure the driver supports W3C WebDriver specification) instead.
WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::TimeOutError is deprecated. Use Selenium::WebDriver::Error::TimeoutError (ensure the driver supports W3C WebDriver specification) instead.
WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::UnhandledError is deprecated. Use Selenium::WebDriver::Error::UnknownError (ensure the driver supports W3C WebDriver specification) instead.
```

Although upgrading to Capybara 3 is clearly preferable, we have a fairly large
suite of feature specs for our apps and upgrading to v3 will not be a quick task
for us.

Would you please be able to release a 2.18.1 gem with this change to remove the
deprecation warnings?

Many thanks.