### PR TITLE
Wrapping injected disable_animation script in CDATA to prevent XHTML/…

### DIFF
--- a/lib/capybara/server/animation_disabler.rb
+++ b/lib/capybara/server/animation_disabler.rb
@@ -44,7 +44,11 @@ module Capybara
       end
 
       DISABLE_MARKUP_TEMPLATE = <<~HTML
-        <script defer>(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
+        <script defer="defer">
+        //<![CDATA[
+          (typeof jQuery !== 'undefined') && (jQuery.fx.off = true);
+        //]]>
+        </script>
         <style>
           %<selector>s, %<selector>s::before, %<selector>s::after {
              transition: none !important;


### PR DESCRIPTION
Addressing issue raised on [#2425](https://github.com/teamcapybara/capybara/issues/2425) - `disable_animation injected script causes XHTML parsing error`.

Wrapped the injected `disable_animation` script with CDATA to prevent XHTML/XML parser errors (see [here](https://monkeyraptor.johanpaul.net/2015/11/fixing-xhtml-parsing-error-on-chrome.html)).