### PR TITLE
Add rspec driver selection info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ describe 'some stuff which requires js', js: true do
 end
 ```
 
+To permanently select a driver, you can add the following to your `rspec_helper.rb`:
+
+```ruby
+...
+RSpec.configure do |config|
+  ...
+  # select driver for each system spec.
+  # if you use feature specs use type: :feature
+  config.before(:each, type: :system) do
+    # see Drivers section for supported drivers
+    driven_by(:selenium_chrome_headless)
+  end
+end
+```
+
 Capybara also comes with a built in DSL for creating descriptive acceptance tests:
 
 ```ruby


### PR DESCRIPTION
I was wondering, why `Capybara.default_driver` and `Capybara.javascript_driver` had no effect in my rspec tests. It took me much time to find a way to select the driver for system tests, as I did not find this documented anywhere. I hope others may profit from this additional documentation.