### PR TITLE
Remove test files from gemspec build

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = 'Capybara is an integration testing tool for rack based web applications. '\
                   'It simulates how a user would interact with a website'
 
-  s.files = Dir.glob('{lib,spec}/**/*') + %w[README.md History.md License.txt .yardopts]
+  s.files = Dir.glob('lib/**/*') + %w[README.md History.md License.txt .yardopts]
 
   s.homepage = 'https://github.com/teamcapybara/capybara'
   s.metadata = {


### PR DESCRIPTION
I have a suggestion to delete test files from the gem build. Test files have been removed from many other gems rubygems/rubygems#735

By removing test files from the gem, it becomes a bit lighter (from 364Kb to 323Kb)
It will also stop annoying image screening tools for containing a private key.
```
key.pem | /usr/local/bundle/gems/capybara-3.35.3/spec/fixtures/key.pem
```
