### PR TITLE
Swap equality check in FirefoxDriver::switch_to_frame

### DIFF
--- a/lib/capybara/selenium/driver_specializations/firefox_driver.rb
+++ b/lib/capybara/selenium/driver_specializations/firefox_driver.rb
@@ -66,7 +66,7 @@ module Capybara::Selenium::Driver::W3CFirefoxDriver
   end
 
   def switch_to_frame(frame)
-    return super unless frame == :parent
+    return super unless :parent == frame
 
     # geckodriver/firefox has an issue if the current frame is removed from within it
     # so we have to move to the default_content and iterate back through the frames


### PR DESCRIPTION
Ensures that any custom `==` implementation for `frame` does not impact the equality check.

Was getting the following error:

```
      undefined method `native' for :parent:Symbol (NoMethodError)
      /Users/acutler/Coding/axe-core-gems/packages/axe-core-cucumber/e2e/capybara/vendor/bundle/ruby/2.6.0/gems/capybara-3.35.3/lib/capybara/selenium/node.rb:203:in `=='
      /Users/acutler/Coding/axe-core-gems/packages/axe-core-cucumber/e2e/capybara/vendor/bundle/ruby/2.6.0/gems/capybara-3.35.3/lib/capybara/selenium/driver_specializations/firefox_driver.rb:70:in `switch_to_frame'
...
```

Where I passed the first element found from `find_css("iframe")` to `switch_to_frame`. Turns out the custom `==` implementation in `Capybara::Selenium::Node` caused errors since it tries to access the `:native` method of the right side of the equals expression. And since the right side is a `Symbol`, ruby rightfully complains.