### PR TITLE
Fix bug in Capybara::Node::Element#drop causing Pathname drops to be ignored

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -435,11 +435,7 @@ module Capybara
       #
       # @return [Capybara::Node::Element]  The element
       def drop(*args)
-        options = args.map do |arg|
-          return arg.to_path if arg.respond_to?(:to_path)
-
-          arg
-        end
+        options = args.map { |arg| arg.respond_to?(:to_path) ? arg.to_path : arg }
         synchronize { base.drop(*options) }
         self
       end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -682,6 +682,15 @@ Capybara::SpecHelper.spec 'node' do
       expect(@session).to have_xpath('//div[contains(., "HTML5 Dropped string: text/plain Some dropped text")]')
     end
 
+    it 'can drop a pathname' do
+      @session.visit('/with_js')
+      target = @session.find('//div[@id="drop_html5"]')
+      target.drop(
+        Pathname.new with_os_path_separators(File.expand_path('../fixtures/capybara.jpg', File.dirname(__FILE__)))
+      )
+      expect(@session).to have_xpath('//div[contains(., "HTML5 Dropped file: capybara.jpg")]')
+    end
+
     it 'can drop multiple strings' do
       @session.visit('/with_js')
       target = @session.find('//div[@id="drop_html5"]')


### PR DESCRIPTION
[Capybara Test Helpers]: https://github.com/ElMassimo/capybara_test_helpers
[tests]: https://github.com/ElMassimo/capybara_test_helpers/blame/master/spec/capybara/node_spec.rb#L595-L625
[pathname was being used]: https://github.com/ElMassimo/capybara_test_helpers/blame/master/test_helpers/js_page_test_helper.rb#L41-L44
[patch]: https://github.com/ElMassimo/capybara_test_helpers/blame/master/spec/support/capybara_patches.rb#L3-L10

### Description 📖 

This pull request fixes an accidental early return in `Capybara::Node::Element#drop`.

### The Bug 🐞 

Using `return` inside a block does not cause the block to return, it halts the execution of the current method instead. This is a very common gotcha in Ruby.

The code intended to cast `Pathname` and similar objects to a `String` path, but instead it was not performing the expected `drop`.

### Background 📜 

Discovered the bug while working on a test for [Capybara Test Helpers].

The [tests] that dropped strings worked, but the ones where a [pathname was being used] would fail.

Applying this patch [manually][patch] fixed the problem.