### PR TITLE
add: `Session#execute_async_script`

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Added
+
+* Support for `Sesison#execute_async_script`
+
 # Version 3.39.0
 Release date: unreleased
 

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -59,7 +59,7 @@ module Capybara
     ].freeze
     SESSION_METHODS = %i[
       body html source current_url current_host current_path
-      execute_script evaluate_script evaluate_async_script visit refresh go_back go_forward send_keys
+      execute_script evaluate_script evaluate_async_script execute_async_script visit refresh go_back go_forward send_keys
       within within_element within_fieldset within_table within_frame switch_to_frame
       current_window windows open_new_window switch_to_window within_window window_opened_by
       save_page save_and_open_page save_screenshot
@@ -603,6 +603,18 @@ module Capybara
     def execute_script(script, *args)
       @touched = true
       driver.execute_script(script, *driver_args(args))
+    end
+
+    ##
+    #
+    # Execute the given JavaScript asynchronously, not returning a result. A callback function which will be passed as the last argument to the script.
+    #
+    # @param  [String] script   A string of JavaScript to execute
+    # @param           args     Optional arguments that will be passed to the script
+    #
+    def execute_async_script(script, *args)
+      @touched = true
+      driver.execute_async_script(script, *driver_args(args))
     end
 
     ##

--- a/lib/capybara/spec/session/execute_async_script_spec.rb
+++ b/lib/capybara/spec/session/execute_async_script_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Capybara::SpecHelper.spec '#execute_async_script', requires: [:js] do
+  it 'should execute the given script and return whatever it produces' do
+    @session.visit('/with_js')
+    expect(@session.execute_async_script('arguments[0](4)')).to eq(4)
+  end
+
+  it 'should support passing elements as arguments to the script', requires: %i[js es_args] do
+    @session.visit('/with_js')
+    el = @session.find(:css, '#drag p')
+    result = @session.execute_async_script('arguments[2]([arguments[0].innerText, arguments[1]])', el, 'Doodle Funk')
+    expect(result).to be_nil
+  end
+
+  it 'should support returning elements after asynchronous operation', requires: %i[js es_args] do
+    @session.visit('/with_js')
+    @session.find(:css, '#change') # ensure page has loaded and element is available
+    el = @session.execute_async_script("var cb = arguments[0]; setTimeout(function(){ cb(document.getElementById('change')) }, 100)")
+    expect(el).to be_nil
+    expect(el).to eq(@session.find(:css, '#change'))
+  end
+end


### PR DESCRIPTION
Similar to [teamcapybara/capybara#2558][] and
[teamcapybara/capybara#2559][], extends the `Session` interface to implement `execute_async_script`.

[teamcapybara/capybara#2558]: https://github.com/teamcapybara/capybara/issues/2558
[teamcapybara/capybara#2559]: https://github.com/teamcapybara/capybara/pull/2559