### PR TITLE
Fix have_text description

### DIFF
--- a/lib/capybara/rspec/matchers/have_text.rb
+++ b/lib/capybara/rspec/matchers/have_text.rb
@@ -15,7 +15,7 @@ module Capybara
         end
 
         def description
-          "text #{format(text)}"
+          "have text #{format(text)}"
         end
 
         def format(content)

--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -265,7 +265,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
 
   describe 'have_content matcher' do
     it 'gives proper description' do
-      expect(have_content('Text').description).to eq('text "Text"')
+      expect(have_content('Text').description).to eq('have text "Text"')
     end
 
     context 'on a string' do
@@ -369,7 +369,7 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
 
   describe 'have_text matcher' do
     it 'gives proper description' do
-      expect(have_text('Text').description).to eq('text "Text"')
+      expect(have_text('Text').description).to eq('have text "Text"')
     end
 
     context 'on a string' do


### PR DESCRIPTION
All other matchers have descriptions that begin with the word `have`, like `have title` or `have current path`, so doing stuff like `it { is_expected.to have_title("Hello World") }`
gives `is expected to have title "Hello World"`
but currently, `it { is_expected.to have_text("Hello World") }`
gives `is expected to text "Hello World"` which seems wrong.

This PR fixes that.