### PR TITLE
Fix MS Edge Click (Button) to Support Ruby 3 Separation of Positional and Keyword Arguments

### DIFF
--- a/lib/capybara/selenium/nodes/edge_node.rb
+++ b/lib/capybara/selenium/nodes/edge_node.rb
@@ -38,7 +38,7 @@ class Capybara::Selenium::EdgeNode < Capybara::Selenium::Node
     html5_drop(*args)
   end
 
-  def click(*)
+  def click(*, **)
     super
   rescue Selenium::WebDriver::Error::InvalidArgumentError => e
     tag_name, type = attrs(:tagName, :type).map { |val| val&.downcase }

--- a/spec/selenium_spec_edge.rb
+++ b/spec/selenium_spec_edge.rb
@@ -11,14 +11,14 @@ require 'rspec/shared_spec_matchers'
 # end
 
 if Selenium::WebDriver::Platform.mac?
-  Selenium::WebDriver::EdgeChrome.path = '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev'
+  Selenium::WebDriver::Edge.path = '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
 end
 
 Capybara.register_driver :selenium_edge do |app|
   # ::Selenium::WebDriver.logger.level = "debug"
   # If we don't create an options object the path set above won't be used
-  browser_options = Selenium::WebDriver::EdgeChrome::Options.new
-  Capybara::Selenium::Driver.new(app, browser: :edge_chrome, options: browser_options).tap do |driver|
+  browser_options = Selenium::WebDriver::Edge::Options.new
+  Capybara::Selenium::Driver.new(app, browser: :edge, options: browser_options).tap do |driver|
     driver.browser
     driver.download_path = Capybara.save_path
   end
@@ -30,7 +30,7 @@ end
 
 skipped_tests = %i[response_headers status_code trigger]
 
-Capybara::SpecHelper.log_selenium_driver_version(Selenium::WebDriver::EdgeChrome) if ENV['CI']
+Capybara::SpecHelper.log_selenium_driver_version(Selenium::WebDriver::Edge) if ENV['CI']
 
 Capybara::SpecHelper.run_specs TestSessions::SeleniumEdge, 'selenium', capybara_skip: skipped_tests do |example|
   case example.metadata[:full_description]


### PR DESCRIPTION
# What
This changeset introduces no changes to existing desired behavior.

This limited changeset has 3 specific changes related only to issues with Microsoft Edge browser support:

1.  Addresses an issue when using the click functionality with Microsoft Edge browser with Ruby 3.  Specifically, when using Ruby 3 and attempting to click, the following exception (and abridged stack trace is produced)
```ruby
ArgumentError:
  wrong number of arguments (given 2, expected 0..1)
# ./lib/capybara/selenium/node.rb:106:in `click'
# ./lib/capybara/selenium/nodes/edge_node.rb:42:in `click'
# ./lib/capybara/node/element.rb:172:in `block in click'
# ./lib/capybara/node/element.rb:608:in `block in perform_click_action'
# ./lib/capybara/node/base.rb:84:in `synchronize'
# ./lib/capybara/node/element.rb:608:in `perform_click_action'
# ./lib/capybara/node/element.rb:171:in `click'
# ./lib/capybara/node/actions.rb:58:in `click_button'
# ./lib/capybara/session.rb:773:in `click_button'
...
```

2. Updates the official Selenium Edge browser naming conventions from `EdgeChrome`/`edge_chrome` to `Edge`/`edge` per Selenium commit [0b23bfe](https://github.com/SeleniumHQ/selenium/commit/0b23bfe15bcf71375a29c789999c1d9e770c8f30).  This change results in now being able to successful run the `spec_edge` rake task without encountering errors...
   ```ruby
   NameError:
       uninitialized constant Selenium::WebDriver::EdgeChrome
   # ./spec/selenium_spec_edge.rb:14:in `<top (required)>'
   ```

3. For Mac only, updates the Edge browser executable to use the official MS Edge instead of MS Edge Dev since Edge is now supported on Mac.

## Reproducing Issues
Assuming that MS Edge is installed and configured, the most concise way to reproduce these issues is to use existing click  tests in `lib/capybara/spec/session/click_button_spec.rb`.

1. Ensure MS Edge is installed and configured
2. Ensure Ruby version is 3.0 or greater (I used Ruby 3.2.0)
3. Edit file `lib/capybara/spec/session/click_button_spec.rb` and add `:focus_` metadata to restrict running just this suite
   ```ruby
   Capybara::SpecHelper.spec '#click_button', :focus_ do
   ```
4. Run just the focused click tests using MS Edge
   ```
   bundle exec rake spec_edge
   ```

> Note that the focused click tests fail under Ruby 3, but pass under Ruby 2 (I used Ruby 2.7.7)

# Why
This changeset resolves the issues mentioned above for MS Edge browser support.

The main issue of using the click functionality with Microsoft Edge browser with Ruby 3 is a result of Ruby 3's breaking change of [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

# Change Impact Analysis and Testing
This changeset...
- Introduce no changes to existing desired behavior.
- Fixes the issue of being unable to execute the `spec_edge` rake task ane being able to run supported tests using MS Edge
- Fixes the issue of the `Capybara::Selenium::EdgeNode#click` method throwing an `ArgumentError` exception when running with Ruby 3
- Changes running the `spec_edge` rake task on Mac to use the official MS Edge browser instead of the Dev(elopment) version

Given that these changes are isolated to the `spec_edge` rake task and the method signature of `Capybara::Selenium::EdgeNode#click`, testing of just these areas should be sufficient following the steps outlined in **Reproducing Issues**.  

Also note that the `Capybara::Selenium::EdgeNode#click` method signature now parallels that of `Capybara::Selenium::ChromeNode:click` which also calls `super`.