### PR TITLE
Cleanup animation disabler, remove deprecation warn

### DIFF
--- a/lib/capybara/server/animation_disabler.rb
+++ b/lib/capybara/server/animation_disabler.rb
@@ -17,9 +17,8 @@ module Capybara
       def initialize(app)
         @app = app
         @disable_css_markup = format(DISABLE_CSS_MARKUP_TEMPLATE,
-                                     selector: self.class.selector_for(Capybara.disable_animation))
-        @disable_js_markup = format(DISABLE_JS_MARKUP_TEMPLATE,
-                                    selector: self.class.selector_for(Capybara.disable_animation))
+                                     { selector: self.class.selector_for(Capybara.disable_animation) })
+        @disable_js_markup = DISABLE_JS_MARKUP_TEMPLATE
       end
 
       def call(env)


### PR DESCRIPTION
Removes warning: `capybara-3.38.0/lib/capybara/server/animation_disabler.rb:21: warning: too many arguments for format string`