### PR TITLE
Fix Ruby 2.7 warning in minitest assert_text

### DIFF
--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -50,15 +50,14 @@ module Capybara
 
       %w[text no_text title no_title current_path no_current_path].each do |assertion_name|
         class_eval <<-ASSERTION, __FILE__, __LINE__ + 1
-          def assert_#{assertion_name} *args
+          def assert_#{assertion_name}(*args, **kwargs)
             self.assertions +=1
             subject, args = determine_subject(args)
-            subject.assert_#{assertion_name}(*args)
+            subject.assert_#{assertion_name}(*args, **kwargs)
           rescue Capybara::ExpectationNotMet => e
             raise ::Minitest::Assertion, e.message
           end
         ASSERTION
-        ruby2_keywords "assert_#{assertion_name}" if respond_to?(:ruby2_keywords)
       end
 
       alias_method :refute_title, :assert_no_title

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -16,7 +16,7 @@ class MinitestTest < Minitest::Test
   end
 
   def test_assert_text
-    assert_text('Form')
+    assert_text('Form', normalize_ws: false)
     assert_no_text('Not on the page')
     refute_text('Also Not on the page')
   end


### PR DESCRIPTION
In our application at GitHub we were seeing a warning coming from
`assert_text` on the latest version and building the source from master.

Warning we were seeing:

```
/vendor/gems/2.7.1/ruby/2.7.0/gems/capybara-3.32.2/lib/capybara/minitest.rb:56: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/vendor/gems/2.7.1/ruby/2.7.0/gems/capybara-3.32.2/lib/capybara/minitest.rb:56:in `assert_text'
```

The warning is only visible when `assert_text` is delegated from
minitest which is why I've updated the minitest_spec.rb file to include
an argument. I was unable to see or reproduce this warning in the assert
text test.

I don't really get why `ruby2_keywords` wasn't adequate for this change
but from my testing my changes work in Ruby 2.6 and 2.7 and fix the
warning in 2.7.