### PR TITLE
fix argument error from change in Selenium 4.9.1

### DIFF
--- a/lib/capybara/selenium/logger_suppressor.rb
+++ b/lib/capybara/selenium/logger_suppressor.rb
@@ -3,7 +3,7 @@
 module Capybara
   module Selenium
     module DeprecationSuppressor
-      def initialize(*)
+      def initialize(*, **)
         @suppress_for_capybara = false
         super
       end


### PR DESCRIPTION
This fixes the error, I'm not sure it is the best solution.

Not sure how it would work into the Capybara approach, but you can also use: `logger.ignore(:deprecations)`.