### PR TITLE
Remove include Capybara::DSL and include Capybara::RSpecMatchers

### DIFF
--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -7,12 +7,6 @@ require 'capybara/rspec/features'
 require 'capybara/rspec/matcher_proxies'
 
 RSpec.configure do |config|
-  config.include Capybara::DSL, type: :feature
-  config.include Capybara::RSpecMatchers, type: :feature
-  config.include Capybara::DSL, type: :system
-  config.include Capybara::RSpecMatchers, type: :system
-  config.include Capybara::RSpecMatchers, type: :view
-
   # The before and after blocks must run instantaneously, because Capybara
   # might not actually be used in all examples where it's included.
   config.after do


### PR DESCRIPTION
'system spec' and 'feature spec' are defined in rspec-**rails**, and it is better to include them in the context of Rails.

rspec-rails actually includes Capybara::DSL properly here,
https://github.com/rspec/rspec-rails/blob/v5.0.2/lib/rspec/rails/vendor/capybara.rb#L13-L27
so I think we don't need to include Capybara::DSL anymore.

(Note that non-Rails users will be affected if they use Capybara without `config.include Capybara::DSL`.)