### PR TITLE
Ignore failure when IE fails to perform `reset_sessions!`

### DIFF
--- a/lib/capybara/selenium/driver_specializations/internet_explorer_driver.rb
+++ b/lib/capybara/selenium/driver_specializations/internet_explorer_driver.rb
@@ -15,6 +15,13 @@ module Capybara::Selenium::Driver::InternetExplorerDriver
 
 private
 
+  def clear_storage
+    clear_session_storage unless !!options[:clear_session_storage]
+    clear_local_storage unless !!options[:clear_local_storage]
+  rescue Selenium::WebDriver::Error::JavascriptError
+    # session/local storage may not be available if on non-http pages (e.g. about:blank)
+  end
+
   def build_node(native_node, initial_cache = {})
     ::Capybara::Selenium::IENode.new(self, native_node, initial_cache)
   end


### PR DESCRIPTION
From SHA:

IE Does not seem to expose the endpoint for clearing local storage. So when trying to reset a session (Default behaviour in capybara/cucumber), we should just ignore this missing endpoint - As the session has still been 'reset'

This is a default hook added, and making this small tweak seems to have the desired effect of not making IE fail with an untraceable hook.

PS: I added the file to gitignore as it kept adding it to my changed files.