### PR TITLE
Remove useless require "matrix"

### DIFF
--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'matrix'
-
 module Capybara
   module Queries
     class SelectorQuery < Queries::BaseQuery


### PR DESCRIPTION
Fix: https://github.com/teamcapybara/capybara/pull/2468

It seems that this `require` is useless, there's no reference at all to `Matrix` in `capybara`.