### PR TITLE
Proof of concept fix for #2556

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -31,11 +31,11 @@ class Capybara::RackTest::Browser
     request(last_request.fullpath, last_request.env)
   end
 
-  def submit(method, path, attributes)
+  def submit(method, path, attributes, multipart: false)
     path = request_path if path.nil? || path.empty?
     uri = build_uri(path)
     uri.query = '' if method.to_s.casecmp('get').zero?
-    process_and_follow_redirects(method, uri.to_s, attributes, 'HTTP_REFERER' => referer_url)
+    process_and_follow_redirects(method, uri.to_s, attributes, multipart: multipart, 'HTTP_REFERER' => referer_url)
   end
 
   def follow(method, path, **attributes)

--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -50,8 +50,8 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     browser.refresh
   end
 
-  def submit(method, path, attributes)
-    browser.submit(method, path, attributes)
+  def submit(method, path, attributes, multipart: false)
+    browser.submit(method, path, attributes, multipart: multipart)
   end
 
   def follow(method, path, **attributes)


### PR DESCRIPTION
This fixes the issue I reported in #2556.

It would however not post as multipart without another present file _unless_ run against (https://github.com/rack/rack-test/pull/303. A workaround could be to do something like:

```rb
merge_param!(params, "_multipart_workaround", NilUploadedFile.new))
```

when not running under a new enough `rack-test`, if any future Capybara version which might include such a fix needs to maintain compatibility with older `rack-test`s.

However, I am not sure which is more problematic: submitting as single part when a `<form enctype="multipart/form-data">` has no filled file inputs or submitting params which were not present in the form in the first place.

My gut is that the latter is actually worse because a single-part form with no file fields should only be a problem if a user is asserting the lower-level data submitted -- which is patently not in the spirit of testing with Capybara. The user wouldn't care, nor should any Capybara test, I would think.