### PR TITLE
selenium log suppression: forward both positional and keyword args

### DIFF
--- a/lib/capybara/selenium/logger_suppressor.rb
+++ b/lib/capybara/selenium/logger_suppressor.rb
@@ -3,7 +3,7 @@
 module Capybara
   module Selenium
     module DeprecationSuppressor
-      def initialize(*)
+      def initialize(*, **)
         @suppress_for_capybara = false
         super
       end
@@ -31,7 +31,7 @@ module Capybara
     end
 
     module ErrorSuppressor
-      def for_code(*)
+      def for_code(*, **)
         ::Selenium::WebDriver.logger.suppress_deprecations do
           super
         end

--- a/lib/capybara/selenium/logger_suppressor.rb
+++ b/lib/capybara/selenium/logger_suppressor.rb
@@ -3,7 +3,7 @@
 module Capybara
   module Selenium
     module DeprecationSuppressor
-      def initialize(*, **)
+      def initialize(...)
         @suppress_for_capybara = false
         super
       end
@@ -31,7 +31,7 @@ module Capybara
     end
 
     module ErrorSuppressor
-      def for_code(*, **)
+      def for_code(...)
         ::Selenium::WebDriver.logger.suppress_deprecations do
           super
         end


### PR DESCRIPTION
Ruby 3 separated positional and keyword arguments, which changes the way we need to forward them. Just using `*` isn't enough, as exposed by #2666. We either need to use `...` or handle both positional and keyword. We opt for the latter approach here since it's compatible with the most Ruby versions.