### PR TITLE
Update broken link from Rspec Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ require 'capybara/rspec'
 
 If you are using Rails, put your Capybara specs in `spec/features` or `spec/system` (only works
 if [you have it configured in
-RSpec](https://www.relishapp.com/rspec/rspec-rails/docs/upgrade#file-type-inference-disabled))
+RSpec](https://relishapp.com/rspec/rspec-rails/v/4-0/docs/feature-specs/feature-spec))
 and if you have your Capybara specs in a different directory, then tag the
 example groups with `type: :feature` or `type: :system` depending on which type of test you're writing.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ require 'capybara/rspec'
 
 If you are using Rails, put your Capybara specs in `spec/features` or `spec/system` (only works
 if [you have it configured in
-RSpec](https://relishapp.com/rspec/rspec-rails/v/4-0/docs/feature-specs/feature-spec))
+RSpec](https://relishapp.com/rspec/rspec-rails/v/4-0/docs/directory-structure))
 and if you have your Capybara specs in a different directory, then tag the
 example groups with `type: :feature` or `type: :system` depending on which type of test you're writing.
 


### PR DESCRIPTION
Rspec documentation was updated recently and the old link is not working anymore. This fixes it with the current equivalent information.