### PR TITLE
Avoid a NoMethodError about min_threads= in Puma 5.0.1

### DIFF
--- a/lib/capybara/registrations/servers.rb
+++ b/lib/capybara/registrations/servers.rb
@@ -39,6 +39,9 @@ Capybara.register_server :puma do |app, port, host, **options|
 
   Puma::Server.new(conf.app, events, conf.options).tap do |s|
     s.binder.parse conf.options[:binds], s.events
-    s.min_threads, s.max_threads = conf.options[:min_threads], conf.options[:max_threads]
+    # Puma v5.0.1 dropped these setters
+    if s.respond_to?(:min_threads=) && s.respond_to?(:max_threads=)
+      s.min_threads, s.max_threads = conf.options[:min_threads], conf.options[:max_threads]
+    end
   end.run.join
 end


### PR DESCRIPTION
This PR attempts to work around a configuration change in Puma v5.0.1: two accessor setters had been turned into readers.

## Background

  - https://github.com/puma/puma/commit/bbbdfb8f4c9ac1da5140d910cd0814bd7478791a removed two setters
  - v5.0.1 released it

What the error looks like when running:

```
Traceback (most recent call last):
        5: from /home/olle/.devbox/code/app/gems/gems/capybara-3.33.0/lib/capybara/server.rb:77:in `block in boot'
        4: from /home/olle/.devbox/code/app/gems/gems/capybara-3.33.0/lib/capybara/registrations/servers.rb:4:in `block in <top (required)>'
        3: from /home/olle/.devbox/code/app/gems/gems/capybara-3.33.0/lib/capybara.rb:252:in `run_default_server'
        2: from /home/olle/.devbox/code/app/gems/gems/capybara-3.33.0/lib/capybara/registrations/servers.rb:40:in `block in <top (required)>'
        1: from /home/olle/.devbox/code/app/gems/gems/capybara-3.33.0/lib/capybara/registrations/servers.rb:40:in `tap'
/home/olle/.devbox/code/app/gems/gems/capybara-3.33.0/lib/capybara/registrations/servers.rb:42:in `block (2 levels) 
in <top (required)>': undefined method `min_threads=' for #<Puma::Server:0x000055e569d0e798> (NoMethodError)
Did you mean?  min_threads
               max_threads

```

New API is: The hash of options in the constructor takes `min_threads` and `max_threads`. We already have that data in the passed-in options.


## Solution

Check for the presence of the `:min_threads=` and `:max_threads=` setters.

