### PR TITLE
Add support for ARIA button role attribute

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -81,6 +81,7 @@ module Capybara
     # - **default_selector** (`:css`, `:xpath` = `:css`) - Methods which take a selector use the given type by default. See also {Capybara::Selector}.
     # - **default_set_options** (Hash = `{}`) - The default options passed to {Capybara::Node::Element#set Element#set}.
     # - **enable_aria_label** (Boolean = `false`) - Whether fields, links, and buttons will match against `aria-label` attribute.
+    # - **enable_aria_button_role** (Boolean = `false`) - Buttons will match against element that has `role="button"` attribute.
     # - **exact** (Boolean = `false`) - Whether locators are matched exactly or with substrings. Only affects selector conditions
     #   written using the `XPath#is` method.
     # - **exact_text** (Boolean = `false`) - Whether the text matchers and `:text` filter match exactly or on substrings.
@@ -501,6 +502,7 @@ Capybara.configure do |config|
   config.visible_text_only = false
   config.automatic_label_click = false
   config.enable_aria_label = false
+  config.enable_aria_button_role = false
   config.reuse_server = true
   config.default_set_options = {}
   config.test_id = nil

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -14,6 +14,7 @@ module Capybara
       def initialize(*args,
                      session_options:,
                      enable_aria_label: session_options.enable_aria_label,
+                     enable_aria_button_role: session_options.enable_aria_button_role,
                      test_id: session_options.test_id,
                      selector_format: nil,
                      order: nil,
@@ -30,7 +31,11 @@ module Capybara
 
         @selector = Selector.new(
           find_selector(args[0].is_a?(Symbol) ? args.shift : args[0]),
-          config: { enable_aria_label: enable_aria_label, test_id: test_id },
+          config: {
+            enable_aria_label: enable_aria_label,
+            enable_aria_button_role: enable_aria_button_role,
+            test_id: test_id
+          },
           format: selector_format
         )
 

--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -4,6 +4,7 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
   xpath(:value, :title, :type, :name) do |locator, **options|
     input_btn_xpath = XPath.descendant(:input)[XPath.attr(:type).one_of('submit', 'reset', 'image', 'button')]
     btn_xpath = XPath.descendant(:button)
+    btn_xpath = btn_xpath.union(XPath.descendant[XPath.attr(:role).equals('button')]) if enable_aria_button_role
     image_btn_xpath = XPath.descendant(:input)[XPath.attr(:type) == 'image']
 
     unless locator.nil?

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -48,6 +48,10 @@ module Capybara
       @config[:enable_aria_label]
     end
 
+    def enable_aria_button_role
+      @config[:enable_aria_button_role]
+    end
+
     def test_id
       @config[:test_id]
     end

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -8,7 +8,7 @@ module Capybara
                  automatic_reload match exact exact_text raise_server_errors visible_text_only
                  automatic_label_click enable_aria_label save_path asset_host default_host app_host
                  server_host server_port server_errors default_set_options disable_animation test_id
-                 predicates_wait default_normalize_ws w3c_click_offset].freeze
+                 predicates_wait default_normalize_ws w3c_click_offset enable_aria_button_role].freeze
 
     attr_accessor(*OPTIONS)
 
@@ -36,6 +36,8 @@ module Capybara
     # @!method automatic_label_click
     #   See {Capybara.configure}
     # @!method enable_aria_label
+    #   See {Capybara.configure}
+    # @!method enable_aria_button_role
     #   See {Capybara.configure}
     # @!method save_path
     #   See {Capybara.configure}

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -108,6 +108,13 @@ $(function() {
     }, 4000);
     return false;
   });
+  $('#aria-button').click(function() {
+    var span = $(this);
+    setTimeout(function() {
+      $(span).after('<span role="button">ARIA button has been clicked</span>')
+    }, 1000);
+    return false;
+  });
   $('#waiter').change(function() {
     activeRequests = 1;
     setTimeout(function() {

--- a/lib/capybara/spec/session/click_button_spec.rb
+++ b/lib/capybara/spec/session/click_button_spec.rb
@@ -193,6 +193,17 @@ Capybara::SpecHelper.spec '#click_button' do
     end
   end
 
+  context 'when Capybara.enable_aria_button_role = true' do
+    it 'should click on a button role', requires: [:js] do
+      Capybara.enable_aria_button_role = true
+      @session.using_wait_time(1.5) do
+        @session.visit('/with_js')
+        @session.click_button('ARIA button')
+        expect(@session).to have_button('ARIA button has been clicked')
+      end
+    end
+  end
+
   context 'with fields associated with the form using the form attribute', requires: [:form_attribute] do
     let(:results) { extract_results(@session) }
 

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -39,6 +39,14 @@ Capybara::SpecHelper.spec '#has_button?' do
     expect(@session).to have_button('awe123', type: 'submit')
     expect(@session).not_to have_button('awe123', type: 'reset')
   end
+
+  it 'should be true for role=button when enable_aria_button_role: true' do
+    expect(@session).to have_button('ARIA button', enable_aria_button_role: true)
+  end
+
+  it 'should be false for role=button when enable_aria_button_role: false' do
+    expect(@session).not_to have_button('ARIA button', enable_aria_button_role: false)
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_button?' do
@@ -65,5 +73,13 @@ Capybara::SpecHelper.spec '#has_no_button?' do
 
   it 'should be false for disabled buttons if disabled: false' do
     expect(@session).to have_no_button('Disabled button', disabled: false)
+  end
+
+  it 'should be true for role=button when enable_aria_button_role: false' do
+    expect(@session).to have_no_button('ARIA button', enable_aria_button_role: false)
+  end
+
+  it 'should be false for role=button when enable_aria_button_role: true' do
+    expect(@session).not_to have_no_button('ARIA button', enable_aria_button_role: true)
   end
 end

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -30,6 +30,7 @@ module Capybara
         Capybara.visible_text_only = false
         Capybara.match = :smart
         Capybara.enable_aria_label = false
+        Capybara.enable_aria_button_role = false
         Capybara.default_set_options = {}
         Capybara.disable_animation = false
         Capybara.test_id = nil

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -453,6 +453,7 @@ New line after and before textarea tag
     <button id="no_type">No Type!</button>
     <button><img alt="A horse eating hay"/></button>
     <input type="button" disabled="disabled" value="Disabled button"/>
+    <span role="button">ARIA button</span>
   </p>
 
   <p>

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -35,6 +35,7 @@
 
     <p><a href="#" id="clickable">Click me</a></p>
     <p><a href="#" id="slow-click">Slowly</a></p>
+    <p><span id="aria-button" role="button">ARIA button</span></p>
 
     <p>
       <select id="waiter">


### PR DESCRIPTION
This adds support for matching on the role=button when finding button element.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role