### PR TITLE
Fix some offenses for RuboCop

### DIFF
--- a/lib/capybara/spec/session/window/windows_spec.rb
+++ b/lib/capybara/spec/session/window/windows_spec.rb
@@ -29,6 +29,6 @@ Capybara::SpecHelper.spec '#windows', requires: [:windows] do
     titles = @session.windows.map do |window|
       @session.within_window(window) { @session.title }
     end
-    expect(titles).to match_array(['With Windows', 'Title of the first popup', 'Title of popup two'])
+    expect(titles).to contain_exactly('With Windows', 'Title of the first popup', 'Title of popup two')
   end
 end

--- a/spec/rspec/features_spec.rb
+++ b/spec/rspec/features_spec.rb
@@ -79,7 +79,7 @@ feature "Capybara's feature DSL with driver", driver: :culerity do
 end
 
 # rubocop:disable RSpec/RepeatedExample
-xfeature 'if xfeature aliases to pending then' do # rubocop:disable RSpec/PendingWithoutReason
+xfeature 'if xfeature aliases to pending then' do
   scenario "this should be 'temporarily disabled with xfeature'" do
     # dummy
   end


### PR DESCRIPTION
This PR is fix some offenses for RuboCop.

```
❯ bundle exec rubocop -A
Inspecting 259 files
.......................................................................................................................................................................................................................C.....................W.....................

Offenses:

lib/capybara/spec/session/window/windows_spec.rb:32:23: C: [Corrected] RSpec/MatchArray: Prefer contain_exactly when matching an array literal.
    expect(titles).to match_array(['With Windows', 'Title of the first popup', 'Title of popup two'])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rspec/features_spec.rb:82:51: W: [Corrected] Lint/RedundantCopDisableDirective: Unnecessary disabling of RSpec/PendingWithoutReason.
xfeature 'if xfeature aliases to pending then' do # rubocop:disable RSpec/PendingWithoutReason
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

259 files inspected, 2 offenses detected, 2 offenses corrected
```