### PR TITLE
Fix wrong counter behavior with changed uri

### DIFF
--- a/lib/capybara/server/middleware.rb
+++ b/lib/capybara/server/middleware.rb
@@ -14,7 +14,7 @@ module Capybara
         end
 
         def decrement(uri)
-          @mutex.synchronize { @value.delete_at(@value.index(uri) || @value.length) }
+          @mutex.synchronize { @value.delete_at(@value.index(uri) || @value.length - 1) }
         end
 
         def positive?

--- a/spec/counter_spec.rb
+++ b/spec/counter_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Capybara::Server::Middleware::Counter do
+  let(:counter) { Capybara::Server::Middleware::Counter.new  }
+  let(:uri) { '/example' }
+
+  context '#increment' do
+    it 'successfully' do
+      counter.increment(uri)
+      expect(counter.positive?).to be true
+    end
+  end
+
+  context 'decrement' do
+    before do
+      counter.increment(uri)
+      expect(counter.positive?).to be true
+    end
+
+    context 'successfully' do
+      it 'with same uri' do
+        counter.decrement(uri)
+        expect(counter.positive?).to be false
+      end
+
+      it 'with changed uri' do
+        counter.decrement('/')
+        expect(counter.positive?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
In some cases, we get an issue when a request is not finished for Capybara, but in reality, it's finished. It looks like we have a case when URI was changed because of server redirection or something like this and the `Counter#decrement` method is going to use a fallback `@value.length`. In the original PR the `- 1` was missed, so for value `['/example']` removing of `@value.length` will resolve to `@value.delete_at(1)` instead of `@value.delete_at(0)`.

### Change log and testing strategy
Fix fallback for Middleware::Counter#decrement which sometimes resolves to `Requests did not finish in 60 seconds` error.

### Related history link
https://github.com/teamcapybara/capybara/pull/2250#discussion_r326843512