### PR TITLE
Fix Selenium specs with base versions

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -221,7 +221,7 @@ class Capybara::Selenium::Node < Capybara::Driver::Node
   end
 
   def shadow_root
-    raise_error 'You must be using Selenium 4.1+ for shadow_root support' unless native.respond_to? :shadow_root
+    raise 'You must be using Selenium 4.1+ for shadow_root support' unless native.respond_to? :shadow_root
 
     root = native.shadow_root
     root && build_node(native.shadow_root)

--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -260,9 +260,10 @@ class TestApp < Sinatra::Base
 
   post '/form' do
     self.class.form_post_count += 1
+    form_params = params[:form] || {}
     %(
       <pre id="content_type">#{request.content_type}</pre>
-      <pre id="results">#{params.fetch(:form, {}).merge('post_count' => self.class.form_post_count).to_yaml}</pre>
+      <pre id="results">#{form_params.merge('post_count' => self.class.form_post_count).to_yaml}</pre>
     )
   end
 

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Capybara::RackTest::Driver do
     it 'should not include fragments in the referer header' do
       driver.visit('/header_links#an-anchor')
       driver.find_xpath('.//input').first.click
-      expect(driver.request.get_header('HTTP_REFERER')).to eq('http://www.example.com/header_links')
+      expect(driver.request.referer).to eq('http://www.example.com/header_links')
     end
 
     it 'is possible to not follow redirects' do

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -87,6 +87,8 @@ Capybara::SpecHelper.run_specs TestSessions::Chrome, CHROME_DRIVER.to_s, capybar
     pending "Chrome headless doesn't support maximize" if ENV['HEADLESS']
   when /Capybara::Session selenium_chrome node #shadow_root should get visible text/
     pending "Selenium doesn't currently support getting visible text for shadow root elements"
+  when /Capybara::Session selenium_chrome node #shadow_root/
+    skip 'Not supported with this Selenium version' if selenium_lt?('4.1', @session)
   end
 end
 

--- a/spec/selenium_spec_firefox.rb
+++ b/spec/selenium_spec_firefox.rb
@@ -82,6 +82,8 @@ Capybara::SpecHelper.run_specs TestSessions::SeleniumFirefox, 'selenium', capyba
     pending 'Not sure what firefox is doing here'
   when /Capybara::Session selenium_chrome node #shadow_root should get visible text/
     pending "Selenium doesn't currently support getting visible text for shadow root elements"
+  when /Capybara::Session selenium node #shadow_root/
+    skip 'Not supported with this Selenium version' if selenium_lt?('4.1', @session)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,15 @@ module Capybara
       chrome?(session) && (chrome_version(session) >= version)
     end
 
+    def selenium?(session)
+      session.driver.is_a? Capybara::Selenium::Driver
+    end
+
+    def selenium_lt?(version, session)
+      selenium?(session) &&
+        Gem::Version.new(::Selenium::WebDriver::VERSION) < Gem::Version.new(version)
+    end
+
     def edge?(session)
       browser_name(session).to_s.start_with?('edge')
     end


### PR DESCRIPTION
This pull request depends on #2613.

The two additional commits make the Firefox Selenium specs pass with the base dependency versions, making the following pass:

```bash
BUNDLE_GEMFILE='gemfiles/Gemfile.base-versions' bundle exec rake spec_firefox
```
