### PR TITLE
Fix invalid HTML generated by AnimationDisabler

### DIFF
--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -381,6 +381,12 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
           @animation_session = Capybara::Session.new(session.mode, TestApp.new)
         end
 
+        it 'should add CSS to the <head> element' do
+          @animation_session.visit('with_animation')
+
+          expect(@animation_session).to have_selector(:css, 'head > style', text: 'transition: none', visible: :hidden)
+        end
+
         it 'should disable CSS transitions' do
           @animation_session.visit('with_animation')
           @animation_session.click_link('transition me away')


### PR DESCRIPTION
While I was experimenting with the [W3C rspec validations](https://github.com/Goltergaul/w3c_rspec_validators) gem, it reported all pages had invalid HTML due to the contents added by Capybara's AnimationDisabler. The W3C Validator was reporting an error:

> Element style not allowed as child of element body in this context.
>
> Contexts in which element style may be used:
>    * Where metadata content is expected.
>    * In a noscript element that is a child of a head element.
>
> Content model for element body:
>    * Flow content.

It looks like [there can't be any style tags inside the body element](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element).

The `<script>` part of the markup template remains at the end of the `<body>` element because it only makes sense if jQuery has already been defined, and jQuery could be defined anywhere inside the `<head>` or `<body>` elements.

I'm not familiar with your source code at all, so comments about either the implementation or the tests are much appreciated :pray:.