### PR TITLE
Call conf.clamp for puma options to convert the default :environment Proc into a String

### DIFF
--- a/lib/capybara/registrations/servers.rb
+++ b/lib/capybara/registrations/servers.rb
@@ -28,6 +28,7 @@ Capybara.register_server :puma do |app, port, host, **options|
   options = default_options.merge(options)
 
   conf = Rack::Handler::Puma.config(app, options)
+  conf.clamp
   events = conf.options[:Silent] ? ::Puma::Events.strings : ::Puma::Events.stdio
 
   puma_ver = Gem::Version.new(Puma::Const::PUMA_VERSION)

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -60,7 +60,7 @@ Capybara::SpecHelper.spec '#find' do
     end
   end
 
-  context 'with frozen time', requires: [:js] do # rubocop:disable RSpec/EmptyExampleGroup
+  context 'with frozen time', requires: [:js] do
     if defined?(Process::CLOCK_MONOTONIC)
       it 'will time out even if time is frozen' do
         @session.visit('/with_js')

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -84,7 +84,7 @@ module Capybara
           end
 
           specs.each do |spec_name, spec_options, block|
-            describe spec_name, *spec_options do # rubocop:disable RSpec/EmptyExampleGroup
+            describe spec_name, *spec_options do
               class_eval(&block)
             end
           end


### PR DESCRIPTION
Hello,

I just saw a deprecation warning when running Puma 5.0.3 in Ruby 2.7: `warning: deprecated Object#=~ is called on Proc`. I initially raised the issue on the puma repo: https://github.com/puma/puma/issues/2455
But it turns out that this was a bug in Capybara: https://github.com/puma/puma/issues/2455#issuecomment-716724207

Capybara was not calling `#finalize_values` to convert default Proc into a string. I've also tried to add a test to confirm that this is fixed, but not sure if it's the best way to test this.