### PR TITLE
Make retry interval configurable

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -79,6 +79,7 @@ module Capybara
     # - **automatic_reload** (Boolean = `true`) - Whether to automatically reload elements as Capybara is waiting.
     # - **default_max_wait_time** (Numeric = `2`) - The maximum number of seconds to wait for asynchronous processes to finish.
     # - **default_normalize_ws** (Boolean = `false`) - Whether text predicates and matchers use normalize whitespace behavior.
+    # - **default_retry_interval** (Numeric = `0.01`) - The number of seconds to delay the next check in asynchronous processes.
     # - **default_selector** (`:css`, `:xpath` = `:css`) - Methods which take a selector use the given type by default. See also {Capybara::Selector}.
     # - **default_set_options** (Hash = `{}`) - The default options passed to {Capybara::Node::Element#set Element#set}.
     # - **enable_aria_label** (Boolean = `false`) - Whether fields, links, and buttons will match against `aria-label` attribute.
@@ -496,6 +497,7 @@ Capybara.configure do |config|
   config.server = :default
   config.default_selector = :css
   config.default_max_wait_time = 2
+  config.default_retry_interval = 0.01
   config.ignore_hidden_elements = true
   config.default_host = 'http://www.example.com'
   config.automatic_reload = true

--- a/lib/capybara/node/base.rb
+++ b/lib/capybara/node/base.rb
@@ -77,6 +77,7 @@ module Capybara
         return yield if session.synchronized
 
         seconds = session_options.default_max_wait_time if [nil, true].include? seconds
+        interval = session_options.default_retry_interval
         session.synchronized = true
         timer = Capybara::Helpers.timer(expire_in: seconds)
         begin
@@ -88,7 +89,7 @@ module Capybara
           if driver.wait?
             raise e if timer.expired?
 
-            sleep(0.01)
+            sleep interval
             reload if session_options.automatic_reload
           else
             old_base = @base

--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -8,7 +8,7 @@ module Capybara
                  automatic_reload match exact exact_text raise_server_errors visible_text_only
                  automatic_label_click enable_aria_label save_path asset_host default_host app_host
                  server_host server_port server_errors default_set_options disable_animation test_id
-                 predicates_wait default_normalize_ws w3c_click_offset enable_aria_role].freeze
+                 predicates_wait default_normalize_ws w3c_click_offset enable_aria_role default_retry_interval].freeze
 
     attr_accessor(*OPTIONS)
 
@@ -20,6 +20,8 @@ module Capybara
     # @!method default_selector
     #   See {Capybara.configure}
     # @!method default_max_wait_time
+    #   See {Capybara.configure}
+    # @!method default_retry_interval
     #   See {Capybara.configure}
     # @!method ignore_hidden_elements
     #   See {Capybara.configure}

--- a/lib/capybara/spec/spec_helper.rb
+++ b/lib/capybara/spec/spec_helper.rb
@@ -24,6 +24,7 @@ module Capybara
         Capybara.app_host = nil
         Capybara.default_selector = :xpath
         Capybara.default_max_wait_time = 1
+        Capybara.default_retry_interval = 0.01
         Capybara.ignore_hidden_elements = true
         Capybara.exact = false
         Capybara.raise_server_errors = true

--- a/spec/capybara_spec.rb
+++ b/spec/capybara_spec.rb
@@ -15,6 +15,18 @@ RSpec.describe Capybara do
     end
   end
 
+  describe 'default_retry_interval' do
+    before { @previous_default_interval = described_class.default_retry_interval }
+
+    after { described_class.default_retry_interval = @previous_default_interval } # rubocop:disable RSpec/InstanceVariable
+
+    it 'should be changeable' do
+      expect(described_class.default_retry_interval).not_to eq(0.1)
+      described_class.default_retry_interval = 0.1
+      expect(described_class.default_retry_interval).to eq(0.1)
+    end
+  end
+
   describe '.register_driver' do
     it 'should add a new driver' do
       described_class.register_driver :schmoo do |app|

--- a/spec/per_session_config_spec.rb
+++ b/spec/per_session_config_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Capybara::SessionConfig do
          default_selector default_max_wait_time ignore_hidden_elements
          automatic_reload match exact raise_server_errors visible_text_only
          automatic_label_click enable_aria_label save_path
-         asset_host].each do |m|
+         asset_host default_retry_interval].each do |m|
            expect(session.config.public_send(m)).to eq Capybara.public_send(m)
          end
     end


### PR DESCRIPTION
Introduce `Capybara.default_retry_interval` which customize the sleep time in `Capybara::Node::Base#synchronize` in order to save CPU usage. (#2574)
