### PR TITLE
Update minor text/link issue in warning for FirefoxNode

### DIFF
--- a/lib/capybara/selenium/nodes/firefox_node.rb
+++ b/lib/capybara/selenium/nodes/firefox_node.rb
@@ -12,7 +12,7 @@ class Capybara::Selenium::FirefoxNode < Capybara::Selenium::Node
   rescue ::Selenium::WebDriver::Error::ElementNotInteractableError
     if tag_name == 'tr'
       warn 'You are attempting to click a table row which has issues in geckodriver/marionette - ' \
-           'see https://github.com/mozilla/geckodriver/issues/1228. Your test should probably be ' \
+           'see https://github.com/mozilla/geckodriver/issues/1228 - Your test should probably be ' \
            'clicking on a table cell like a user would. Clicking the first cell in the row instead.'
       return find_css('th:first-child,td:first-child')[0].click(keys, **options)
     end


### PR DESCRIPTION
When using CI systems, this auto-converts into a link. But appends the `.` at the end. So I've just removed it.