### PR TITLE
Fix various comment typos

### DIFF
--- a/lib/capybara/selector/definition.rb
+++ b/lib/capybara/selector/definition.rb
@@ -83,7 +83,7 @@ module Capybara
       # Automatic selector detection
       #
       # @yield [locator]                   This block takes the passed in locator string and returns whether or not it matches the selector
-      # @yieldparam [String], locator      The locator string used to determin if it matches the selector
+      # @yieldparam [String], locator      The locator string used to determine if it matches the selector
       # @yieldreturn [Boolean]             Whether this selector matches the locator string
       # @return [#call]                    The block that will be used to detect selector match
       #

--- a/lib/capybara/session/matchers.rb
+++ b/lib/capybara/session/matchers.rb
@@ -13,7 +13,7 @@ module Capybara
     #     @param string [String]           The string that the current 'path' should equal
     #   @overload $0(regexp, **options)
     #     @param regexp [Regexp]           The regexp that the current 'path' should match to
-    #   @option options [Boolean] :url (true if `string` ia a full url, otherwise false) Whether the compare should be done against the full current url or just the path
+    #   @option options [Boolean] :url (true if `string` is a full url, otherwise false) Whether the comparison should be done against the full current url or just the path
     #   @option options [Boolean] :ignore_query (false)  Whether the query portion of the current url/path should be ignored
     #   @option options [Numeric] :wait (Capybara.default_max_wait_time) Maximum time that Capybara will wait for the current url/path to eq/match given string/regexp argument
     # @raise [Capybara::ExpectationNotMet] if the assertion hasn't succeeded during wait time

--- a/lib/capybara/window.rb
+++ b/lib/capybara/window.rb
@@ -4,7 +4,7 @@ module Capybara
   ##
   # The {Window} class represents a browser window.
   #
-  # You can get an instance of the class by calling either of:
+  # You can get an instance of the class by calling any of:
   #
   # * {Capybara::Session#windows}
   # * {Capybara::Session#current_window}
@@ -82,8 +82,8 @@ module Capybara
     # Resize window.
     #
     # @macro about_current
-    # @param width [String]  the new window width in pixels
-    # @param height [String]  the new window height in pixels
+    # @param width [Integer]  the new window width in pixels
+    # @param height [Integer]  the new window height in pixels
     #
     def resize_to(width, height)
       wait_for_stable_size { @driver.resize_window_to(handle, width, height) }


### PR DESCRIPTION
Changes the documentation for the `width` and `height` arguments for `Window#resize_to` to specify that Integers are expected. Also fixes a couple miscellaneous typos.