### PR TITLE
Avoid booting errors when using selenium_headless_chrome in docker

### DIFF
--- a/lib/capybara/registrations/drivers.rb
+++ b/lib/capybara/registrations/drivers.rb
@@ -29,6 +29,9 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.args << '--headless'
     opts.args << '--disable-gpu' if Gem.win_platform?
+    if RbConfig::CONFIG['host_os'] =~ /linux/ && system('grep -q docker /proc/self/cgroup')
+      opts.args << '--disable-dev-shm-usage'
+    end
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.args << '--disable-site-isolation-trials'
   end


### PR DESCRIPTION
This line solves this problem:

https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t