### PR TITLE
Fix a duplicate options suggested in `have_xxxx` method at invalid option error message

### DIFF
--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -355,7 +355,7 @@ module Capybara
         return if unhandled_options.empty?
 
         invalid_names = unhandled_options.map(&:inspect).join(', ')
-        valid_names = (valid_keys - [:allow_self]).map(&:inspect).join(', ')
+        valid_names = (valid_keys - [:allow_self]).map(&:inspect).uniq.join(', ')
         raise ArgumentError, "Invalid option(s) #{invalid_names}, should be one of #{valid_names}"
       end
 

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -77,6 +77,12 @@ Capybara::SpecHelper.spec '#has_button?' do
       expect(@session).to have_button('A Button', focused: false)
     end
   end
+
+  it 'should raise an error if an invalid option is passed' do
+    expect do
+      expect(@session).to have_button('A Button', invalid: true)
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :value, :title, :type')
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_button?' do

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -36,6 +36,12 @@ Capybara::SpecHelper.spec '#has_link?' do
       expect(@session).to have_link('labore', focused: false)
     end
   end
+
+  it 'should raise an error if an invalid option is passed' do
+    expect do
+      expect(@session).to have_link('labore', invalid: true)
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :alt, :title, :download')
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_link?' do

--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -179,6 +179,12 @@ Capybara::SpecHelper.spec '#has_select?' do
     end
   end
 
+  it 'should raise an error if an invalid option is passed' do
+    expect do
+      expect(@session).to have_select('form_languages', invalid: true)
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :placeholder, :options, :enabled_options, :disabled_options, :selected, :with_selected, :multiple, :with_options')
+  end
+
   it 'should support locator-less usage' do
     expect(@session.has_select?(with_options: %w[Norway Sweden])).to be true
     expect(@session).to have_select(with_options: ['London'])


### PR DESCRIPTION
This PR eliminates the duplication of options proposed in the `have_xxxx` method's invalid option error message.

If the following code is executed:
```ruby
expect(page).to have_link(invalid: true)
```

The following error message appears (e.g. :href is displayed in duplicate)
```
Failure/Error: expect(page).to have_link(invalid: true)

     ArgumentError:
       Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :href, :alt, :title, :download
```