### PR TITLE
Fix #set_text behavior with clear: :none option

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -537,9 +537,11 @@ private
   RAPID_SET_TEXT = <<~'JS'
     (function(el, value) {
       if (el.maxLength && el.maxLength != -1){
-        value = value.slice(0, el.maxLength);
+        value = el.value + value;
+        el.value = value.slice(0, el.maxLength);
+      } else {
+        el.value = el.value + value;
       }
-      el.value = el.value + value;
     })(arguments[0], arguments[1])
   JS
 

--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -281,7 +281,7 @@ private
       driver.execute_script 'arguments[0].select()', self unless clear == :none
       if rapid == true || ((value.length > auto_rapid_set_length) && rapid != false)
         send_keys(value[0..3])
-        driver.execute_script RAPID_SET_TEXT, self, value[0...-3]
+        driver.execute_script RAPID_SET_TEXT, self, value[4...-3]
         send_keys(value[-3..-1])
       else
         send_keys(value)
@@ -539,7 +539,7 @@ private
       if (el.maxLength && el.maxLength != -1){
         value = value.slice(0, el.maxLength);
       }
-      el.value = value;
+      el.value = el.value + value;
     })(arguments[0], arguments[1])
   JS
 

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -160,6 +160,15 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
                         fill_options: { clear: :none })
         expect(session.find(:fillable_field, 'form_first_name').value).to eq('JohnHarry')
       end
+
+      it 'works with rapid fill' do
+        pending 'Safari overwrites by default - need to figure out a workaround' if safari?(session)
+
+        long_string = (0...60).map { |i| ((i % 26) + 65).chr }.join
+        session.visit('/form')
+        session.fill_in('form_first_name', with: long_string, fill_options: { clear: :none })
+        expect(session.find(:fillable_field, 'form_first_name').value).to eq('John' + long_string)
+      end
     end
 
     describe '#fill_in with Date' do


### PR DESCRIPTION
## Overview

After 696f9d3 are committed, Capybara has been overwrite form input even if `clear: :none` option is provided.
This bug occur with rapid fill when input over 30 words.

This PR fixes that.