### PR TITLE
Skip shadow root related spec for #evaluate_script on older Selenium

### DIFF
--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -281,6 +281,7 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
       end
 
       it 'returns a shadow root' do
+        skip 'Not supported with this Selenium version' if selenium_lt?('4.1', session)
         pending "Geckodriver doesn't fully support shadow root yet" if firefox?(session)
         session.visit('/with_shadow')
         shadow = session.find(:css, '#shadow_host')


### PR DESCRIPTION
This makes specs for Chrome pass with the base dependency versions:

```
BUNDLE_GEMFILE='gemfiles/Gemfile.base-versions' bundle exec rake spec_chrome
```
