### PR TITLE
Test in Standards Mode && Fix Page Scroll

### DIFF
--- a/lib/capybara/node/document.rb
+++ b/lib/capybara/node/document.rb
@@ -41,7 +41,7 @@ module Capybara
       end
 
       def scroll_to(*args, **options)
-        find(:xpath, '//body').scroll_to(*args, **options)
+        find(:xpath, '/html').scroll_to(*args, **options)
       end
     end
   end

--- a/lib/capybara/spec/session/scroll_spec.rb
+++ b/lib/capybara/spec/session/scroll_spec.rb
@@ -15,7 +15,7 @@ Capybara::SpecHelper.spec '#scroll_to', requires: [:scroll] do
     el = @session.find(:css, '#scroll')
     @session.scroll_to(el, align: :bottom)
     el_bottom = el.evaluate_script('this.getBoundingClientRect().bottom')
-    viewport_bottom = el.evaluate_script('document.body.clientHeight')
+    viewport_bottom = el.evaluate_script('document.documentElement.clientHeight')
     expect(el_bottom).to be_within(1).of(viewport_bottom)
   end
 
@@ -23,7 +23,7 @@ Capybara::SpecHelper.spec '#scroll_to', requires: [:scroll] do
     el = @session.find(:css, '#scroll')
     @session.scroll_to(el, align: :center)
     el_center = el.evaluate_script('(function(rect){return (rect.top + rect.bottom)/2})(this.getBoundingClientRect())')
-    viewport_bottom = el.evaluate_script('document.body.clientHeight')
+    viewport_bottom = el.evaluate_script('document.documentElement.clientHeight')
     expect(el_center).to be_within(2).of(viewport_bottom / 2)
   end
 
@@ -35,13 +35,13 @@ Capybara::SpecHelper.spec '#scroll_to', requires: [:scroll] do
 
   it 'can scroll the window to the vertical bottom' do
     @session.scroll_to :bottom
-    max_scroll = @session.evaluate_script('document.body.scrollHeight - document.body.clientHeight')
+    max_scroll = @session.evaluate_script('document.documentElement.scrollHeight - document.documentElement.clientHeight')
     expect(@session.evaluate_script('[window.scrollX || window.pageXOffset, window.scrollY || window.pageYOffset]')).to eq [0, max_scroll]
   end
 
   it 'can scroll the window to the vertical center' do
     @session.scroll_to :center
-    max_scroll = @session.evaluate_script('document.documentElement.scrollHeight - document.body.clientHeight')
+    max_scroll = @session.evaluate_script('document.documentElement.scrollHeight - document.documentElement.clientHeight')
     expect(@session.evaluate_script('[window.scrollX || window.pageXOffset, window.scrollY || window.pageYOffset]')).to eq [0, max_scroll / 2]
   end
 

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -163,10 +163,17 @@ class TestApp < Sinatra::Base
 
   get '/with_title' do
     <<-HTML
-      <title>#{params[:title] || 'Test Title'}</title>
-      <body>
-        <svg><title>abcdefg</title></svg>
-      </body>
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+          <title>#{params[:title] || 'Test Title'}</title>
+        </head>
+
+        <body>
+          <svg><title>abcdefg</title></svg>
+        </body>
+      </html>
     HTML
   end
 
@@ -177,7 +184,9 @@ class TestApp < Sinatra::Base
   end
 
   get '/:view' do |view|
-    erb view.to_sym, locals: { referrer: request.referrer }
+    view_template = "#{__dir__}/views/#{view}.erb"
+    has_layout = File.exist?(view_template) && File.open(view_template) { |f| f.first.downcase.include?('doctype') }
+    erb view.to_sym, locals: { referrer: request.referrer }, layout: !has_layout
   end
 
   post '/form' do

--- a/lib/capybara/spec/views/animated.erb
+++ b/lib/capybara/spec/views/animated.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
@@ -46,4 +47,3 @@
 
   <iframe id="frameOne" src="/frame_one"></iframe>
 </html>
-

--- a/lib/capybara/spec/views/frame_child.erb
+++ b/lib/capybara/spec/views/frame_child.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>This is the child frame title</title>

--- a/lib/capybara/spec/views/frame_one.erb
+++ b/lib/capybara/spec/views/frame_one.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>This is the title of frame one</title>

--- a/lib/capybara/spec/views/frame_parent.erb
+++ b/lib/capybara/spec/views/frame_parent.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>This is the parent frame title</title>

--- a/lib/capybara/spec/views/frame_two.erb
+++ b/lib/capybara/spec/views/frame_two.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>This is the title of frame two</title>

--- a/lib/capybara/spec/views/initial_alert.erb
+++ b/lib/capybara/spec/views/initial_alert.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <body>
     <div>
       Initial alert page

--- a/lib/capybara/spec/views/layout.erb
+++ b/lib/capybara/spec/views/layout.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/lib/capybara/spec/views/obscured.erb
+++ b/lib/capybara/spec/views/obscured.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
@@ -44,4 +45,3 @@
     </div>
   </body>
 </html>
-

--- a/lib/capybara/spec/views/offset.erb
+++ b/lib/capybara/spec/views/offset.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>

--- a/lib/capybara/spec/views/path.erb
+++ b/lib/capybara/spec/views/path.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <body>
     <div>
       <a href="#">First Link</a>

--- a/lib/capybara/spec/views/popup_one.erb
+++ b/lib/capybara/spec/views/popup_one.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>Title of the first popup</title>

--- a/lib/capybara/spec/views/popup_two.erb
+++ b/lib/capybara/spec/views/popup_two.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>Title of popup two</title>

--- a/lib/capybara/spec/views/react.erb
+++ b/lib/capybara/spec/views/react.erb
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <script src="https://unpkg.com/react/umd/react.development.js"></script>

--- a/lib/capybara/spec/views/scroll.erb
+++ b/lib/capybara/spec/views/scroll.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html style="height: 250%; width: 150%">
   <head>
     <style>

--- a/lib/capybara/spec/views/spatial.erb
+++ b/lib/capybara/spec/views/spatial.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
@@ -28,4 +29,3 @@
     <div class="footer distance">10</div>
   </body>
 </html>
-

--- a/lib/capybara/spec/views/with_animation.erb
+++ b/lib/capybara/spec/views/with_animation.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_animation</title>
@@ -79,4 +79,3 @@
     </a>
   </body>
 </html>
-

--- a/lib/capybara/spec/views/with_base_tag.erb
+++ b/lib/capybara/spec/views/with_base_tag.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <base href="http://example2.com" />

--- a/lib/capybara/spec/views/with_dragula.erb
+++ b/lib/capybara/spec/views/with_dragula.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_dragula</title>
@@ -21,4 +22,3 @@
     </script>
   </body>
 </html>
-

--- a/lib/capybara/spec/views/with_fixed_header_footer.erb
+++ b/lib/capybara/spec/views/with_fixed_header_footer.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <style>

--- a/lib/capybara/spec/views/with_hover.erb
+++ b/lib/capybara/spec/views/with_hover.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_hover</title>

--- a/lib/capybara/spec/views/with_jquery_animation.erb
+++ b/lib/capybara/spec/views/with_jquery_animation.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -1,5 +1,5 @@
-
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_js</title>
@@ -160,4 +160,3 @@
     </script>
   </body>
 </html>
-

--- a/lib/capybara/spec/views/with_jstree.erb
+++ b/lib/capybara/spec/views/with_jstree.erb
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>

--- a/lib/capybara/spec/views/with_namespace.erb
+++ b/lib/capybara/spec/views/with_namespace.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Namespace</title>

--- a/lib/capybara/spec/views/with_slow_unload.erb
+++ b/lib/capybara/spec/views/with_slow_unload.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <script>

--- a/lib/capybara/spec/views/with_sortable_js.erb
+++ b/lib/capybara/spec/views/with_sortable_js.erb
@@ -1,4 +1,5 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
     <title>with_sortable_js</title>
@@ -18,4 +19,3 @@
     </script>
   </body>
 </html>
-

--- a/lib/capybara/spec/views/with_title.erb
+++ b/lib/capybara/spec/views/with_title.erb
@@ -1,5 +1,0 @@
-
-<title>Test Title</title>
-<body>
-  <svg><title>abcdefg</title></svg>
-</body>

--- a/lib/capybara/spec/views/with_unload_alert.erb
+++ b/lib/capybara/spec/views/with_unload_alert.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <script>

--- a/lib/capybara/spec/views/with_windows.erb
+++ b/lib/capybara/spec/views/with_windows.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
   <head>
     <title>With Windows</title>

--- a/lib/capybara/spec/views/within_frames.erb
+++ b/lib/capybara/spec/views/within_frames.erb
@@ -1,4 +1,4 @@
-
+<!DOCTYPE html>
 <html>
     <head>
         <title>With Frames</title>


### PR DESCRIPTION
This is a followup to issue #2476.

The primary goal was to fix page scroll when the page operates in standards mode. Per the discussion on that issue all test pages were all updated to use standards mode to confirm there are no other standard vs quirks mode issues in Capybara.

Commit f20c8de is just that conversion. See the commit notes for more information about that. Commit b2e2a27 fixes the main problem referred to in #2476.

I have also verified that the application I am developing that was attempting to use `page.scroll_to :top` is now able to use that method successfully without any sort of `execute_script` hack.