### PR TITLE
Allow selenium-webdriver 4.1.0 or higher

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -12,7 +12,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
     clear_session_storage: nil
   }.freeze
   SPECIAL_OPTIONS = %i[browser clear_local_storage clear_session_storage timeout native_displayed].freeze
-  CAPS_VERSION = Gem::Requirement.new('~> 4.0.0.alpha6')
+  CAPS_VERSION = Gem::Requirement.new('>= 4.0.0.alpha6')
 
   attr_reader :app, :options
 


### PR DESCRIPTION
This PR fixes the following warning when running with selenium-webdriver 4.1.0.

```
WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
```