### PR TITLE
Support `described_by:` filter

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,6 +9,7 @@ Release date: unreleased
 
 * `allow_label_click` accepts click options to be used when clicking an associated label
 * Deprecated `allow_gumbo=` in favor of `use_html5_parsing=` to enable use of Nokogiri::HTL5 when available
+* Filter fields, buttons, and links by descriptions constructed from their `aria-describedby` attribute [Sean Doyle]
 
 ### Fixed
 

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -41,6 +41,7 @@ require 'capybara/selector/definition'
 #       * :multiple (Boolean) - Match fields that accept multiple values
 #       * :valid (Boolean) - Match fields that are valid/invalid according to HTML5 form validation
 #       * :validation_message (String, Regexp) - Matches the elements current validationMessage
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:fieldset** - Select fieldset elements
 #   * Locator: Matches id, {Capybara.configure test_id}, or contents of wrapped legend
@@ -55,6 +56,7 @@ require 'capybara/selector/definition'
 #       * :title (String) - Matches the title attribute
 #       * :alt (String) - Matches the alt attribute of a contained img element
 #       * :href (String, Regexp, nil, false) - Matches the normalized href of the link, if nil will find `<a>` elements with no href attribute, if false ignores href presence
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:button** - Find buttons ( input [of type submit, reset, image, button] or button elements )
 #   * Locator: Matches the id, {Capybara.configure test_id} attribute, name, value, or title attributes, string content of a button, or the alt attribute of an image type button or of a descendant image of a button
@@ -64,11 +66,13 @@ require 'capybara/selector/definition'
 #       * :value (String) - Matches the value of an input button
 #       * :type (String) - Matches the type attribute
 #       * :disabled (Boolean, :all) - Match disabled buttons (Default: false)
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:link_or_button** - Find links or buttons
 #   * Locator: See :link and :button selectors
 #   * Filters:
 #       * :disabled (Boolean, :all) - Match disabled buttons? (Default: false)
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:fillable_field** - Find text fillable fields ( textarea, input [not of type submit, image, radio, checkbox, hidden, file] )
 #   * Locator: Matches against the id, {Capybara.configure test_id} attribute, name, placeholder, or associated label text
@@ -81,6 +85,7 @@ require 'capybara/selector/definition'
 #       * :multiple (Boolean) - Match fields that accept multiple values
 #       * :valid (Boolean) - Match fields that are valid/invalid according to HTML5 form validation
 #       * :validation_message (String, Regexp) - Matches the elements current validationMessage
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:radio_button** - Find radio buttons
 #   * Locator: Match id, {Capybara.configure test_id} attribute, name, or associated label text
@@ -91,6 +96,7 @@ require 'capybara/selector/definition'
 #       * :disabled (Boolean, :all) - Match disabled field? (Default: false)
 #       * :option (String, Regexp) - Match the current value
 #       * :with - Alias of :option
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:checkbox** - Find checkboxes
 #   * Locator: Match id, {Capybara.configure test_id} attribute, name, or associated label text
@@ -101,6 +107,7 @@ require 'capybara/selector/definition'
 #       * :disabled (Boolean, :all) - Match disabled field? (Default: false)
 #       * :with (String, Regexp) - Match the current value
 #       * :option - Alias of :with
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:select** - Find select elements
 #   * Locator: Match id, {Capybara.configure test_id} attribute, name, placeholder, or associated label text
@@ -115,6 +122,7 @@ require 'capybara/selector/definition'
 #       * :with_options (Array<String>) - Partial match options
 #       * :selected (String, Array<String>) - Match the selection(s)
 #       * :with_selected (String, Array<String>) - Partial match the selection(s)
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:option** - Find option elements
 #   * Locator: Match text of option
@@ -143,6 +151,7 @@ require 'capybara/selector/definition'
 #       * :name (String, Regexp) - Matches the name attribute
 #       * :disabled (Boolean, :all) - Match disabled field? (Default: false)
 #       * :multiple (Boolean) - Match field that accepts multiple values
+#       * :described_by (String) - Matches the element's description generated from its aria-describedby
 #
 # * **:label** - Find label elements
 #   * Locator: Match id, {Capybara.configure test_id}, or text contents
@@ -186,6 +195,7 @@ Capybara::Selector::FilterSet.add(:_field) do
       add_error("Expected validation message to be #{msg.inspect} but was #{vm}") unless res
     end
   end
+  node_filter(:described_by) { |node, text| text_from_tokens(node, 'aria-describedby').include?(text.to_s) }
 
   expression_filter(:name) do |xpath, val|
     builder(xpath).add_attribute_conditions(name: val)
@@ -206,7 +216,7 @@ Capybara::Selector::FilterSet.add(:_field) do
     desc
   end
 
-  describe(:node_filters) do |checked: nil, unchecked: nil, disabled: nil, valid: nil, validation_message: nil, **|
+  describe(:node_filters) do |checked: nil, unchecked: nil, disabled: nil, valid: nil, validation_message: nil, described_by: nil, **|
     desc, states = +'', []
     states << 'checked' if checked || (unchecked == false)
     states << 'not checked' if unchecked || (checked == false)
@@ -215,6 +225,7 @@ Capybara::Selector::FilterSet.add(:_field) do
     desc << ' that is valid' if valid == true
     desc << ' that is invalid' if valid == false
     desc << " with validation message #{validation_message.to_s.inspect}" if validation_message
+    desc << " with ARIA description #{described_by.to_s.inspect}" if described_by
     desc
   end
 end

--- a/lib/capybara/selector/definition/button.rb
+++ b/lib/capybara/selector/definition/button.rb
@@ -40,6 +40,8 @@ Capybara.add_selector(:button, locator_type: [String, Symbol]) do
     builder(xpath).add_attribute_conditions(name: val)
   end
 
+  node_filter(:described_by) { |node, text| text_from_tokens(node, 'aria-describedby').include?(text.to_s) }
+
   describe_expression_filters do |disabled: nil, **options|
     desc = +''
     desc << ' that is not disabled' if disabled == false

--- a/lib/capybara/selector/definition/link.rb
+++ b/lib/capybara/selector/definition/link.rb
@@ -36,6 +36,8 @@ Capybara.add_selector(:link, locator_type: [String, Symbol]) do
     end
   end
 
+  node_filter(:described_by) { |node, text| text_from_tokens(node, 'aria-describedby').include?(text.to_s) }
+
   expression_filter(:download, valid_values: [true, false, String]) do |expr, download|
     builder(expr).add_attribute_conditions(download: download)
   end

--- a/lib/capybara/selector/selector.rb
+++ b/lib/capybara/selector/selector.rb
@@ -139,6 +139,13 @@ module Capybara
       XPath.descendant(:label)[XPath.string.n.is(locator)]
     end
 
+    def text_from_tokens(node, attribute)
+      ids = node[attribute].to_s.split
+      elements = ids.map { |id| node.session.find_by_id(id) }
+
+      elements.map(&:text).join(' ')
+    end
+
     def find_by_attr(attribute, value)
       finder_name = "find_by_#{attribute}_attr"
       if respond_to?(finder_name, true)

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -65,6 +65,26 @@ Capybara::SpecHelper.spec '#has_button?' do
   it 'should not affect other selectors when enable_aria_role: false' do
     expect(@session).to have_button('Click me!', enable_aria_role: false)
   end
+
+  context 'with described_by:' do
+    it 'should be true if button is described by the text' do
+      expect(@session).to have_button(described_by: 'description (part 1)')
+      expect(@session).to have_button(described_by: 'description (part 2)')
+      expect(@session).to have_button(described_by: 'description (part 1) description (part 2)')
+      expect(@session).to have_button('Button with aria-describedby', described_by: 'description (part 1)')
+      expect(@session).to have_button('Button with aria-describedby', described_by: 'description (part 2)')
+      expect(@session).to have_button('Button with aria-describedby', described_by: 'description (part 1) description (part 2)')
+    end
+
+    it 'should be false if the button is described by missing elements' do
+      expect(@session).not_to have_button(described_by: 'elements are missing')
+      expect(@session).not_to have_button('Button described by missing elements', described_by: 'elements are missing')
+    end
+
+    it 'should be false if button is not described by the text' do
+      expect(@session).not_to have_button('Button with aria-describedby', described_by: 'does not exist')
+    end
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_button?' do
@@ -116,5 +136,23 @@ Capybara::SpecHelper.spec '#has_no_button?' do
 
   it 'should not affect other selectors when enable_aria_role: false' do
     expect(@session).to have_no_button('Junk button that does not exist', enable_aria_role: false)
+  end
+
+  context 'with described_by:' do
+    it 'should be true if button is not described by the text' do
+      expect(@session).to have_no_button('Button with aria-describedby', described_by: 'does not exist')
+    end
+
+    it 'should be true if the button is described by missing elements' do
+      expect(@session).to have_no_button(described_by: 'elements are missing')
+      expect(@session).to have_no_button('Button described by missing elements', described_by: 'elements are missing')
+    end
+
+    it 'should be false if button is described by the text' do
+      expect(@session).not_to have_no_button(described_by: 'description (part 1)')
+      expect(@session).not_to have_no_button(described_by: 'description (part 2)')
+      expect(@session).not_to have_no_button(described_by: 'description (part 1) description (part 2)')
+      expect(@session).not_to have_no_button('Button with aria-describedby', described_by: 'description (part 1) description (part 2)')
+    end
   end
 end

--- a/lib/capybara/spec/session/has_field_spec.rb
+++ b/lib/capybara/spec/session/has_field_spec.rb
@@ -127,6 +127,26 @@ Capybara::SpecHelper.spec '#has_field' do
       expect(@session).not_to have_field('length', valid: true)
     end
   end
+
+  context 'with described_by:' do
+    it 'should be true if field is described by the text' do
+      expect(@session).to have_field(described_by: 'description (part 1)')
+      expect(@session).to have_field(described_by: 'description (part 2)')
+      expect(@session).to have_field(described_by: 'description (part 1) description (part 2)')
+      expect(@session).to have_field('Input with aria-describedby', described_by: 'description (part 1)')
+      expect(@session).to have_field('Input with aria-describedby', described_by: 'description (part 2)')
+      expect(@session).to have_field('Input with aria-describedby', described_by: 'description (part 1) description (part 2)')
+    end
+
+    it 'should be false if field is not described by the text' do
+      expect(@session).not_to have_field(described_by: 'does not exist')
+      expect(@session).not_to have_field('Input with aria-describedby', described_by: 'does not exist')
+    end
+
+    it 'should be false if the field is described by missing elements' do
+      expect(@session).not_to have_field('Input described by missing elements', described_by: 'elements are missing')
+    end
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_field' do
@@ -182,6 +202,26 @@ Capybara::SpecHelper.spec '#has_no_field' do
       expect(@session).to have_no_field('Description', type: '')
       expect(@session).to have_no_field('Description', type: 'email')
       expect(@session).to have_no_field('Languages', type: 'textarea')
+    end
+  end
+
+  context 'with described_by:' do
+    it 'should be true if field is not described by the text' do
+      expect(@session).to have_no_field(described_by: 'does not exist')
+      expect(@session).to have_no_field('Input with aria-describedby', described_by: 'does not exist')
+    end
+
+    it 'should be true if the field is described by missing elements' do
+      expect(@session).to have_no_field('Input described by missing elements', described_by: 'elements are missing')
+    end
+
+    it 'should be false if field is described by the text' do
+      expect(@session).not_to have_no_field(described_by: 'description (part 1)')
+      expect(@session).not_to have_no_field(described_by: 'description (part 2)')
+      expect(@session).not_to have_no_field(described_by: 'description (part 1) description (part 2)')
+      expect(@session).not_to have_no_field('Input with aria-describedby', described_by: 'description (part 1)')
+      expect(@session).not_to have_no_field('Input with aria-describedby', described_by: 'description (part 2)')
+      expect(@session).not_to have_no_field('Input with aria-describedby', described_by: 'description (part 1) description (part 2)')
     end
   end
 end

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -18,6 +18,26 @@ Capybara::SpecHelper.spec '#has_link?' do
     expect(@session).not_to have_link('A link', href: '/nonexistent-href')
     expect(@session).not_to have_link('A link', href: /nonexistent/)
   end
+
+  context 'with described_by:' do
+    it 'should be true if link is described by the text' do
+      expect(@session).to have_link(described_by: 'description (part 1)')
+      expect(@session).to have_link(described_by: 'description (part 2)')
+      expect(@session).to have_link(described_by: 'description (part 1) description (part 2)')
+      expect(@session).to have_link('Link with aria-describedby', described_by: 'description (part 1)')
+      expect(@session).to have_link('Link with aria-describedby', described_by: 'description (part 2)')
+      expect(@session).to have_link('Link with aria-describedby', described_by: 'description (part 1) description (part 2)')
+    end
+
+    it 'should be false if the link is described by missing elements' do
+      expect(@session).not_to have_link(described_by: 'elements are missing')
+      expect(@session).not_to have_link('Link described by missing elements', described_by: 'elements are missing')
+    end
+
+    it 'should be false if link is not described by the text' do
+      expect(@session).not_to have_link('Link with aria-describedby', described_by: 'does not exist')
+    end
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_link?' do
@@ -35,5 +55,25 @@ Capybara::SpecHelper.spec '#has_no_link?' do
     expect(@session).to have_no_link('monkey')
     expect(@session).to have_no_link('A link', href: '/nonexistent-href')
     expect(@session).to have_no_link('A link', href: %r{/nonexistent-href})
+  end
+
+  context 'with described_by:' do
+    it 'should be true if link is not described by the text' do
+      expect(@session).to have_no_link('Link with aria-describedby', described_by: 'does not exist')
+    end
+
+    it 'should be true if the link is described by missing elements' do
+      expect(@session).to have_no_link(described_by: 'elements are missing')
+      expect(@session).to have_no_link('Link described by missing elements', described_by: 'elements are missing')
+    end
+
+    it 'should be false if link is described by the text' do
+      expect(@session).not_to have_no_link(described_by: 'description (part 1)')
+      expect(@session).not_to have_no_link(described_by: 'description (part 2)')
+      expect(@session).not_to have_no_link(described_by: 'description (part 1) description (part 2)')
+      expect(@session).not_to have_no_link('Link with aria-describedby', described_by: 'description (part 1)')
+      expect(@session).not_to have_no_link('Link with aria-describedby', described_by: 'description (part 2)')
+      expect(@session).not_to have_no_link('Link with aria-describedby', described_by: 'description (part 1) description (part 2)')
+    end
   end
 end

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -708,3 +708,21 @@ New line after and before textarea tag
     <div>Visual representation of the checkbox</div>
   </div>
 </label>
+
+<p>
+  <button aria-describedby="description_part_1 description_part_2">Button with aria-describedby</button>
+
+  <label>
+    Input with aria-describedby
+    <input type="text" aria-describedby="description_part_1 description_part_2">
+  </label>
+  <span id="description_part_1">description (part 1)</span>
+  <span id="description_part_2">description (part 2)</span>
+
+  <button aria-describedby="missing_element">Button described by missing elements</button>
+
+  <label>
+    Input described by missing elements
+    <input type="text" aria-describedby="missing_element">
+  </label>
+</p>

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -206,3 +206,9 @@ banana</textarea>
 
 <a href="/download.csv" download>Download Me</a>
 <a href="/download.csv" download="other.csv">Download Other</a>
+
+<a href="#" aria-describedby="description_part_1 description_part_2">Link with aria-describedby</a>
+<a href="#" aria-describedby="missing_element">Link described by missing elements</a>
+
+<span id="description_part_1">description (part 1)</span>
+<span id="description_part_2">description (part 2)</span>


### PR DESCRIPTION
Filter fields, buttons, and links by descriptions constructed from their
[aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attribute.

For example, given the following HTML:

```html
<label id="price">Price</label>
<span id="price_currency">USD</price>
<input id="price" type="number" name="price" value="-1" aria-describedby="price_currency price_errors">
<span id="price_errors">must be greater than $0</span>
```

consider the following:

```ruby
expect(page).to have_field(described_by: "USD")
expect(page).to have_field("USD must be greater than $0")
expect(page).to have_field("Price", described_by: "USD")
expect(page).to have_field("Price", described_by: "must be greater than $0")
expect(page).to have_field("Price", described_by: "USD must be greater than $0")
```