### PR TITLE
Fix #2670 Wrong number of arguments exception

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -31,7 +31,8 @@ class Capybara::RackTest::Browser
     request(last_request.fullpath, last_request.env)
   end
 
-  def submit(method, path, attributes, content_type: nil)
+  def submit(method, path, attributes)
+    content_type = attributes.delete(:content_type)
     path = request_path if path.nil? || path.empty?
     uri = build_uri(path)
     uri.query = '' if method.to_s.casecmp('get').zero?

--- a/lib/capybara/rack_test/form.rb
+++ b/lib/capybara/rack_test/form.rb
@@ -54,7 +54,8 @@ class Capybara::RackTest::Form < Capybara::RackTest::Node
   def submit(button)
     action = button&.[]('formaction') || native['action']
     method = button&.[]('formmethod') || request_method
-    driver.submit(method, action.to_s, params(button), content_type: native['enctype'])
+    params = params(button) || {}
+    driver.submit(method, action.to_s, params.merge!(content_type: native['enctype']))
   end
 
   def multipart?


### PR DESCRIPTION
## Changes
Resolve https://github.com/teamcapybara/capybara/issues/2670 by
passing content-type argument to submit in attributes instead of as another param to preserve interface in use by other drivers.