### PR TITLE
Added `Capybara.disable_animation_extra_css` option to insert extra CSS in Capybara::Server::AnimationDisabler::DISABLE_MARKUP_TEMPLATE

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "files.trimTrailingWhitespace": true
+}

--- a/History.md
+++ b/History.md
@@ -4,6 +4,8 @@ Release date: unreleased
 ### Added
 
 * Ability to fill in with emoji when using Chrome with selenium driver (Firefox already worked)
+* Added `Capybara.disable_animation_extra_css` option, which can be used to add additional CSS rules
+  to the AnimationDisabler middleware [Nathan Broadbent]
 
 ### Fixed
 

--- a/lib/capybara/server/animation_disabler.rb
+++ b/lib/capybara/server/animation_disabler.rb
@@ -16,7 +16,11 @@ module Capybara
 
       def initialize(app)
         @app = app
-        @disable_markup = format(DISABLE_MARKUP_TEMPLATE, selector: self.class.selector_for(Capybara.disable_animation))
+        @disable_markup = format(
+          DISABLE_MARKUP_TEMPLATE,
+          selector: self.class.selector_for(Capybara.disable_animation),
+          extra_css: Capybara.disable_animation_extra_css || ''
+        )
       end
 
       def call(env)
@@ -51,6 +55,7 @@ module Capybara
              animation-duration: 0s !important;
              animation-delay: 0s !important;
              scroll-behavior: auto !important;
+             %<extra_css>s
           }
         </style>
       HTML

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -7,8 +7,8 @@ module Capybara
     OPTIONS = %i[always_include_port run_server default_selector default_max_wait_time ignore_hidden_elements
                  automatic_reload match exact exact_text raise_server_errors visible_text_only
                  automatic_label_click enable_aria_label save_path asset_host default_host app_host
-                 server_host server_port server_errors default_set_options disable_animation test_id
-                 predicates_wait default_normalize_ws w3c_click_offset enable_aria_role].freeze
+                 server_host server_port server_errors default_set_options disable_animation disable_animation_extra_css
+                 test_id predicates_wait default_normalize_ws w3c_click_offset enable_aria_role].freeze
 
     attr_accessor(*OPTIONS)
 
@@ -56,6 +56,8 @@ module Capybara
     # @!method default_set_options
     #   See {Capybara.configure}
     # @!method disable_animation
+    #   See {Capybara.configure}
+    # @!method disable_animation_extra_css
     #   See {Capybara.configure}
     # @!method test_id
     #   See {Capybara.configure}

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -60,7 +60,7 @@ Capybara::SpecHelper.spec '#find' do
     end
   end
 
-  context 'with frozen time', requires: [:js] do # rubocop:disable RSpec/EmptyExampleGroup
+  context 'with frozen time', requires: [:js] do
     if defined?(Process::CLOCK_MONOTONIC)
       it 'will time out even if time is frozen' do
         @session.visit('/with_js')

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -33,6 +33,7 @@ module Capybara
         Capybara.enable_aria_role = false
         Capybara.default_set_options = {}
         Capybara.disable_animation = false
+        Capybara.disable_animation_extra_css = nil
         Capybara.test_id = nil
         Capybara.predicates_wait = true
         Capybara.default_normalize_ws = false

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -84,7 +84,7 @@ module Capybara
           end
 
           specs.each do |spec_name, spec_options, block|
-            describe spec_name, *spec_options do # rubocop:disable RSpec/EmptyExampleGroup
+            describe spec_name, *spec_options do
               class_eval(&block)
             end
           end

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -475,6 +475,24 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
         end
       end
     end
+
+    describe 'Capybara#disable_animation_extra_css' do
+      before(:context) do # rubocop:disable RSpec/BeforeAfterAll
+        skip "Safari doesn't support multiple sessions" if safari?(session)
+        # NOTE: Although Capybara.SpecHelper.reset! sets Capybara.disable_animation to false,
+        # it doesn't affect any of these tests because the settings are applied per-session
+        Capybara.disable_animation = true
+        Capybara.disable_animation_extra_css = 'color: rgba(0, 0, 249, 1);'
+        @animation_session = Capybara::Session.new(session.mode, TestApp.new)
+      end
+
+      it 'should add custom CSS rules to the selector' do
+        @animation_session.visit('with_animation')
+        rgba_color = @animation_session.find(:css, '#with_animation .animation').native.css_value('color')
+        expect(rgba_color).to eq 'rgba(0, 0, 249, 1)'
+      end
+    end
+
     # rubocop:enable RSpec/InstanceVariable
 
     describe ':element selector' do


### PR DESCRIPTION
This is just a follow-up change for my previous PR: https://github.com/teamcapybara/capybara/pull/2399

This new option can be used to add additional CSS rules to the `AnimationDisabler` middleware.

I also need to use `caret-color: transparent;` to hide any cursors in inputs. I have some screenshot tests that ensure that some inputs are visually correct on the page.

(I don't know if this is technically "disabling animation" since the cursor is blinking twice per second, and this change makes it possible to remove the blinking cursor.)

I'm currently doing this in my code:

```
  Capybara::Server::AnimationDisabler.class_eval do
    # rubocop:disable Lint/ConstantDefinitionInBlock
    DISABLE_MARKUP_TEMPLATE_CARET_TRANSPARENT = <<~HTML
      <script defer>(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
      <style>
        %<selector>s, %<selector>s::before, %<selector>s::after {
          transition: none !important;
          animation-duration: 0s !important;
          animation-delay: 0s !important;
          scroll-behavior: auto !important;
          caret-color: transparent;
        }
      </style>
    HTML
    # rubocop:enable Lint/ConstantDefinitionInBlock

    def initialize(app)
      @app = app
      @disable_markup = format(
        DISABLE_MARKUP_TEMPLATE_CARET_TRANSPARENT,
        selector: self.class.selector_for(Capybara.disable_animation)
      )
    end
  end
```

So I'd like to get rid of the class_eval and replace it with this: `Capybara.disable_animation_extra_css = 'caret-color: transparent;'`