### PR TITLE
Find <button> elements through <label>

### DIFF
--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -19,11 +19,12 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
       locator_matchers |= XPath.attr(test_id) == locator if test_id
 
       input_btn_xpath = input_btn_xpath[locator_matchers]
+      input_btn_xpath += XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(input_btn_xpath)
 
       btn_xpath = btn_xpath[locator_matchers |
                             XPath.string.n.is(locator) |
-                            XPath.descendant(:label)[XPath.string.n.is(locator)] |
                             XPath.descendant(:img)[XPath.attr(:alt).is(locator)]]
+      btn_xpath += XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(btn_xpath)
 
       alt_matches = XPath.attr(:alt).is(locator)
       alt_matches |= XPath.attr(:'aria-label').is(locator) if enable_aria_label

--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -12,7 +12,9 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
       locator_matchers = XPath.attr(:id).equals(locator) |
                          XPath.attr(:name).equals(locator) |
                          XPath.attr(:value).is(locator) |
-                         XPath.attr(:title).is(locator)
+                         XPath.attr(:title).is(locator) |
+                         (XPath.attr(:id) == XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))
+
       locator_matchers |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
       locator_matchers |= XPath.attr(test_id) == locator if test_id
 
@@ -20,6 +22,7 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
 
       btn_xpath = btn_xpath[locator_matchers |
                             XPath.string.n.is(locator) |
+                            XPath.descendant(:label)[XPath.string.n.is(locator)] |
                             XPath.descendant(:img)[XPath.attr(:alt).is(locator)]]
 
       alt_matches = XPath.attr(:alt).is(locator)

--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -9,24 +9,24 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
 
     unless locator.nil?
       locator = locator.to_s
-      attr_matchers = XPath.attr(:id).equals(locator) |
-                      XPath.attr(:name).equals(locator) |
-                      XPath.attr(:value).is(locator) |
-                      XPath.attr(:title).is(locator) |
-                      (XPath.attr(:id) == XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))
-      attr_matchers |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
-      attr_matchers |= XPath.attr(test_id) == locator if test_id
+      locator_matchers = XPath.attr(:id).equals(locator) |
+                         XPath.attr(:name).equals(locator) |
+                         XPath.attr(:value).is(locator) |
+                         XPath.attr(:title).is(locator) |
+                         (XPath.attr(:id) == XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))
+      locator_matchers |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
+      locator_matchers |= XPath.attr(test_id) == locator if test_id
 
-      input_btn_xpath = input_btn_xpath[attr_matchers] +
-        XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(input_btn_xpath)
+      input_btn_xpath = input_btn_xpath[locator_matchers] + locate_label(locator).descendant(input_btn_xpath)
 
-      btn_xpath = btn_xpath[attr_matchers | XPath.string.n.is(locator) | XPath.descendant(:img)[XPath.attr(:alt).is(locator)]] +
-        XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(btn_xpath)
+      btn_xpath = btn_xpath[locator_matchers |
+                            XPath.string.n.is(locator) |
+                            XPath.descendant(:img)[XPath.attr(:alt).is(locator)]
+                           ] + locate_label(locator).descendant(btn_xpath)
 
       alt_matches = XPath.attr(:alt).is(locator)
       alt_matches |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
-      image_btn_xpath = image_btn_xpath[alt_matches] +
-        XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(image_btn_xpath)
+      image_btn_xpath = image_btn_xpath[alt_matches] + locate_label(locator).descendant(image_btn_xpath)
     end
 
     %i[value title type].inject(input_btn_xpath.union(btn_xpath).union(image_btn_xpath)) do |memo, ef|

--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -9,26 +9,24 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
 
     unless locator.nil?
       locator = locator.to_s
-      locator_matchers = XPath.attr(:id).equals(locator) |
-                         XPath.attr(:name).equals(locator) |
-                         XPath.attr(:value).is(locator) |
-                         XPath.attr(:title).is(locator) |
-                         (XPath.attr(:id) == XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))
+      attr_matchers = XPath.attr(:id).equals(locator) |
+                      XPath.attr(:name).equals(locator) |
+                      XPath.attr(:value).is(locator) |
+                      XPath.attr(:title).is(locator) |
+                      (XPath.attr(:id) == XPath.anywhere(:label)[XPath.string.n.is(locator)].attr(:for))
+      attr_matchers |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
+      attr_matchers |= XPath.attr(test_id) == locator if test_id
 
-      locator_matchers |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
-      locator_matchers |= XPath.attr(test_id) == locator if test_id
+      input_btn_xpath = input_btn_xpath[attr_matchers] +
+        XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(input_btn_xpath)
 
-      input_btn_xpath = input_btn_xpath[locator_matchers]
-      input_btn_xpath += XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(input_btn_xpath)
-
-      btn_xpath = btn_xpath[locator_matchers |
-                            XPath.string.n.is(locator) |
-                            XPath.descendant(:img)[XPath.attr(:alt).is(locator)]]
-      btn_xpath += XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(btn_xpath)
+      btn_xpath = btn_xpath[attr_matchers | XPath.string.n.is(locator) | XPath.descendant(:img)[XPath.attr(:alt).is(locator)]] +
+        XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(btn_xpath)
 
       alt_matches = XPath.attr(:alt).is(locator)
       alt_matches |= XPath.attr(:'aria-label').is(locator) if enable_aria_label
-      image_btn_xpath = image_btn_xpath[alt_matches]
+      image_btn_xpath = image_btn_xpath[alt_matches] +
+        XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(image_btn_xpath)
     end
 
     %i[value title type].inject(input_btn_xpath.union(btn_xpath).union(image_btn_xpath)) do |memo, ef|

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -132,7 +132,11 @@ module Capybara
       attr_matchers |= XPath.attr(test_id) == locator if test_id
 
       locate_xpath = locate_xpath[attr_matchers]
-      locate_xpath + XPath.descendant(:label)[XPath.string.n.is(locator)].descendant(xpath)
+      locate_xpath + locate_label(locator).descendant(xpath)
+    end
+
+    def locate_label(locator)
+      XPath.descendant(:label)[XPath.string.n.is(locator)]
     end
 
     def find_by_attr(attribute, value)

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -9,6 +9,8 @@ Capybara::SpecHelper.spec '#has_button?' do
     expect(@session).to have_button('med')
     expect(@session).to have_button('crap321')
     expect(@session).to have_button(:crap321)
+    expect(@session).to have_button('button with label element')
+    expect(@session).to have_button('button within label element')
   end
 
   it 'should be true for disabled buttons if disabled: true' do

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -456,6 +456,12 @@ New line after and before textarea tag
     <button type="submit" name="form[no_value]">No Value!</button>
     <button id="no_type">No Type!</button>
     <button><img alt="A horse eating hay"/></button>
+    <button id="button_with_label"></button>
+    <label for="button_with_label">button with label element</label>
+    <label>
+      button within label element
+      <button></button>
+    </label>
     <input type="button" disabled="disabled" value="Disabled button"/>
     <span role="button">ARIA button</span>
   </p>


### PR DESCRIPTION
Browsers consider [<button> elements][mdn-button] as
["labelable"][labelable], meaning that a `<button
id="button-with-label">` element can be labelled by a [`<label
for="button-with-label">` element][mdn-label].

This commit extends the button selector to resolve `<button>` elements
with a locator that references a `<label>` element's text. That
`<label>` element can either reference the button through its `[for]`
attribute, or it can be an ancestor of the `<button>` element.

[labelable]: https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable
[mdn-button]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
[mdn-label]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

