### PR TITLE
Set range inputs via JS in selenium driver

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 # Version 3.30.1
 Release date: unreleased
 
+* Support setting `<input type="range">` elements with the selenium driver
+
 * Fix Ruby 2.7 deprecation notices around keyword arguments. I have tried to do this without
   any breaking changes, but due to the nature of the 2.7 changes and some selector types accepting
   Hashes as locators there are a lot of edge cases. If you find any broken cases please report

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -78,6 +78,8 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
         set_datetime_local(value)
       when 'color'
         set_color(value)
+      when 'range'
+        set_range(value)
       else
         set_text(value, **options)
       end
@@ -293,6 +295,10 @@ private
   end
 
   def set_color(value) # rubocop:disable Naming/AccessorMethodName
+    update_value_js(value)
+  end
+
+  def set_range(value) # rubocop:disable Naming/AccessorMethodName
     update_value_js(value)
   end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -63,6 +63,11 @@
   </p>
 
   <p>
+    <label for="form_age">Age</label>
+    <input type="range" name="form[age]" value="18" min="13" max="100" id="form_age"/>
+  </p>
+
+  <p>
     <label for="form_schmooo">Schmooo</label>
     <input type="schmooo" name="form[schmooo]" value="This is Schmooo!" id="form_schmooo"/>
   </p>

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -205,6 +205,18 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
       end
     end
 
+    describe '#fill_in with input[type="range"]' do
+      before do
+        session.visit('/form')
+      end
+
+      it 'should set the range slider correctly' do
+        session.fill_in('form_age', with: 51)
+        session.click_button('awesome')
+        expect(Integer(extract_results(session)['age'])).to eq 51
+      end
+    end
+
     describe '#path' do
       it 'returns xpath' do
         # this is here because it is testing for an XPath that is specific to the algorithm used in the selenium driver


### PR DESCRIPTION
The slider can't be controlled so set it via JS like color inputs.