### PR TITLE
Use chrome browser in chrome drivers

### DIFF
--- a/lib/capybara/registrations/drivers.rb
+++ b/lib/capybara/registrations/drivers.rb
@@ -25,7 +25,7 @@ Capybara.register_driver :selenium_chrome do |app|
     opts.add_argument('--disable-site-isolation-trials')
   end
 
-  Capybara::Selenium::Driver.new(app, **Hash[:browser => :firefox, options_key => browser_options])
+  Capybara::Selenium::Driver.new(app, **Hash[:browser => :chrome, options_key => browser_options])
 end
 
 Capybara.register_driver :selenium_chrome_headless do |app|
@@ -38,5 +38,5 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument('--disable-site-isolation-trials')
   end
 
-  Capybara::Selenium::Driver.new(app, **Hash[:browser => :firefox, options_key => browser_options])
+  Capybara::Selenium::Driver.new(app, **Hash[:browser => :chrome, options_key => browser_options])
 end


### PR DESCRIPTION
Hey! 
It seems, that 0ad261ad0a9771d2f3ee45555c34caf7e79c563e accidentally changed browser from `chrome` to `firefox` in `:selenium_chrome` and `:selenium_chrome_headless` drivers