### PR TITLE
Fix button selector when enable_aria_role = true

### DIFF
--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -22,7 +22,7 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
       btn_xpath = btn_xpath[locator_matchers |
                             XPath.string.n.is(locator) |
                             XPath.descendant(:img)[XPath.attr(:alt).is(locator)]
-                           ] + locate_label(locator).descendant(btn_xpath)
+                           ] + Array(btn_xpath).map! { |xpath| locate_label(locator).descendant(xpath) }
 
       alt_matches = XPath.attr(:alt).is(locator)
       alt_matches |= XPath.attr(:'aria-label').is(locator) if enable_aria_label

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -36,6 +36,7 @@
     <p><a href="#" id="clickable">Click me</a></p>
     <p><a href="#" id="slow-click">Slowly</a></p>
     <p><span id="aria-button" role="button">ARIA button</span></p>
+    <p><span role="button">ARIA button2</span></p>
 
     <p>
       <select id="waiter">


### PR DESCRIPTION
[When]() `enable_aria_role = true`, the `btn_xpath` is union expression.
Then `locate_label(locator).descendant(btn_xpath)` generates xpath like below,
it matches every element which has `role="button"`.

```rb
btn_xpath = XPath.descendant(:button)
role_xpath = XPath.descendant[XPath.attr(:role).equals('button')]
label_xpath = XPath.descendant(:label)
puts label_xpath.descendant(btn_xpath + role_xpath)
# .//label//.//button | .//*[(./@role = 'button')]
```