### PR TITLE
Add support for custom message to `assert_selector`

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -104,6 +104,7 @@ module Capybara
       #
       # @param (see Capybara::Node::Finders#all)
       # @option options [Integer] :count (nil)    Number of times the expression should occur
+      # @option options [String] :message (nil)   Custom message to display if assertion fails
       # @raise [Capybara::ExpectationNotMet]      If the selector does not exist
       #
       def assert_selector(*args, &optional_filter_block)

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -9,7 +9,7 @@ module Capybara
 
       SPATIAL_KEYS = %i[above below left_of right_of near].freeze
       VALID_KEYS = SPATIAL_KEYS + COUNT_KEYS +
-                   %i[text id class style visible obscured exact exact_text normalize_ws match wait filter_set]
+                   %i[text id class style visible obscured exact exact_text normalize_ws match wait filter_set message]
       VALID_MATCH = %i[first smart prefer_exact one].freeze
 
       def initialize(*args,

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -115,6 +115,8 @@ module Capybara
     end
 
     def failure_message
+      return @query.options[:message] if @query.options[:message]
+
       message = @query.failure_message
       if count.zero?
         message << ' but there were no matches'


### PR DESCRIPTION
### Problem

As a developer writing tests, the built-in error messages
for assert_selector can sometimes be confusing/not clear.

### Solution
Allow for custom error messages for `assert_selector`.

This PR is just an idea. I could see us adding this option
to all the assertion helpers in Capybara, but wanted to get
feedback on the idea first :heart:. I'd be happy to implement
this feature throughout the library if desired.