### PR TITLE
Start synchronize timeout countdown after yield

### DIFF
--- a/lib/capybara/node/base.rb
+++ b/lib/capybara/node/base.rb
@@ -78,7 +78,6 @@ module Capybara
 
         seconds = session_options.default_max_wait_time if [nil, true].include? seconds
         session.synchronized = true
-        timer = Capybara::Helpers.timer(expire_in: seconds)
         begin
           yield
         rescue StandardError => e
@@ -86,6 +85,7 @@ module Capybara
           raise e unless catch_error?(e, errors)
 
           if driver.wait?
+            timer ||= Capybara::Helpers.timer(expire_in: seconds)
             raise e if timer.expired?
 
             sleep(0.01)


### PR DESCRIPTION
While debugging a flaky spec I noticed that first call to visible text retrieval from selenium chrome driver may be very slow, the subsequent text queries don't have that issue. As a result I see the following message in ajax specs

> expected to find text "new-text" in "add text". (However, it was found 1 time including non-visible text.)

Current implementation of `wait` starts timer before making a first text query, this PR starts timer only after the first call.

Issue might be related to css application/caching process browser does under the hood, since I was only able to reproduce issue with tons of css. A minimal gist that demonstrates issue is available here https://gist.github.com/artygus/3ac4dd463658e288caf2742e15b97514, `setTimeout` replaces ajax call

Chrome driver version: 83.0.4103.39