### PR TITLE
Fix `Driver#submit` to forward the required args

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -50,8 +50,8 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     browser.refresh
   end
 
-  def submit(method, path, attributes)
-    browser.submit(method, path, attributes)
+  def submit(...)
+    browser.submit(...)
   end
 
   def follow(method, path, **attributes)


### PR DESCRIPTION
## Issue
It looks like the recent release `3.38.0` contains a [small bug](https://github.com/teamcapybara/capybara/commit/a3ff5514f40f3af0ec6655354d3596f6d9ea8964#diff-7ba980837bac726069131342051c1571ce448f8c54887109543c0fbc85e30bc8R57) when forwarding params from the `Capybara::RackTest::Driver` to the `Capybara::RackTest::Browser`.

From our spec suite:
```bash
     Failure/Error: Capybara::RackTest::Form.new(page.driver, form.native).submit({})
     
     ArgumentError:
       wrong number of arguments (given 4, expected 3)
```

After checking it a bit, it looks related to this change a3ff5514f40f3af0ec6655354d3596f6d9ea8964, when the `Capybara::RackTest::Browser#submit` signature was changed, but not the `Capybara::RackTest::Driver` one.

## Approach
Replacing the existing signature to just forward the received params to the final class. I guess we could use this same approach to same methods present in this class, but I didn't want to mix things.

_Note: I know that it doesn't contain any spec, but I am not familiar with the code base. Let me know if you have a clear idea of what I should cover here and I'll do my best to add them ASAP._