### PR TITLE
Make it so passing match: first to ancestor() finds closest ancestor

### DIFF
--- a/lib/capybara/queries/ancestor_query.rb
+++ b/lib/capybara/queries/ancestor_query.rb
@@ -12,6 +12,7 @@ module Capybara
           ancestors = node.find_xpath(XPath.ancestor.to_s)
                           .map(&method(:to_element))
                           .select { |el| match_results.include?(el) }
+                          .reverse
           Capybara::Result.new(ancestors, self)
         end
       end

--- a/lib/capybara/spec/session/ancestor_spec.rb
+++ b/lib/capybara/spec/session/ancestor_spec.rb
@@ -26,6 +26,12 @@ Capybara::SpecHelper.spec '#ancestor' do
     expect { el.ancestor('//div', text: 'Ancestor') }.to raise_error(Capybara::Ambiguous)
   end
 
+  it 'with match: first should find closest ancestor' do
+    el = @session.find(:css, '#child')
+    expect(el.ancestor(:css, 'div', match: :first)[:id]).to eq 'ancestor1'
+    expect(el.ancestor(:css, 'div', match: :first, text: 'Ancestor')[:id]).to eq 'ancestor1'
+  end
+
   context 'with css selectors' do
     it 'should find the first element using the given locator' do
       el = @session.find(:css, '#first_image')


### PR DESCRIPTION
Usually, when looking for an ancestor, you're interested in the _closest_ ancestor, not the most distantly related ancestor.

And when one speaks of the "_first_ ancestor", one always means the _closest_ ancestor, as you traverse parent elements upwards towards the root of the document (see [`Element.closest`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)).

This simple change makes it easier to find the closest (first) ancestor.

## Expected Behavior

```
  it 'with match: first should find closest ancestor' do
    el = @session.find(:css, '#child')
    expect(el.ancestor(:css, 'div', match: :first)[:id]).to eq 'ancestor1'
    expect(el.ancestor(:css, 'div', match: :first, text: 'Ancestor')[:id]).to eq 'ancestor1'
  end
```

## Actual Behavior

```
  1) Capybara::Session RackTest #ancestor with match: first should find closest ancestor
     Failure/Error: expect(el.ancestor(:css, 'div', match: :first)[:id]).to eq 'ancestor1'
     
       expected: "ancestor1"
            got: "ancestor3"
     
       (compared using ==)
     # ./lib/capybara/spec/session/ancestor_spec.rb:31:in `block (2 levels) in <top (required)>'
```

## `mach: last`?

Adding a `match: :last` option (#1733) could also be an option, but I think in this case, it just makes more sense for `:first` to mean closest.