### PR TITLE
Fix Rack specs with base dependency versions

### DIFF
--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -260,9 +260,10 @@ class TestApp < Sinatra::Base
 
   post '/form' do
     self.class.form_post_count += 1
+    form_params = params[:form] || {}
     %(
       <pre id="content_type">#{request.content_type}</pre>
-      <pre id="results">#{params.fetch(:form, {}).merge('post_count' => self.class.form_post_count).to_yaml}</pre>
+      <pre id="results">#{form_params.merge('post_count' => self.class.form_post_count).to_yaml}</pre>
     )
   end
 

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Capybara::RackTest::Driver do
     it 'should not include fragments in the referer header' do
       driver.visit('/header_links#an-anchor')
       driver.find_xpath('.//input').first.click
-      expect(driver.request.get_header('HTTP_REFERER')).to eq('http://www.example.com/header_links')
+      expect(driver.request.referer).to eq('http://www.example.com/header_links')
     end
 
     it 'is possible to not follow redirects' do


### PR DESCRIPTION
These two changes together make the Rack specs pass with the base dependency versions, i.e., they make running the following pass:

```bash
BUNDLE_GEMFILE='gemfiles/Gemfile.base-versions' bundle exec rake spec_rack
```