### PR TITLE
Fix regression in 3.31.0 with Result#[] using inclusive range ending in -1

### DIFF
--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -63,6 +63,7 @@ module Capybara
         # idx.max is broken with beginless ranges
         # idx.end && idx.max # endless range will have end == nil
         max = idx.end
+        max = nil if max == -1 && !idx.exclude_end?
         max -= 1 if max && idx.exclude_end?
         max
       end


### PR DESCRIPTION
The logic was changed to support beginless ranges, and it broke
this case, because later in the method it loads up to max + 1,
which will be 0 for inclusive ranges ending in -1.  Since in
this context, inclusive ranges ending in -1 are endless, treat
them as endless ranges.

Not sure if this is the best way to fix this, but it does work.

Sorry for the lack of specs.  Here's an example showing 3.30, 3.31 (bug), and patched behavior:

```
$ ruby -e 'gem "capybara", "=3.30"; require "capybara"; p Capybara.string("<tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr>").all("tr").map{|s| s.all("td")[1..-1]}'
[[#<Capybara::Node::Simple tag="td" path="/html/body/tr[1]/td[2]">], [#<Capybara::Node::Simple tag="td" path="/html/body/tr[2]/td[2]">]]

$ ruby -e 'gem "capybara", "=3.31"; require "capybara"; p Capybara.string("<tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr>").all("tr").map{|s| s.all("td")[1..-1]}'
[[], []]

$ ruby -I lib -e 'require "capybara"; p Capybara.string("<tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr>").all("tr").map{|s| s.all("td")[1..-1]}'
[[#<Capybara::Node::Simple tag="td" path="/html/body/tr[1]/td[2]">], [#<Capybara::Node::Simple tag="td" path="/html/body/tr[2]/td[2]">]]
```