### PR TITLE
Fix js animation not disable if load jquery in body

### DIFF
--- a/lib/capybara/server/animation_disabler.rb
+++ b/lib/capybara/server/animation_disabler.rb
@@ -40,11 +40,11 @@ module Capybara
       end
 
       def insert_disable(html)
-        html.sub(%r{(</head>)}, "#{disable_markup}\\1")
+        html.sub(%r{(</body>)}, "#{disable_markup}\\1")
       end
 
       DISABLE_MARKUP_TEMPLATE = <<~HTML
-        <script defer="defer">
+        <script>
         //<![CDATA[
           (typeof jQuery !== 'undefined') && (jQuery.fx.off = true);
         //]]>

--- a/lib/capybara/spec/views/with_jquery_animation.erb
+++ b/lib/capybara/spec/views/with_jquery_animation.erb
@@ -1,0 +1,24 @@
+
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title>with_jquery_animation</title>
+    <style>
+      body {
+        height: 2000px;
+      }
+    </style>
+  </head>
+
+  <body id="with_animation">
+    <a href="#" id='scroll'>scroll top 500</a>
+
+    <script src="/jquery.js" type="text/javascript" charset="utf-8"></script>
+    <script type='text/javascript'>
+      $('#scroll').click(function(e){
+        e.preventDefault();
+        $('html, body').animate({ scrollTop: 500 }, 'slow');
+      });
+    </script>
+  </body>
+</html>

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -411,6 +411,13 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
           JS
           expect(scroll_y).to eq 500
         end
+
+        it 'should scroll the page instantly without jquery animation', requires: [:js] do
+          @animation_session.visit('with_jquery_animation')
+          @animation_session.click_link('scroll top 500')
+          scroll_y = @animation_session.evaluate_script('window.scrollY')
+          expect(scroll_y).to eq 500
+        end
       end
 
       context 'when set to `false`' do
@@ -431,6 +438,13 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
             })()
           JS
           # measured over 0.5 seconds: 0, 75, 282, 478, 500
+          expect(scroll_y).to be < 500
+        end
+
+        it 'should scroll the page with jquery animation', requires: [:js] do
+          @animation_session.visit('with_jquery_animation')
+          @animation_session.click_link('scroll top 500')
+          scroll_y = @animation_session.evaluate_script('window.scrollY')
           expect(scroll_y).to be < 500
         end
       end


### PR DESCRIPTION
Animation disabler now can only turn off the animation come from jQuery if jQuery is loaded in head, because `insert_disable` place the template at the end of head.
https://github.com/teamcapybara/capybara/blob/a08e0477ac2cfd3319d8a423d8661b73103acbf3/lib/capybara/server/animation_disabler.rb#L42-L44

If jQuery is loaded with the body, jQuery will be undefined in head so the function won't work.
https://github.com/teamcapybara/capybara/blob/a08e0477ac2cfd3319d8a423d8661b73103acbf3/lib/capybara/server/animation_disabler.rb#L46-L49

By placing it to the end of the body, developer do not have to worry about where they are loading jQuery and give a better experience 😄 