### PR TITLE
Fixes ruby 2.7 deprecation warning when registering webrick

### DIFF
--- a/lib/capybara/registrations/servers.rb
+++ b/lib/capybara/registrations/servers.rb
@@ -7,7 +7,7 @@ end
 Capybara.register_server :webrick do |app, port, host, **options|
   require 'rack/handler/webrick'
   options = { Host: host, Port: port, AccessLog: [], Logger: WEBrick::Log.new(nil, 0) }.merge(options)
-  Rack::Handler::WEBrick.run(app, options)
+  Rack::Handler::WEBrick.run(app, **options)
 end
 
 Capybara.register_server :puma do |app, port, host, **options|


### PR DESCRIPTION
I'm not sure what (if any) test would be appropriate for this change (I looked at the earlier batch of 2.7 deprecation changes, and nothing stood out), but I'm happy to oblige.
