### PR TITLE
Add `dragenter` event and test to `drag_to`

### DIFF
--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -165,6 +165,9 @@ class Capybara::Selenium::Node
           }
           opts[key + 'Key'] = true;
         }
+        
+        var dragEnterEvent = new DragEvent('dragenter', opts);
+        target.dispatchEvent(dragEnterEvent);
 
         // fire 2 dragover events to simulate dragging with a direction
         var entryPoint = pointOnRect(sourceCenter, targetRect)

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -44,6 +44,10 @@ $(function() {
     $(this).after('<div class="log">DragOver with client position: ' + ev.clientX + ',' + ev.clientY)
     if ($(this).hasClass('drop')) { ev.preventDefault(); }
   });
+  $('#drop_html5, #drop_html5_scroll').on('dragenter', function(ev){
+    $(this).after('<div class="log">DragEnter')
+    if ($(this).hasClass('drop')) { ev.preventDefault(); }
+  });
   $('#drop_html5, #drop_html5_scroll').on('dragleave', function(ev){
     $(this).after('<div class="log">DragLeave with client position: ' + ev.clientX + ',' + ev.clientY)
     if ($(this).hasClass('drop')) { ev.preventDefault(); }

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -651,6 +651,16 @@ Capybara::SpecHelper.spec 'node' do
           expect(target).to have_text(%r{^HTML5 Dropped string: text/plain drag_html5-#{key}$}m, exact: true)
         end
       end
+      
+      it 'should trigger a dragenter event, before the first dragover event' do
+        @session.visit('/with_js')
+        element = @session.find('//div[@id="drag_html5"]')
+        target = @session.find('//div[@id="drop_html5"]')
+        element.drag_to(target)
+      
+        # Events are listed in reverse chronological order
+        expect(@session).to have_text(/DragOver.*DragEnter/m)
+      end
     end
   end
 


### PR DESCRIPTION
Fire a `dragenter` event before the two `dragover` events.

The [spec](https://www.w3.org/html/wg/spec/dnd.html#introduction-6) requires a `dragenter` event to be fired first:

> To accept a drop, the drop target has to listen to at least three events. First, the [dragenter](https://www.w3.org/html/wg/spec/dnd.html#event-dragenter) event, which is used to determine whether or not the drop target is to accept the drop.

Addresses #2576 

This is my first code contribution and I'm much more comfortable in Ruby than JavaScript so please let me know if I've done this badly or misunderstood the JavaScript side of things!

P.S. This is basically a duplicate of #2601 but rebased against latest master. I accidentally closed the other PR by deleting my branch before it had been merged. Hacktoberfest is teaching me a lot about Git and Github. Sorry for the notification spam 😔