### PR TITLE
feat: Add the ability to grab elements attributes

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -97,6 +97,29 @@ module Capybara
           end
         end
       end
+      
+      ##
+      #
+      # Retrieve the given element's attributes and not their underlying properties. 
+      #   Each attribute is equivalent to +element.getAttribute(attribute_name)+.
+      #
+      #     <button type="button" class="btn btn-primary">Button</button> 
+      #     element.attributes('type', 'class') # => { "type": "button", "class": "btn btn-primary" }
+      #
+      # @param [Array<String>] attributes   Names of the desired element attributes
+      # @return [Hash]            Hash of the element's attributes
+      #
+      def attributes(*attributes)
+        attributes = attributess.flatten.map(&:to_s)
+        
+        raise ArgumentError, 'You must specify at least one attribute' if attributes.empty?
+
+        begin
+          node.evaluate_script(ATTRIBUTE_SCRIPT, *attributes)
+        rescue Capybara::NotSupportedByDriverError
+          raise e
+        end
+      end
 
       ##
       #
@@ -597,6 +620,17 @@ module Capybara
           }
           return result;
         }).apply(this, arguments)
+      JS
+        
+      ATTRIBUTE_SCRIPT = <<~JS
+        (function(){
+          var result = {};
+          for (var i = arguments.length; i--; ) {
+            var property_name = arguments[i];
+            result[property_name] = this.getAttribute(property_name);
+          }
+          return result;
+         }).apply(this, arguments)
       JS
 
     private

--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -110,7 +110,7 @@ module Capybara
       # @return [Hash]            Hash of the element's attributes
       #
       def attributes(*attributes)
-        attributes = attributess.flatten.map(&:to_s)
+        attributes = attributes.flatten.map(&:to_s)
         
         raise ArgumentError, 'You must specify at least one attribute' if attributes.empty?
 


### PR DESCRIPTION
# Purpose

I noticed while working on a Rich Text Editor that Capybara's hash accessing of "attributes" actually accesses properties, and not the actual attribute.

## Example

Let's assume that I have an `<img>` element like this:

```html
<img width="100" height="100">
```

If I do:

```rb
find("img")[:width] # => Returns the calculated width of the element in the browser.
find("img")[:height] # => Returns the calculated height of the element in the browser.

attributes = find("img").attributes("height", "width")

attributes["height"] # => 100
attributes["width"] # => 100
```

I have an example for this case in my text editor wrapper:

https://github.com/ParamagicDev/tip-tap-rails/blob/2961b78bb1aa252c933ec5771c533cd689ad3427/test/system/attachment_attributes_test.rb#L73-L80

Happy to discuss more about the "attribute" vs "property" issue!

I do also wonder if this should read "properties" and not "attributes"

https://rubydoc.info/github/teamcapybara/capybara/master/Capybara%2FNode%2FElement:[]
