### PR TITLE
Update Capybara::Minitest::Assertion docs

### DIFF
--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -165,6 +165,123 @@ module Capybara
       alias_method :refute_ancestor, :assert_no_ancestor
       alias_method :refute_sibling, :assert_no_sibling
 
+      ##
+      # Assert that provided xpath exists
+      #
+      # @!method assert_xpath
+      #   See {Capybara::Node::Matchers#has_xpath?}
+
+      ##
+      # Assert that provide xpath does not exist
+      #
+      # @!method refute_xpath
+      # @!method assert_no_xpath
+      #   See {Capybara::Node::Matchers#has_no_xpath?}
+
+      ##
+      # Assert that provided css exists
+      #
+      # @!method assert_css
+      #   See {Capybara::Node::Matchers#has_css?}
+
+      ##
+      # Assert that provided css does not exist
+      #
+      # @!method refute_css
+      # @!method assert_no_css
+      #   See {Capybara::Node::Matchers#has_no_css?}
+
+      ##
+      # Assert that provided link exists
+      #
+      # @!method assert_link
+      #   See {Capybara::Node::Matchers#has_link?}
+
+      ##
+      # Assert that provided link does not exist
+      #
+      # @!method assert_no_link
+      # @!method refute_link
+      #   See {Capybara::Node::Matchers#has_no_link?}
+
+      ##
+      # Assert that provided button exists
+      #
+      # @!method assert_button
+      #   See {Capybara::Node::Matchers#has_button?}
+
+      ##
+      # Assert that provided button does not exist
+      #
+      # @!method refute_button
+      # @!method assert_no_button
+      #   See {Capybara::Node::Matchers#has_no_button?}
+
+      ##
+      # Assert that provided field exists
+      #
+      # @!method assert_field
+      #   See {Capybara::Node::Matchers#has_field?}
+
+      ##
+      # Assert that provided field does not exist
+      #
+      # @!method refute_field
+      # @!method assert_no_field
+      #   See {Capybara::Node::Matchers#has_no_field?}
+
+      ##
+      # Assert that provided checked field exists
+      #
+      # @!method assert_checked_field
+      #   See {Capybara::Node::Matchers#has_checked_field?}
+
+      ##
+      # Assert that provided checked_field does not exist
+      #
+      # @!method assert_no_checked_field
+      # @!method refute_checked_field
+      #   See {Capybara::Node::Matchers#has_no_checked_field?}
+
+      ##
+      # Assert that provided unchecked field exists
+      #
+      # @!method assert_unchecked_field
+      #   See {Capybara::Node::Matchers#has_unchecked_field?}
+
+      ##
+      # Assert that provided unchecked field does not exist
+      #
+      # @!method assert_no_unchecked_field
+      # @!method refute_unchecked_field
+      #   See {Capybara::Node::Matchers#has_no_unchecked_field?}
+
+      ##
+      # Assert that provided select exists
+      #
+      # @!method assert_select
+      #   See {Capybara::Node::Matchers#has_select?}
+
+      ##
+      # Assert that provided select does not exist
+      #
+      # @!method refute_select
+      # @!method assert_no_select
+      #   See {Capybara::Node::Matchers#has_no_select?}
+
+      ##
+      # Assert that provided table exists
+      #
+      # @!method assert_table
+      #   See {Capybara::Node::Matchers#has_table?}
+
+      ##
+      # Assert that provided table does not exist
+      #
+      # @!method refute_table
+      # @!method assert_no_table
+      #   See {Capybara::Node::Matchers#has_no_table?}
+
       %w[xpath css link button field select table].each do |selector_type|
         define_method "assert_#{selector_type}" do |*args, &optional_filter_block|
           subject, args = determine_subject(args)
@@ -245,123 +362,6 @@ module Capybara
         ruby2_keywords "assert_not_matches_#{selector_type}" if respond_to?(:ruby2_keywords)
         alias_method "refute_matches_#{selector_type}", "assert_not_matches_#{selector_type}"
       end
-
-    ##
-    # Assertion that there is xpath
-    #
-    # @!method assert_xpath
-    #   See {Capybara::Node::Matchers#has_xpath?}
-
-    ##
-    # Assertion that there is no xpath
-    #
-    # @!method refute_xpath
-    # @!method assert_no_xpath
-    #   See {Capybara::Node::Matchers#has_no_xpath?}
-
-    ##
-    # Assertion that there is css
-    #
-    # @!method assert_css
-    #   See {Capybara::Node::Matchers#has_css?}
-
-    ##
-    # Assertion that there is no css
-    #
-    # @!method refute_css
-    # @!method assert_no_css
-    #   See {Capybara::Node::Matchers#has_no_css?}
-
-    ##
-    # Assertion that there is link
-    #
-    # @!method assert_link
-    #   See {Capybara::Node::Matchers#has_link?}
-
-    ##
-    # Assertion that there is no link
-    #
-    # @!method assert_no_link
-    # @!method refute_link
-    #   See {Capybara::Node::Matchers#has_no_link?}
-
-    ##
-    # Assertion that there is button
-    #
-    # @!method assert_button
-    #   See {Capybara::Node::Matchers#has_button?}
-
-    ##
-    # Assertion that there is no button
-    #
-    # @!method refute_button
-    # @!method assert_no_button
-    #   See {Capybara::Node::Matchers#has_no_button?}
-
-    ##
-    # Assertion that there is field
-    #
-    # @!method assert_field
-    #   See {Capybara::Node::Matchers#has_field?}
-
-    ##
-    # Assertion that there is no field
-    #
-    # @!method refute_field
-    # @!method assert_no_field
-    #   See {Capybara::Node::Matchers#has_no_field?}
-
-    ##
-    # Assertion that there is checked_field
-    #
-    # @!method assert_checked_field
-    #   See {Capybara::Node::Matchers#has_checked_field?}
-
-    ##
-    # Assertion that there is no checked_field
-    #
-    # @!method assert_no_checked_field
-    # @!method refute_checked_field
-    #   See {Capybara::Node::Matchers#has_no_checked_field?}
-
-    ##
-    # Assertion that there is unchecked_field
-    #
-    # @!method assert_unchecked_field
-    #   See {Capybara::Node::Matchers#has_unchecked_field?}
-
-    ##
-    # Assertion that there is no unchecked_field
-    #
-    # @!method assert_no_unchecked_field
-    # @!method refute_unchecked_field
-    #   See {Capybara::Node::Matchers#has_no_unchecked_field?}
-
-    ##
-    # Assertion that there is select
-    #
-    # @!method assert_select
-    #   See {Capybara::Node::Matchers#has_select?}
-
-    ##
-    # Assertion that there is no select
-    #
-    # @!method refute_select
-    # @!method assert_no_select
-    #   See {Capybara::Node::Matchers#has_no_select?}
-
-    ##
-    # Assertion that there is table
-    #
-    # @!method assert_table
-    #   See {Capybara::Node::Matchers#has_table?}
-
-    ##
-    # Assertion that there is no table
-    #
-    # @!method refute_table
-    # @!method assert_no_table
-    #   See {Capybara::Node::Matchers#has_no_table?}
 
     private
 

--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -9,38 +9,38 @@ module Capybara
       ## Assert text exists
       #
       # @!method assert_text
-      #   @see Capybara::Node::Matchers#assert_text
+      #   See {Capybara::Node::Matchers#assert_text}
 
       ## Assert text does not exist
       #
       # @!method assert_no_text
-      #   @see Capybara::Node::Matchers#assert_no_text
+      #   See {Capybara::Node::Matchers#assert_no_text}
 
       ##
       # Assertion that page title does match
       #
       # @!method assert_title
-      #   @see Capybara::Node::DocumentMatchers#assert_title
+      #   See {Capybara::Node::DocumentMatchers#assert_title}
 
       ##
       # Assertion that page title does not match
       #
       # @!method refute_title
       # @!method assert_no_title
-      #   @see Capybara::Node::DocumentMatchers#assert_no_title
+      #   See {Capybara::Node::DocumentMatchers#assert_no_title}
 
       ##
       # Assertion that current path matches
       #
       # @!method assert_current_path
-      #   @see Capybara::SessionMatchers#assert_current_path
+      #   See {Capybara::SessionMatchers#assert_current_path}
 
       ##
       # Assertion that current page does not match
       #
       # @!method refute_current_path
       # @!method assert_no_current_path
-      #   @see Capybara::SessionMatchers#assert_no_current_path
+      #   See {Capybara::SessionMatchers#assert_no_current_path}
 
       %w[text no_text title no_title current_path no_current_path].each do |assertion_name|
         class_eval <<-ASSERTION, __FILE__, __LINE__ + 1
@@ -65,37 +65,37 @@ module Capybara
       ## Assert selector exists on page
       #
       # @!method assert_selector
-      #   @see Capybara::Node::Matchers#assert_selector
+      #   See {Capybara::Node::Matchers#assert_selector}
 
       ## Assert selector does not exist on page
       #
       # @!method assert_no_selector
-      #   @see Capybara::Node::Matchers#assert_no_selector
+      #   See {Capybara::Node::Matchers#assert_no_selector}
 
       ## Assert element matches selector
       #
       # @!method assert_matches_selector
-      #   @see Capybara::Node::Matchers#assert_matches_selector
+      #   See {Capybara::Node::Matchers#assert_matches_selector}
 
       ## Assert element does not match selector
       #
       # @!method assert_xpath
-      #   @see Capybara::Node::Matchers#assert_not_matches_selector
+      #   See {Capybara::Node::Matchers#assert_not_matches_selector}
 
       ## Assert element has the provided CSS styles
       #
       # @!method assert_matches_style
-      #   @see Capybara::Node::Matchers#assert_matches_style
+      #   See {Capybara::Node::Matchers#assert_matches_style}
 
       ## Assert element has a matching sibling
       #
       # @!method assert_sibling
-      #   @see Capybara::Node::Matchers#assert_sibling
+      #   See {Capybara::Node::Matchers#assert_sibling}
 
       ## Assert element has a matching ancestor
       #
       # @!method assert_ancestor
-      #   @see Capybara::Node::Matchers#assert_ancestor
+      #   See {Capybara::Node::Matchers#assert_ancestor}
 
       %w[selector no_selector matches_style
          all_of_selectors none_of_selectors any_of_selectors
@@ -177,72 +177,72 @@ module Capybara
     # Assertion that there is xpath
     #
     # @!method assert_xpath
-    #   @see Capybara::Node::Matchers#has_xpath?
+    #   See {Capybara::Node::Matchers#has_xpath?}
 
     ##
     # Assertion that there is no xpath
     #
     # @!method refute_xpath
     # @!method assert_no_xpath
-    #   @see Capybara::Node::Matchers#has_no_xpath?
+    #   See {Capybara::Node::Matchers#has_no_xpath?}
 
     ##
     # Assertion that there is css
     #
     # @!method assert_css
-    #   @see Capybara::Node::Matchers#has_css?
+    #   See {Capybara::Node::Matchers#has_css?}
 
     ##
     # Assertion that there is no css
     #
     # @!method refute_css
     # @!method assert_no_css
-    #   @see Capybara::Node::Matchers#has_no_css?
+    #   See {Capybara::Node::Matchers#has_no_css?}
 
     ##
     # Assertion that there is link
     #
     # @!method assert_link
-    #   @see Capybara::Node::Matchers#has_link?
+    #   See {Capybara::Node::Matchers#has_link?}
 
     ##
     # Assertion that there is no link
     #
     # @!method assert_no_link
     # @!method refute_link
-    #   @see Capybara::Node::Matchers#has_no_link?
+    #   See {Capybara::Node::Matchers#has_no_link?}
 
     ##
     # Assertion that there is button
     #
     # @!method assert_button
-    #   @see Capybara::Node::Matchers#has_button?
+    #   See {Capybara::Node::Matchers#has_button?}
 
     ##
     # Assertion that there is no button
     #
     # @!method refute_button
     # @!method assert_no_button
-    #   @see Capybara::Node::Matchers#has_no_button?
+    #   See {Capybara::Node::Matchers#has_no_button?}
 
     ##
     # Assertion that there is field
     #
     # @!method assert_field
-    #   @see Capybara::Node::Matchers#has_field?
+    #   See {Capybara::Node::Matchers#has_field?}
 
     ##
     # Assertion that there is no field
     #
     # @!method refute_field
     # @!method assert_no_field
-    #   @see Capybara::Node::Matchers#has_no_field?
+    #   See {Capybara::Node::Matchers#has_no_field?}
 
     ##
     # Assertion that there is checked_field
     #
     # @!method assert_checked_field
-    #   @see Capybara::Node::Matchers#has_checked_field?
+    #   See {Capybara::Node::Matchers#has_checked_field?}
 
     ##
     # Assertion that there is no checked_field
@@ -254,7 +254,7 @@ module Capybara
     # Assertion that there is unchecked_field
     #
     # @!method assert_unchecked_field
-    #   @see Capybara::Node::Matchers#has_unchecked_field?
+    #   See {Capybara::Node::Matchers#has_unchecked_field?}
 
     ##
     # Assertion that there is no unchecked_field
@@ -266,27 +266,27 @@ module Capybara
     # Assertion that there is select
     #
     # @!method assert_select
-    #   @see Capybara::Node::Matchers#has_select?
+    #   See {Capybara::Node::Matchers#has_select?}
 
     ##
     # Assertion that there is no select
     #
     # @!method refute_select
     # @!method assert_no_select
-    #   @see Capybara::Node::Matchers#has_no_select?
+    #   See {Capybara::Node::Matchers#has_no_select?}
 
     ##
     # Assertion that there is table
     #
     # @!method assert_table
-    #   @see Capybara::Node::Matchers#has_table?
+    #   See {Capybara::Node::Matchers#has_table?}
 
     ##
     # Assertion that there is no table
     #
     # @!method refute_table
     # @!method assert_no_table
-    #   @see Capybara::Node::Matchers#has_no_table?
+    #   See {Capybara::Node::Matchers#has_no_table?}
 
     private
 

--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -6,13 +6,19 @@ require 'capybara/dsl'
 module Capybara
   module Minitest
     module Assertions
-      ## Assert text exists
+      ##
+      # Assert text exists
       #
+      # @!method assert_content
       # @!method assert_text
       #   See {Capybara::Node::Matchers#assert_text}
 
-      ## Assert text does not exist
+      ##
+      # Assert text does not exist
       #
+      # @!method refute_content
+      # @!method assert_no_content
+      # @!method refute_text
       # @!method assert_no_text
       #   See {Capybara::Node::Matchers#assert_no_text}
 
@@ -62,40 +68,81 @@ module Capybara
       alias_method :assert_content, :assert_text
       alias_method :assert_no_content, :refute_text
 
-      ## Assert selector exists on page
+      ##
+      # Assert selector exists on page
       #
       # @!method assert_selector
       #   See {Capybara::Node::Matchers#assert_selector}
 
-      ## Assert selector does not exist on page
+      ##
+      # Assert selector does not exist on page
       #
+      # @!method refute_selector
       # @!method assert_no_selector
       #   See {Capybara::Node::Matchers#assert_no_selector}
 
-      ## Assert element matches selector
+      ##
+      # Assert element matches selector
       #
       # @!method assert_matches_selector
       #   See {Capybara::Node::Matchers#assert_matches_selector}
 
-      ## Assert element does not match selector
+      ##
+      # Assert element does not match selector
       #
-      # @!method assert_xpath
+      # @!method refute_matches_selector
+      # @!method assert_not_matches_selector
       #   See {Capybara::Node::Matchers#assert_not_matches_selector}
 
-      ## Assert element has the provided CSS styles
+      ##
+      # Assert all of the provided selectors exist on page
+      #
+      # @!method assert_all_of_selectors
+      #   See {Capybara::Node::Matchers#assert_all_of_selectors}
+
+      ##
+      # Assert none of the provided selectors exist on page
+      #
+      # @!method assert_none_of_selectors
+      #   See {Capybara::Node::Matchers#assert_none_of_selectors}
+
+      ##
+      # Assert any of the provided selectors exist on page
+      #
+      # @!method assert_any_of_selectors
+      #   See {Capybara::Node::Matchers#assert_any_of_selectors}
+
+      ##
+      # Assert element has the provided CSS styles
       #
       # @!method assert_matches_style
       #   See {Capybara::Node::Matchers#assert_matches_style}
 
-      ## Assert element has a matching sibling
+      ##
+      # Assert element has a matching sibling
       #
       # @!method assert_sibling
       #   See {Capybara::Node::Matchers#assert_sibling}
 
-      ## Assert element has a matching ancestor
+      ##
+      # Assert element does not have a matching sibling
+      #
+      # @!method refute_sibling
+      # @!method assert_no_sibling
+      #   See {Capybara::Node::Matchers#assert_no_sibling}
+
+      ##
+      # Assert element has a matching ancestor
       #
       # @!method assert_ancestor
       #   See {Capybara::Node::Matchers#assert_ancestor}
+
+      ##
+      # Assert element does not have a matching ancestor
+      #
+      # @!method refute_ancestor
+      # @!method assert_no_ancestor
+      #   See {Capybara::Node::Matchers#assert_no_ancestor}
 
       %w[selector no_selector matches_style
          all_of_selectors none_of_selectors any_of_selectors
@@ -157,6 +204,32 @@ module Capybara
         ruby2_keywords "assert_no_#{field_type}_field" if respond_to?(:ruby2_keywords)
         alias_method "refute_#{field_type}_field", "assert_no_#{field_type}_field"
       end
+
+      ##
+      # Assert that element matches xpath
+      #
+      # @!method assert_matches_xpath
+      #   See {Capybara::Node::Matchers#matches_xpath?}
+
+      ##
+      # Assert that element does not match xpath
+      #
+      # @!method refute_matches_xpath
+      # @!method assert_not_matches_xpath
+      #   See {Capybara::Node::Matchers#not_matches_xpath?}
+
+      ##
+      # Assert that element matches css
+      #
+      # @!method assert_matches_css
+      #   See {Capybara::Node::Matchers#matches_css?}
+
+      ##
+      # Assert that element matches css
+      #
+      # @!method refute_matches_css
+      # @!method assert_not_matches_css
+      #   See {Capybara::Node::Matchers#not_matches_css?}
 
       %w[xpath css].each do |selector_type|
         define_method "assert_matches_#{selector_type}" do |*args, &optional_filter_block|
@@ -249,6 +322,7 @@ module Capybara
     #
     # @!method assert_no_checked_field
     # @!method refute_checked_field
+    #   See {Capybara::Node::Matchers#has_no_checked_field?}
 
     ##
     # Assertion that there is unchecked_field
@@ -261,6 +335,7 @@ module Capybara
     #
     # @!method assert_no_unchecked_field
     # @!method refute_unchecked_field
+    #   See {Capybara::Node::Matchers#has_no_unchecked_field?}
 
     ##
     # Assertion that there is select


### PR DESCRIPTION
Continuation of updates made in #2305 

Updates Minitest::Assertion documentation as follows:
- adds documentation for undocumented assertion methods
- adds "also known as" methods to existing method documentation
- updates `See {METHOD}` syntax to be consistent w/ rest of codebase

_before_
<img width="1440" alt="Screen Shot 2020-02-09 at 9 25 09 PM" src="https://user-images.githubusercontent.com/8152930/74116775-041c8b80-4b83-11ea-82b1-7ef477a8e970.png">
<img width="1440" alt="Screen Shot 2020-02-09 at 9 25 19 PM" src="https://user-images.githubusercontent.com/8152930/74116776-04b52200-4b83-11ea-9e3c-6627ae30e9fc.png">

----------
_after_
<img width="1440" alt="Screen Shot 2020-02-09 at 8 37 11 PM" src="https://user-images.githubusercontent.com/8152930/74116782-0a126c80-4b83-11ea-93f6-b9ea423c4ad8.png">
<img width="1440" alt="Screen Shot 2020-02-09 at 9 26 46 PM" src="https://user-images.githubusercontent.com/8152930/74116784-0a126c80-4b83-11ea-82cc-c65bf923bf74.png">
