### PR TITLE
Fix Rubocop warnings about unneeded # rubocop:disable instructions

### DIFF
--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -60,7 +60,7 @@ Capybara::SpecHelper.spec '#find' do
     end
   end
 
-  context 'with frozen time', requires: [:js] do # rubocop:disable RSpec/EmptyExampleGroup
+  context 'with frozen time', requires: [:js] do
     if defined?(Process::CLOCK_MONOTONIC)
       it 'will time out even if time is frozen' do
         @session.visit('/with_js')

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -84,7 +84,7 @@ module Capybara
           end
 
           specs.each do |spec_name, spec_options, block|
-            describe spec_name, *spec_options do # rubocop:disable RSpec/EmptyExampleGroup
+            describe spec_name, *spec_options do
               class_eval(&block)
             end
           end


### PR DESCRIPTION
Fixes the Rubocop warnings that are currently failing the builds on the master branch, e.g. https://travis-ci.org/github/teamcapybara/capybara/jobs/739956102

----

RuboCop is fixed: https://travis-ci.org/github/teamcapybara/capybara/jobs/740141163

```
Running RuboCop...
Inspecting 254 files
..............................................................................................................................................................................................................................................................
```