### PR TITLE
Fix warnings when running RuboCop

### DIFF
--- a/spec/rspec/shared_spec_matchers.rb
+++ b/spec/rspec/shared_spec_matchers.rb
@@ -840,10 +840,10 @@ RSpec.shared_examples Capybara::RSpecMatchers do |session, _mode|
     end
 
     it 'gives proper description when :visible option passed' do
-      expect(have_table('Lovely table', visible: true).description).to eq('have visible table "Lovely table"') # rubocop:disable RSpec/Capybara/VisibilityMatcher
+      expect(have_table('Lovely table', visible: true).description).to eq('have visible table "Lovely table"') # rubocop:disable Capybara/VisibilityMatcher
       expect(have_table('Lovely table', visible: :hidden).description).to eq('have non-visible table "Lovely table"')
       expect(have_table('Lovely table', visible: :all).description).to eq('have table "Lovely table"')
-      expect(have_table('Lovely table', visible: false).description).to eq('have table "Lovely table"') # rubocop:disable RSpec/Capybara/VisibilityMatcher
+      expect(have_table('Lovely table', visible: false).description).to eq('have table "Lovely table"') # rubocop:disable Capybara/VisibilityMatcher
     end
 
     it 'passes if there is such a table' do

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Capybara do
           css { |_sel| 'input[type="hidden"]' }
         end
 
-        expect(string).to have_no_css('input[type="hidden"]') # rubocop:disable RSpec/Capybara/SpecificMatcher
+        expect(string).to have_no_css('input[type="hidden"]') # rubocop:disable Capybara/SpecificMatcher
         expect(string).to have_selector(:hidden_field)
       end
     end


### PR DESCRIPTION
This PR is fix warnings when running RuboCop.

```
spec/selector_spec.rb: RSpec/Capybara/SpecificMatcher has the wrong namespace - should be Capybara
spec/rspec/shared_spec_matchers.rb: RSpec/Capybara/VisibilityMatcher has the wrong namespace - should be Capybara
spec/rspec/shared_spec_matchers.rb: RSpec/Capybara/VisibilityMatcher has the wrong namespace - should be Capybara
Inspecting 259 files
:
```