### PR TITLE
Fix a Ruby 2.7 deprecation warning.

### DIFF
--- a/lib/capybara/selenium/driver_specializations/chrome_driver.rb
+++ b/lib/capybara/selenium/driver_specializations/chrome_driver.rb
@@ -96,7 +96,7 @@ private
 
   def execute_cdp(cmd, params = {})
     if browser.respond_to? :execute_cdp
-      browser.execute_cdp(cmd, params)
+      browser.execute_cdp(cmd, **params)
     else
       args = { cmd: cmd, params: params }
       result = bridge.http.call(:post, "session/#{bridge.session_id}/goog/cdp/execute", args)


### PR DESCRIPTION
I was getting this deprecation warning (among others) when running my tests:

```
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/capybara-3.30.0/lib/capybara/selenium/driver_specializations/chrome_driver.rb:99: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/selenium-webdriver-3.142.6/lib/selenium/webdriver/chrome/driver.rb:59: warning: The called method `execute_cdp' is defined here
```

The selenium `execute_cdp` method takes `params` as a set of keyword arguments, so `params` should be passed with a doublesplat.

That's true on [Selenium `master`](https://github.com/SeleniumHQ/selenium/blob/3f2f8fdd7ec1c518fad859d37c3087d23b830510/rb/lib/selenium/webdriver/chrome/driver.rb#L41) and [`rb-3.x`](https://github.com/SeleniumHQ/selenium/blob/9a3be099506a43fa27ad7db04080345a1727be93/rb/lib/selenium/webdriver/chrome/driver.rb#L59).

I've tried fixing some of the other deprecation warnings but unfortunately they're quite a bit harder than this one. Good luck! :)