### PR TITLE
Add "scroll-behavior: auto" CSS to Capybara::Server::AnimationDisabler

### DIFF
--- a/lib/capybara/server/animation_disabler.rb
+++ b/lib/capybara/server/animation_disabler.rb
@@ -46,10 +46,11 @@ module Capybara
       DISABLE_MARKUP_TEMPLATE = <<~HTML
         <script defer>(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
         <style>
-           %<selector>s, %<selector>s::before, %<selector>s::after {
+          %<selector>s, %<selector>s::before, %<selector>s::after {
              transition: none !important;
              animation-duration: 0s !important;
              animation-delay: 0s !important;
+             scroll-behavior: auto !important;
           }
         </style>
       HTML

--- a/lib/capybara/spec/views/with_animation.erb
+++ b/lib/capybara/spec/views/with_animation.erb
@@ -18,6 +18,14 @@
       });
     </script>
     <style>
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        min-height: 2000px;
+      }
+
       .transition.away {
           width: 0%;
       }


### PR DESCRIPTION
I have some test cases where I need to call `page.execute_script('window.scrollTo(0, 0)')` before taking a screenshot. I'm using [Tabler](https://tabler.io/), which [sets `scroll-behavior: smooth;`](https://github.com/tabler/tabler/blob/542e3541c18ccbb7d26265fd70b9357f4f4e23ea/scss/layout/_core.scss#L4), so any scroll actions are smoothly animated. This is nice in production, but annoying during tests.

This proposed change will cause the scroll to always complete instantly without any animations. (This will only work when using the default `selector_for` value of `'*'`, so that the rule matches the `html` element.)

[`scroll-behavior: auto` is the default value](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior), so I don't think this change should cause any problems.

I've added some tests, including an "inverse" test for `Capybara.disable_animation = false`. I think this important to show that `scroll-behavior: smooth;` does affect the scrolling speed, so that the test will have no false negatives.

EDIT: I just remembered another change that I made in my own version:

```
caret-color: transparent;
```

This is also very helpful during some of my screenshot diff tests where I'm checking that form inputs are rendered and filled in correctly.

Would it be ok to add `caret-color: transparent;`? I would love to start using the built-in `AnimationDisabler` from Capybara, but I really need this `caret-color: transparent;` as well. Or would it be possible to add the option to inject my own custom CSS?

EDIT 2: What do you think about [this `disable_animation_extra_properties` change](https://github.com/DocSpring/capybara/commit/54f333ff20bcbf94ad6e962e0e25bedc60ab0d29), so that I can set `Capybara.disable_animation_extra_properties = 'caret-color: transparent;'`?