### PR TITLE
Support `Session#active_element`

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@ Release date: unreleased
 
 * `allow_label_click` accepts click options to be used when clicking an associated label
 * Deprecated `allow_gumbo=` in favor of `use_html5_parsing=` to enable use of Nokogiri::HTL5 when available
+* `Session#active_element` returns the element with focus - Not supported by the `RackTest` driver [Sean Doyle]
 
 ### Fixed
 

--- a/lib/capybara/driver/base.rb
+++ b/lib/capybara/driver/base.rb
@@ -63,6 +63,10 @@ class Capybara::Driver::Base
     raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#send_keys'
   end
 
+  def active_element
+    raise Capybara::NotSupportedByDriverError, 'Capybara::Driver::Base#active_element'
+  end
+
   ##
   #
   # @param frame [Capybara::Node::Element, :parent, :top]  The iframe element to switch to

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -148,8 +148,12 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     unwrap_script_result(result)
   end
 
+  def active_element
+    build_node(browser.switch_to.active_element)
+  end
+
   def send_keys(*args)
-    active_element.send_keys(*args)
+    active_element.native.send_keys(*args)
   end
 
   def save_screenshot(path, **_options)
@@ -472,10 +476,6 @@ private
 
   def find_context
     browser
-  end
-
-  def active_element
-    browser.switch_to.active_element
   end
 
   def build_node(native_node, initial_cache = {})

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -313,6 +313,16 @@ module Capybara
 
     ##
     #
+    # Returns the element with focus.
+    #
+    # Not supported by Rack Test
+    #
+    def active_element
+      driver.active_element
+    end
+
+    ##
+    #
     # Executes the given block within the context of a node. {#within} takes the
     # same options as {Capybara::Node::Finders#find #find}, as well as a block. For the duration of the
     # block, any command to Capybara will be handled as though it were scoped

--- a/lib/capybara/spec/session/active_element_spec.rb
+++ b/lib/capybara/spec/session/active_element_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Capybara::SpecHelper.spec '#active_element', requires: [:js] do
+  it 'should return the active element' do
+    @session.visit('/form')
+    @session.send_keys(:tab)
+
+    expect(@session.active_element).to eq(@session.find_by_id('form_title'))
+
+    @session.send_keys(:tab)
+
+    expect(@session.active_element).not_to eq(@session.find_by_id('form_title'))
+  end
+end

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -12,6 +12,7 @@ skipped_tests = %i[
   screenshot
   frames
   windows
+  active_element
   send_keys
   server
   hover
@@ -144,6 +145,14 @@ RSpec.describe Capybara::Session do # rubocop:disable RSpec/MultipleDescribes
         session.visit('/form')
 
         expect { session.send_keys(:tab) }.to raise_error(Capybara::NotSupportedByDriverError)
+      end
+    end
+
+    describe '#active_element' do
+      it 'raises an UnsupportedMethodError' do
+        session.visit('/form')
+
+        expect { session.active_element }.to raise_error(Capybara::NotSupportedByDriverError)
       end
     end
 


### PR DESCRIPTION
As a [follow-up][] to [#2422][], expose the [document.activeElement][]
(that is, the element with focus) via the `Session`.

When called from Rack Test environments, `Session#active_element` raises
an error.

[Document.activeElement]: https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
[follow-up]: https://github.com/teamcapybara/capybara/pull/2422#discussion_r520646573
[#2422]: https://github.com/teamcapybara/capybara/pull/2422
[document.activeElement]: https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement