### PR TITLE
add support for setting the server to ssl and skip the HTTP request

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,7 @@ Release date: 2021-10-24
 * Deprecated `allow_gumbo=` in favor of `use_html5_parsing=` to enable use of Nokogiri::HTML5 when available
 * `Session#active_element` returns the element with focus - Not supported by the `RackTest` driver [Sean Doyle]
 * Support `focused:` filter for finding interactive elements - Not supported by the `RackTest` driver [Sean Doyle]
+* Add `config.server_ssl` to skip HTTP request
 
 ### Fixed
 

--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -97,6 +97,7 @@ module Capybara
     # - **server** (Symbol = `:default` (which uses puma)) - The name of the registered server to use when running the app under test.
     # - **server_port** (Integer) - The port Capybara will run the application server on, if not specified a random port will be used.
     # - **server_host** (String = "127.0.0.1") - The IP address Capybara will bind the application server to. If the test application is to be accessed from an external host, you will want to change this to "0.0.0.0" or to a more specific IP address that your test client can reach.
+    # - **server_ssl** (Boolean) - Indicate that the server has SSL enabled to skip the HTTP request
     # - **server_errors** (Array\<Class> = `[Exception]`) - Error classes that should be raised in the tests if they are raised in the server
     #   and {configure raise_server_errors} is `true`.
     # - **test_id** (Symbol, String, `nil` = `nil`) - Optional attribute to match locator against with built-in selectors along with id.

--- a/lib/capybara/server.rb
+++ b/lib/capybara/server.rb
@@ -22,6 +22,7 @@ module Capybara
                    *deprecated_options,
                    port: Capybara.server_port,
                    host: Capybara.server_host,
+                   ssl: false,
                    reportable_errors: Capybara.server_errors,
                    extra_middleware: [])
       unless deprecated_options.empty?
@@ -35,7 +36,7 @@ module Capybara
       @port = deprecated_options[0] || port
       @port ||= Capybara::Server.ports[port_key]
       @port ||= find_available_port(host)
-      @checker = Checker.new(@host, @port)
+      @checker = Checker.new(@host, @port, ssl: ssl)
     end
 
     def reset_error!

--- a/lib/capybara/server/checker.rb
+++ b/lib/capybara/server/checker.rb
@@ -5,9 +5,9 @@ module Capybara
     class Checker
       TRY_HTTPS_ERRORS = [EOFError, Net::ReadTimeout, Errno::ECONNRESET].freeze
 
-      def initialize(host, port)
+      def initialize(host, port, ssl: false)
         @host, @port = host, port
-        @ssl = false
+        @ssl = ssl
       end
 
       def request(&block)

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -88,8 +88,17 @@ module Capybara
         yield config
       end
       @server = if config.run_server && @app && driver.needs_server?
-        server_options = { port: config.server_port, host: config.server_host, reportable_errors: config.server_errors }
-        server_options[:extra_middleware] = [Capybara::Server::AnimationDisabler] if config.disable_animation
+        server_options = {
+          port: config.server_port,
+          host: config.server_host,
+          reportable_errors: config.server_errors,
+          ssl: config.server_ssl
+        }
+
+        if config.disable_animation
+          server_options[:extra_middleware] = [Capybara::Server::AnimationDisabler]
+        end
+
         Capybara::Server.new(@app, **server_options).boot
       end
       @touched = false

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -7,7 +7,7 @@ module Capybara
     OPTIONS = %i[always_include_port run_server default_selector default_max_wait_time ignore_hidden_elements
                  automatic_reload match exact exact_text raise_server_errors visible_text_only
                  automatic_label_click enable_aria_label save_path asset_host default_host app_host
-                 server_host server_port server_errors default_set_options disable_animation test_id
+                 server_host server_port server_ssl server_errors default_set_options disable_animation test_id
                  predicates_wait default_normalize_ws w3c_click_offset enable_aria_role].freeze
 
     attr_accessor(*OPTIONS)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -142,6 +142,39 @@ RSpec.describe Capybara::Server do
     Capybara.server = :default
   end
 
+  context "with ssl: option not provided" do
+    it 'should be set to http before booting' do
+      server = described_class.new(-> { })
+      expect(server.using_ssl?).to eq(true)
+      expect(server.base_url).to match(/^http:/)
+      server.boot
+      expect(server.using_ssl?).to eq(true)
+      expect(server.base_url).to match(/^https:/)
+    end
+  end
+
+  context "with ssl: false" do
+    it 'should be set to http before booting' do
+      server = described_class.new(-> { }, ssl: true)
+      expect(server.using_ssl?).to eq(false)
+      expect(server.base_url).to match(/^http:/)
+      server.boot
+      expect(server.using_ssl?).to eq(true)
+      expect(server.base_url).to match(/^https:/)
+    end
+  end
+
+  context "with ssl: true" do
+    it 'should be set to https before booting' do
+      server = described_class.new(-> { }, ssl: true)
+      expect(server.using_ssl?).to eq(true)
+      expect(server.base_url).to match(/^https:/)
+      server.boot
+      expect(server.using_ssl?).to eq(true)
+      expect(server.base_url).to match(/^https:/)
+    end
+  end
+
   context 'When Capybara.reuse_server is true' do
     let!(:old_reuse_server) { Capybara.reuse_server }
 


### PR DESCRIPTION
It's to skip the HTTP requests that result in:

```
2021-12-11 11:58:11 +0100 SSL error, peer: 127.0.0.1, peer cert: : #<Puma::MiniSSL::SSLError: HTTP connection?>
```