### PR TITLE
Add uplelvel to deprecation warning of Capybara

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Layout/LineLength:
   IgnoredPatterns:
     - '\s+# _?rubocop'
     - '^\s*#'
-    - '^\s*(raise|warn) '
+    - '^\s*(raise|warn|Capybara::Helpers.warn) '
   Max: 120
 
 Metrics/BlockLength:

--- a/lib/capybara/config.rb
+++ b/lib/capybara/config.rb
@@ -84,7 +84,7 @@ module Capybara
     def deprecate(method, alternate_method, once = false)
       @deprecation_notified ||= {}
       unless once && @deprecation_notified[method]
-        warn "DEPRECATED: ##{method} is deprecated, please use ##{alternate_method} instead: #{Capybara::Helpers.filter_backtrace(caller)}"
+        Capybara::Helpers.warn "DEPRECATED: ##{method} is deprecated, please use ##{alternate_method} instead: #{Capybara::Helpers.filter_backtrace(caller)}"
       end
       @deprecation_notified[method] = true
     end

--- a/lib/capybara/helpers.rb
+++ b/lib/capybara/helpers.rb
@@ -15,7 +15,7 @@ module Capybara
     # @return [String]         Normalized text
     #
     def normalize_whitespace(text)
-      warn 'DEPRECATED: Capybara::Helpers::normalize_whitespace is deprecated, please update your driver'
+      Capybara::Helpers.warn 'DEPRECATED: Capybara::Helpers::normalize_whitespace is deprecated, please update your driver'
       text.to_s.gsub(/[[:space:]]+/, ' ').strip
     end
 
@@ -79,6 +79,16 @@ module Capybara
       new_trace = trace.dup if new_trace.empty?
 
       new_trace.first.split(/:in /, 2).first
+    end
+
+    # Workaround for emulating `warn '...', uplevel: n` in Ruby 2.5 or lower.
+    def warn(message, uplevel: 1)
+      if (match = /^(?<file>.+?):(?<line>\d+)(?::in `.*')?/.match(caller[uplevel]))
+        location = [match[:file], match[:line]].join(':')
+        Kernel.warn "#{location}: #{message}"
+      else
+        Kernel.warn message
+      end
     end
 
     if defined?(Process::CLOCK_MONOTONIC)

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -69,7 +69,7 @@ module Capybara
       # @deprecated Use {#matches_style?} instead.
       #
       def has_style?(styles = nil, **options)
-        warn "DEPRECATED: has_style? is deprecated, please use matches_style? : #{Capybara::Helpers.filter_backtrace(caller)}"
+        Capybara::Helpers.warn "DEPRECATED: has_style? is deprecated, please use matches_style? : #{Capybara::Helpers.filter_backtrace(caller)}"
         matches_style?(styles, **options)
       end
 

--- a/lib/capybara/registration_container.rb
+++ b/lib/capybara/registration_container.rb
@@ -12,13 +12,13 @@ module Capybara
     end
 
     def []=(name, value)
-      warn 'DEPRECATED: Directly setting drivers/servers is deprecated, please use Capybara.register_driver/register_server instead'
+      Capybara::Helpers.warn 'DEPRECATED: Directly setting drivers/servers is deprecated, please use Capybara.register_driver/register_server instead'
       @registered[name] = value
     end
 
     def method_missing(method_name, *args, **options, &block)
       if @registered.respond_to?(method_name)
-        warn "DEPRECATED: Calling '#{method_name}' on the drivers/servers container is deprecated without replacement"
+        Capybara::Helpers.warn "DEPRECATED: Calling '#{method_name}' on the drivers/servers container is deprecated without replacement"
         # RUBY 2.6 will send an empty hash rather than nothing with **options so fix that
         return @registered.public_send(method_name, *args, &block) if options.empty?
 

--- a/lib/capybara/rspec/matchers.rb
+++ b/lib/capybara/rspec/matchers.rb
@@ -155,7 +155,7 @@ module Capybara
     # @deprecated
     #
     def have_style(styles = nil, **options)
-      warn "DEPRECATED: have_style is deprecated, please use match_style : #{Capybara::Helpers.filter_backtrace(caller)}"
+      Capybara::Helpers.warn "DEPRECATED: have_style is deprecated, please use match_style : #{Capybara::Helpers.filter_backtrace(caller)}"
       match_style(styles, **options)
     end
 

--- a/lib/capybara/selector/definition/css.rb
+++ b/lib/capybara/selector/definition/css.rb
@@ -3,7 +3,7 @@
 Capybara.add_selector(:css, locator_type: [String, Symbol], raw_locator: true) do
   css do |css|
     if css.is_a? Symbol
-      warn "DEPRECATED: Passing a symbol (#{css.inspect}) as the CSS locator is deprecated - please pass a string instead : #{Capybara::Helpers.filter_backtrace(caller)}"
+      Capybara::Helpers.warn "DEPRECATED: Passing a symbol (#{css.inspect}) as the CSS locator is deprecated - please pass a string instead : #{Capybara::Helpers.filter_backtrace(caller)}"
     end
     css
   end

--- a/lib/capybara/selector/filter_set.rb
+++ b/lib/capybara/selector/filter_set.rb
@@ -49,7 +49,7 @@ module Capybara
       end
 
       def descriptions
-        warn 'DEPRECATED: FilterSet#descriptions is deprecated without replacement'
+        Capybara::Helpers.warn 'DEPRECATED: FilterSet#descriptions is deprecated without replacement'
         [undeclared_descriptions, node_filter_descriptions, expression_filter_descriptions].flatten
       end
 

--- a/lib/capybara/spec/session/has_css_spec.rb
+++ b/lib/capybara/spec/session/has_css_spec.rb
@@ -14,8 +14,9 @@ Capybara::SpecHelper.spec '#has_css?' do
     # This was never a specifically accepted format but it has worked for a
     # lot of versions.
     # TODO: Remove in 4.0
-    expect_any_instance_of(Kernel).to receive(:warn) # rubocop:disable RSpec/AnyInstance
+    allow(Capybara::Helpers).to receive(:warn).and_return(nil)
     expect(@session).to have_css(:p)
+    expect(Capybara::Helpers).to have_received(:warn)
   end
 
   it 'should be false if the given selector is not on the page' do

--- a/lib/capybara/spec/session/matches_style_spec.rb
+++ b/lib/capybara/spec/session/matches_style_spec.rb
@@ -28,8 +28,8 @@ Capybara::SpecHelper.spec '#matches_style?', requires: [:css] do
       output(/have_style is deprecated/).to_stderr
 
     el = @session.find(:css, '#first')
-    allow(el).to receive(:warn).and_return(nil)
+    allow(Capybara::Helpers).to receive(:warn).and_return(nil)
     el.has_style?('display' => /^bl/)
-    expect(el).to have_received(:warn)
+    expect(Capybara::Helpers).to have_received(:warn)
   end
 end


### PR DESCRIPTION
Follow https://github.com/teamcapybara/capybara/issues/2371.

This PR adds `uplelvel` to deprecation warning of Capybara.
The `uplevel` option has been introduced from Ruby 2.6.

> If the `uplevel` keyword argument is given, the string will be prepended with information for the given caller frame in the same format used by the `rb_warn` C function.

https://ruby-doc.org/core-2.6.0/Kernel.html#method-i-warn

On the other hand, Capybara supports Ruby 2.5.
Therefore, This PR adds `Capybara::Helpers.warn` internal method for emulating `warn 'message', uplevel: 1` in Ruby 2.5 or lower.
This option will clarify where deprecation warnings should be fixed.

## Before

```console
DEPRECATED: Calling 'has_key?' on the drivers/servers container is
deprecated without replacement
```

## After

```console
/Users/koic/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/turnip-4.1.0/
lib/turnip/capybara.rb:10: warning:
DEPRECATED: Calling 'has_key?' on the drivers/servers container is
deprecated without replacement
```