### PR TITLE
Fix offense and obsolete warnings in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'lib/capybara/spec/**/*'
     - 'capybara.gemspec'
-  IgnoredMethods:
+  AllowedMethods:
     - Capybara.add_selector
     - Capybara::Selector::FilterSet.add
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -166,6 +166,9 @@ RSpec/ContextWording:
 RSpec/NestedGroups:
   Enabled: false
 
+RSpec/NoExpectationExample:
+  Enabled: false
+
 RSpec/DescribeClass:
   Enabled: false
 

--- a/lib/capybara/spec/session/current_scope_spec.rb
+++ b/lib/capybara/spec/session/current_scope_spec.rb
@@ -7,7 +7,7 @@ Capybara::SpecHelper.spec '#current_scope' do
 
   context 'when not in a #within block' do
     it 'should return the document' do
-      expect(@session.current_scope).to be_kind_of Capybara::Node::Document
+      expect(@session.current_scope).to be_a Capybara::Node::Document
     end
   end
 

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'capybara/minitest' do
     output = StringIO.new
     reporter = Minitest::SummaryReporter.new(output)
     reporter.start
-    MinitestTest.run reporter, { }
+    MinitestTest.run reporter, {}
     reporter.report
     expect(output.string).to include('22 runs, 53 assertions, 0 failures, 0 errors, 1 skips')
   end

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Capybara do
           css { |_sel| 'input[type="hidden"]' }
         end
 
-        expect(string).to have_no_css('input[type="hidden"]')
+        expect(string).to have_no_field('this is hidden')
         expect(string).to have_selector(:hidden_field)
       end
     end


### PR DESCRIPTION
This PR is fixed offense and obsolete warnings in rubocop.

Fixed the following obsolete warnings that occurred when running the latest version of RuboCop.
```
Warning: obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`.
```

The following offenses were then corrected
```
Offenses:

lib/capybara/spec/session/assert_all_of_selectors_spec.rb:8:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should be true if the given selectors are on the page' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_all_of_selectors_spec.rb:49:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should not raise error if all the elements appear before given wait duration' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_all_of_selectors_spec.rb:70:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should be true if none of the given locators are on the page' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_all_of_selectors_spec.rb:109:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should not find elements if they appear after given wait duration' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_all_of_selectors_spec.rb:122:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should be true if any of the given selectors are on the page' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:8:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should be true if the given selector is on the page' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:34:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should be true if the content is on the page the given number of times' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:65:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should find element if it appears before given wait duration' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:86:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should be true if the given selector is not on the page' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:112:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should be true if the content is on the page the wrong number of times' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:118:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it "should be true if the content isn't on the page at all" do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_selector_spec.rb:137:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should not find element if it appears after given wait duration' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_text_spec.rb:130:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should find element if it appears before given wait duration' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_text_spec.rb:231:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it "should be true if the text in the page doesn't match given regexp" do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/assert_text_spec.rb:251:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should not find element if it appears after given wait duration' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/click_button_spec.rb:8:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should wait for asynchronous load', requires: [:js] do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/click_link_or_button_spec.rb:28:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should wait for asynchronous load', requires: [:js] do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/click_link_spec.rb:8:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should wait for asynchronous load', requires: [:js] do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_scope_spec.rb:10:41: C: [Correctable] RSpec/ClassCheck: Prefer be_a over be_kind_of.
      expect(@session.current_scope).to be_kind_of Capybara::Node::Document
                                        ^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:34:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is affected by visiting a page directly' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:39:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'returns to the app host when visiting a relative url' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:48:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is affected by setting Capybara.app_host' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:58:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is unaffected by following a relative link' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:64:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is affected by following an absolute link' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:70:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is unaffected by posting through a relative form' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:76:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is affected by posting through an absolute form' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:82:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'is affected by following a redirect' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:87:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'maintains fragment' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/current_url_spec.rb:92:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'redirects to a fragment' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/element/assert_match_selector_spec.rb:34:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should accept a filter block' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/fill_in_spec.rb:192:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should wait for asynchronous load', requires: [:js] do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/frame/within_frame_spec.rb:71:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should find multiple nested frames' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/node_spec.rb:468:5: C: RSpec/NoExpectationExample: No expectation found in this example.
    it 'should work with jsTree' do ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/capybara/spec/session/visit_spec.rb:45:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'should be able to open non-http url', requires: [:about_scheme] do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec.rb:164:33: C: [Correctable] Layout/SpaceInsideHashLiteralBraces: Space inside empty hash literal braces detected.
    MinitestTest.run reporter, { }
                                ^
spec/minitest_spec_spec.rb:23:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports text expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:31:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports current_path expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:36:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports title expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:42:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports xpath expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:52:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'support css expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:60:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports link expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:66:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports button expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:71:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports field expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:76:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports select expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:81:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports checked_field expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:86:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports unchecked_field expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:91:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports table expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:97:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports all_of_selectors expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:101:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports none_of_selectors expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:105:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports any_of_selectors expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:109:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports match_selector expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:114:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports match_css expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:119:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports match_xpath expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:124:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles failures' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:128:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports style expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:135:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports ancestor expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/minitest_spec_spec.rb:140:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'supports sibling expectations' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:6:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles strings' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:13:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles escaped characters' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:23:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles wildcards' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:51:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles optional characters for #alternated_substrings' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:66:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles character classes' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:76:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles posix bracket expressions' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:84:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles repitition' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:102:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles non-greedy repetition' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:140:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles alternation for #alternated_substrings' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:175:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles grouping' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:191:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles meta characters' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:199:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles character properties' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:207:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles backreferences' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:213:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles subexpressions' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:219:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'ignores negative lookaheads' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/regexp_dissassembler_spec.rb:229:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'handles anchors' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^
spec/result_spec.rb:25:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'has a first element' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/result_spec.rb:29:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  it 'has a last element' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rspec/features_spec.rb:83:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  scenario "this should be 'temporarily disabled with xfeature'" do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rspec/features_spec.rb:87:3: C: RSpec/NoExpectationExample: No expectation found in this example.
  scenario "this also should be 'temporarily disabled with xfeature'" do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rspec_spec.rb:31:7: C: RSpec/NoExpectationExample: No expectation found in this example.
      it 'sets the current driver in one example...' do ...
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/selector_spec.rb:120:27: C: RSpec/Capybara/SpecificMatcher: Prefer have_no_field over have_no_css.
        expect(string).to have_no_css('input[type="hidden"]')
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/shared_selenium_session.rb:533:9: C: RSpec/NoExpectationExample: No expectation found in this example.
        it 'can set and clear a text field' do ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/shared_selenium_session.rb:549:9: C: RSpec/NoExpectationExample: No expectation found in this example.
        it 'works with rapid fill' do ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

257 files inspected, 81 offenses detected, 2 offenses autocorrectable
```