### PR TITLE
Rack-test driver adds additional carriage return to CR+LF in textareas

### DIFF
--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -120,7 +120,7 @@ private
   end
 
   def add_textarea_param(field, params)
-    merge_param!(params, field['name'], field['_capybara_raw_value'].to_s.gsub(/\n/, "\r\n"))
+    merge_param!(params, field['name'], field['_capybara_raw_value'].to_s.gsub(/\r?\n/, "\r\n"))
   end
 
   def submitter?(el)

--- a/lib/capybara/spec/session/fill_in_spec.rb
+++ b/lib/capybara/spec/session/fill_in_spec.rb
@@ -98,6 +98,12 @@ Capybara::SpecHelper.spec '#fill_in' do
     expect(extract_results(@session)['description']).to eq("\r\nSome text\r\n")
   end
 
+  it 'should handle carriage returns with line feeds in a textarea correct' do
+    @session.fill_in('form_description', with: "\r\nSome text\r\n")
+    @session.click_button('awesome')
+    expect(extract_results(@session)['description']).to eq("\r\nSome text\r\n")
+  end
+
   it 'should fill in a color field' do
     @session.fill_in('Html5 Color', with: '#112233')
     @session.click_button('html5_submit')


### PR DESCRIPTION
According to [the HTML spec](https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1) line breaks in forms should be represented as CR+LF (`\r\n`). The rack-test driver correctly converts this when a textarea contains `\n`. However if the textarea already had `\r\n` the driver adds another `\r` after the form is submitted resulting in an additional carriage return: `\r\r\n`.

This change does not add an additional carriage return when there already is one.