### PR TITLE
Improve a format for .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
 
 Layout/LineLength:
   Description: 'Limit lines to 120 characters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  StyleGuide: 'https://github.com/rubocop/ruby-style-guide#maximum-line-length'
   Exclude:
     - 'spec/**/*'
     - 'lib/capybara/spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,24 @@ AllCops:
 
 #################### Lint ################################
 
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/IndentationWidth:
+  AllowedPatterns: ['^\s*module']
+
 Layout/LineLength:
   Description: 'Limit lines to 120 characters.'
   StyleGuide: 'https://github.com/rubocop/ruby-style-guide#maximum-line-length'
@@ -26,6 +44,19 @@ Layout/LineLength:
     - '^\s*(raise|warn|Capybara::Helpers.warn) '
   Max: 120
 
+Lint/EmptyBlock:
+  Exclude:
+    - 'lib/capybara/spec/**/*'
+    - 'spec/**/*.rb'
+
+Lint/UnusedMethodArgument:
+  Exclude:
+    - 'lib/capybara/driver/base.rb'
+    - 'lib/capybara/driver/node.rb'
+
+Metrics/AbcSize:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
@@ -34,9 +65,6 @@ Metrics/BlockLength:
   AllowedMethods:
     - Capybara.add_selector
     - Capybara::Selector::FilterSet.add
-
-Metrics/AbcSize:
-  Enabled: false
 
 Metrics/ClassLength:
   CountComments: false
@@ -53,28 +81,11 @@ Metrics/ModuleLength:
   Enabled: false
   CountComments: false
 
-Metrics/PerceivedComplexity:
-  Enabled: false
-
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
-Lint/UnusedMethodArgument:
-  Exclude:
-    - 'lib/capybara/driver/base.rb'
-    - 'lib/capybara/driver/node.rb'
-
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
-
-Lint/EmptyBlock:
-  Exclude:
-    - 'lib/capybara/spec/**/*'
-    - 'spec/**/*.rb'
-
-Naming/PredicateName:
-  Exclude:
-    - '**/*/*matchers.rb'
+Metrics/PerceivedComplexity:
+  Enabled: false
 
 Naming/MethodParameterName:
   AllowedNames:
@@ -85,13 +96,62 @@ Naming/MethodParameterName:
     - 'y'
     - 'on'
 
-Style/ParallelAssignment:
+Naming/PredicateName:
+  Exclude:
+    - '**/*/*matchers.rb'
+
+Performance/MethodObjectAsBlock:
   Enabled: false
 
-Style/SingleLineMethods:
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+
+RSpec/Capybara/NegationMatcher:
+  Enabled: false
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/ExampleWording:
+  Enabled: false
+
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  AssignmentOnly: true
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/NoExpectationExample:
+  Enabled: false
+
+RSpec/PredicateMatcher:
+  Exclude:
+    - 'spec/basic_node_spec.rb'
+
+Security/YAMLLoad:
+  Exclude:
+    - 'lib/capybara/spec/**/*'
+    - 'spec/**/*'
+
+Style/AccessorGrouping:
   Enabled: false
 
 Style/Alias:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/Documentation:
@@ -106,81 +166,21 @@ Style/DocumentDynamicEvalDefinition:
 Style/EmptyElse:
   EnforcedStyle: empty
 
-Style/ClassAndModuleChildren:
-  Enabled: false
+Style/IfUnlessModifier:
+  Exclude:
+    - 'spec/**/*'
 
 Style/NumericLiterals:
   Exclude:
     - 'lib/capybara/spec/**/*'
     - 'spec/**/*'
 
+Style/ParallelAssignment:
+  Enabled: false
+
+Style/SingleLineMethods:
+  Enabled: false
+
 Style/SpecialGlobalVars:
   Exclude:
     - 'capybara.gemspec'
-
-Style/IfUnlessModifier:
-  Exclude:
-    - 'spec/**/*'
-
-Style/AccessorGrouping:
-  Enabled: false
-
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
-
-Layout/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
-Layout/CaseIndentation:
-  EnforcedStyle: end
-
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-
-Layout/IndentationWidth:
-  AllowedPatterns: ['^\s*module']
-
-Security/YAMLLoad:
-  Exclude:
-    - 'lib/capybara/spec/**/*'
-    - 'spec/**/*'
-
-Performance/MethodObjectAsBlock:
-  Enabled: false
-
-RSpec/ExampleWording:
-  Enabled: false
-
-RSpec/InstanceVariable:
-  AssignmentOnly: true
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/ContextWording:
-  Enabled: false
-
-RSpec/NestedGroups:
-  Enabled: false
-
-RSpec/NoExpectationExample:
-  Enabled: false
-
-RSpec/DescribeClass:
-  Enabled: false
-
-RSpec/FilePath:
-  Enabled: false
-
-RSpec/PredicateMatcher:
-  Exclude:
-    - 'spec/basic_node_spec.rb'
-
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
-
-RSpec/Capybara/NegationMatcher:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,8 +33,8 @@ Layout/IndentationWidth:
   AllowedPatterns: ['^\s*module']
 
 Layout/LineLength:
-  Description: 'Limit lines to 120 characters.'
-  StyleGuide: 'https://github.com/rubocop/ruby-style-guide#maximum-line-length'
+  # Limit lines to 120 characters
+  # https://github.com/rubocop/ruby-style-guide#maximum-line-length
   Exclude:
     - 'spec/**/*'
     - 'lib/capybara/spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 require:
-  - rubocop-rspec
-  - rubocop-performance
   - rubocop-minitest
+  - rubocop-performance
   - rubocop-rake
+  - rubocop-rspec
 
 AllCops:
   NewCops: enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
       - 'vendor/**/*'
       - 'gemfiles/vendor/**/*'
 
-#################### Lint ################################
+#################### Layout ####################
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
@@ -44,6 +44,8 @@ Layout/LineLength:
     - '^\s*(raise|warn|Capybara::Helpers.warn) '
   Max: 120
 
+#################### Lint ####################
+
 Lint/EmptyBlock:
   Exclude:
     - 'lib/capybara/spec/**/*'
@@ -53,6 +55,8 @@ Lint/UnusedMethodArgument:
   Exclude:
     - 'lib/capybara/driver/base.rb'
     - 'lib/capybara/driver/node.rb'
+
+#################### Metrics ####################
 
 Metrics/AbcSize:
   Enabled: false
@@ -87,6 +91,8 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+#################### Naming ####################
+
 Naming/MethodParameterName:
   AllowedNames:
     - 'el'
@@ -100,8 +106,12 @@ Naming/PredicateName:
   Exclude:
     - '**/*/*matchers.rb'
 
+#################### Performance ####################
+
 Performance/MethodObjectAsBlock:
   Enabled: false
+
+#################### RSpec ####################
 
 RSpec/Capybara/FeatureMethods:
   Enabled: false
@@ -140,10 +150,14 @@ RSpec/PredicateMatcher:
   Exclude:
     - 'spec/basic_node_spec.rb'
 
+#################### Security ####################
+
 Security/YAMLLoad:
   Exclude:
     - 'lib/capybara/spec/**/*'
     - 'spec/**/*'
+
+#################### Style ####################
 
 Style/AccessorGrouping:
   Enabled: false


### PR DESCRIPTION
This PR improve a format for .rubocop.yml.

- Update the URL of the link.
- Sort alphabetically.
- Add comments for each department.
- Change comment-use text that was written as YAML to comments.