### PR TITLE
Fix failure during quit caused by Selenium raising `InvalidSessionIdError`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+# Version 3.34.1
+Release date: unreleased
+
+* Ignore Selenium::WebDriver::Error::InvalidSessionIdError when quitting driver [Robin Daugherty]
+
 # Version 3.34.0
 Release date: 2020-11-26
 

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -265,7 +265,8 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
 
   def quit
     @browser&.quit
-  rescue Selenium::WebDriver::Error::SessionNotCreatedError, Errno::ECONNREFUSED
+  rescue Selenium::WebDriver::Error::SessionNotCreatedError, Errno::ECONNREFUSED,
+         Selenium::WebDriver::Error::InvalidSessionIdError
     # Browser must have already gone
   rescue Selenium::WebDriver::Error::UnknownError => e
     unless silenced_unknown_error_message?(e.message) # Most likely already gone


### PR DESCRIPTION
Under some random conditions, Selenium throws `Selenium::WebDriver::Error::InvalidSessionIdError` during `quit`, causing the test suite to report a failing status code.

> Finished in 1 minute 52.93 seconds (files took 3.23 seconds to load)
> 120 examples, 0 failures, 25 pending
> 
> Randomized with seed 54517
> 
> Traceback (most recent call last):
> 	11: from /usr/local/bundle/gems/capybara-3.34.0/lib/capybara/selenium/driver.rb:486:in `block in setup_exit_handler'
> 	10: from /usr/local/bundle/gems/capybara-3.34.0/lib/capybara/selenium/driver.rb:267:in `quit'
> 	 9: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/common/driver.rb:168:in `quit'
> 	 8: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/w3c/bridge.rb:155:in `quit'
> 	 7: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/w3c/bridge.rb:567:in `execute'
> 	 6: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/bridge.rb:167:in `execute'
> 	 5: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/common.rb:64:in `call'
> 	 4: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/default.rb:114:in `request'
> 	 3: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/common.rb:88:in `create_response'
> 	 2: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/http/common.rb:88:in `new'
> 	 1: from /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/response.rb:34:in `initialize'
> /usr/local/bundle/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/response.rb:72:in `assert_ok': Tried to run command without establishing a connection (Selenium::WebDriver::Error::InvalidSessionIdError)

This must have happened with at least one other Selenium error previously, since there was already a rescue in place for `Selenium::WebDriver::Error::SessionNotCreatedError` during quit. I added the new exception to the same rescue.

There is an argument to made here for catching all Selenium errors and treating them this way. Considering that the process has ended, any error raised here is unlikely to be consequential but does certainly cause the test suite to return a failure status code.

This is a minor change, so I added an entry to History.md under the assumption that this will result in a patch release.
