### PR TITLE
Shush deprecation warning when opening new window on Selenium WebDriver 4

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -254,7 +254,11 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   end
 
   def open_new_window(kind = :tab)
-    browser.manage.new_window(kind)
+    if browser.switch_to.respond_to?(:new_window)
+      browser.switch_to.new_window(kind)
+    else
+      browser.manage.new_window(kind)
+    end
   rescue NoMethodError, Selenium::WebDriver::Error::WebDriverError
     # If not supported by the driver or browser default to using JS
     browser.execute_script('window.open();')


### PR DESCRIPTION
The warning:

```
WARN Selenium [DEPRECATION] [:new_window] Manager#new_window is deprecated. Use TargetLocator#new_window instead. e.g., `driver.switch_to.new_window(:tab)`
```

`TargetLocator#new_window` is added in Selenium WebDriver 4. Prefer it when available to shush the warning.

References SeleniumHQ/selenium@d047b4d087f30ccf30914dcc58bbb8058061020f.