### PR TITLE
Add `:focus_` usage to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,9 @@ particular feature into Capybara.
 
 ## Pull Requests
 
-- **Add tests!** Your patch won't be accepted if it doesn't have tests.
+- **Add tests!** Your patch won't be accepted if it doesn't have tests.  
+To run a single test or scenario in development use `:focus_` metadada, e.g.:  
+`it 'should simulate multiple held down modifier keys', :focus_ do`
 
 - **Document any change in behaviour**. Make sure the README and any other
   relevant documentation are kept up-to-date.


### PR DESCRIPTION
This should make it easier for new contributors to get started... I spent quite a while trying to figure out how to run a single new test before eventually finding [the answer](https://groups.google.com/g/ruby-capybara/c/7ACASr4wpMI/m/7xqhD9r9GAAJ) on the mailing list.

This documents an old change... https://github.com/teamcapybara/capybara/commit/7155323929c94d981f80deff0200a062dbcdcac8