### PR TITLE
Add support `:target` filter option on `:link` selector

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,10 @@
 # Version 3.39.0
 Release date: unreleased
 
+### Added
+
+* Support `:target` filter option on `:link` selector [Yudai Takada]
+
 ###  Changed
 
 * Dropped support for rack 1.x

--- a/lib/capybara/node/finders.rb
+++ b/lib/capybara/node/finders.rb
@@ -149,6 +149,8 @@ module Capybara
       #   @option options [String, Regexp] id         Match links with the id provided
       #   @option options [String] title              Match links with the title provided
       #   @option options [String] alt                Match links with a contained img element whose alt matches
+      #   @option options [String, Boolean] download  Match links with the download provided
+      #   @option options [String] target             Match links with the target provided
       #   @option options [String, Array<String>, Regexp] class    Match links that match the class(es) provided
       # @return [Capybara::Node::Element]   The found element
       #

--- a/lib/capybara/selector/definition/link.rb
+++ b/lib/capybara/selector/definition/link.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Capybara.add_selector(:link, locator_type: [String, Symbol]) do
-  xpath do |locator, href: true, alt: nil, title: nil, **|
+  xpath do |locator, href: true, alt: nil, title: nil, target: nil, **|
     xpath = XPath.descendant(:a)
     xpath = builder(xpath).add_attribute_conditions(href: href) unless href == false
 
@@ -25,6 +25,7 @@ Capybara.add_selector(:link, locator_type: [String, Symbol]) do
 
     xpath = xpath[find_by_attr(:title, title)]
     xpath = xpath[XPath.descendant(:img)[XPath.attr(:alt) == alt]] if alt
+    xpath = xpath[find_by_attr(:target, target)] if target
 
     xpath
   end

--- a/lib/capybara/spec/session/click_link_spec.rb
+++ b/lib/capybara/spec/session/click_link_spec.rb
@@ -131,6 +131,17 @@ Capybara::SpecHelper.spec '#click_link' do
     end
   end
 
+  context 'with :target option given' do
+    it 'should find links with valid target' do
+      @session.click_link('labore', target: '_self')
+      expect(@session).to have_content('Bar')
+    end
+
+    it "should raise error if link wasn't found" do
+      expect { @session.click_link('labore', target: '_blank') }.to raise_error(Capybara::ElementNotFound, /Unable to find link "labore"/)
+    end
+  end
+
   it 'should follow relative links' do
     @session.visit('/')
     @session.click_link('Relative')

--- a/lib/capybara/spec/session/find_link_spec.rb
+++ b/lib/capybara/spec/session/find_link_spec.rb
@@ -67,4 +67,14 @@ Capybara::SpecHelper.spec '#find_link' do
       expect { @session.find_link(download: 37) }.to raise_error ArgumentError
     end
   end
+
+  context 'with :target option' do
+    it 'should accept partial matches when false' do
+      expect(@session.find_link(target: '_self').text).to eq('labore')
+    end
+
+    it 'should not accept partial matches when true' do
+      expect { @session.find_link(target: '_blank') }.to raise_error Capybara::ElementNotFound
+    end
+  end
 end

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -11,12 +11,14 @@ Capybara::SpecHelper.spec '#has_link?' do
     expect(@session).to have_link('A link', href: '/with_simple_html')
     expect(@session).to have_link(:'A link', href: :'/with_simple_html')
     expect(@session).to have_link('A link', href: %r{/with_simple_html})
+    expect(@session).to have_link('labore', target: '_self')
   end
 
   it 'should be false if the given link is not on the page' do
     expect(@session).not_to have_link('monkey')
     expect(@session).not_to have_link('A link', href: '/nonexistent-href')
     expect(@session).not_to have_link('A link', href: /nonexistent/)
+    expect(@session).not_to have_link('labore', target: '_blank')
   end
 
   it 'should notify if an invalid locator is specified' do
@@ -40,7 +42,7 @@ Capybara::SpecHelper.spec '#has_link?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_link('labore', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :alt, :title, :download')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :alt, :title, :target, :download')
   end
 end
 
@@ -53,12 +55,14 @@ Capybara::SpecHelper.spec '#has_no_link?' do
     expect(@session).not_to have_no_link('foo')
     expect(@session).not_to have_no_link('awesome title')
     expect(@session).not_to have_no_link('A link', href: '/with_simple_html')
+    expect(@session).not_to have_no_link('labore', target: '_self')
   end
 
   it 'should be true if the given link is not on the page' do
     expect(@session).to have_no_link('monkey')
     expect(@session).to have_no_link('A link', href: '/nonexistent-href')
     expect(@session).to have_no_link('A link', href: %r{/nonexistent-href})
+    expect(@session).not_to have_no_link('labore', target: '_blank')
   end
 
   context 'with focused:', requires: [:active_element] do

--- a/lib/capybara/spec/views/with_html.erb
+++ b/lib/capybara/spec/views/with_html.erb
@@ -19,7 +19,7 @@
 
 <p class="para" id="first" data-random="abc\def" style="line-height: 25px;">
   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-  tempor incididunt ut <a href="/with_simple_html" title="awesome title" class="simple" tabindex="1">labore</a>
+  tempor incididunt ut <a href="/with_simple_html" title="awesome title" class="simple" tabindex="1" target="_self">labore</a>
   et dolore magna aliqua. Ut enim ad minim veniam,
   quis nostrud exercitation <a href="/foo" id="foo" data-test-id="test-foo">ullamco</a> laboris nisi
   ut aliquip ex ea commodo consequat.


### PR DESCRIPTION
This PR add support `:target` filter option on `:link` selector.

## Motivation

When wanting to write a test that checks whether the [HTML < a > target attribute](https://www.w3schools.com/tags/att_a_target.asp) has been set to `_blank` or not, it is currently not possible to use matchers like `has_link?`. If passing it as an option raises an invalid option error.

```
Failures:

  1) something something test
     Failure/Error: expect(page).to have_link(target: '_blank')

     ArgumentError:
       Invalid option(s) :target, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :alt, :title, :download
```

Therefore, we would like to support filtering by the target option. What do you think?