### PR TITLE
Fix clearing text in content-editable elements with `set`

### DIFF
--- a/lib/capybara/selenium/node.rb
+++ b/lib/capybara/selenium/node.rb
@@ -403,11 +403,13 @@ private
       return false;
     JS
 
+    value = value.to_s
+
     # The action api has a speed problem but both chrome and firefox 58 raise errors
     # if we use the faster direct send_keys.  For now just send_keys to the element
     # we've already focused.
-    # native.send_keys(value.to_s)
-    browser_action.send_keys(value.to_s).perform if editable
+    # native.send_keys(value)
+    browser_action.send_keys(value.empty? ? :delete : value).perform if editable
   end
 
   def action_with_modifiers(click_options)

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -148,6 +148,8 @@ Capybara::SpecHelper.spec 'node' do
         @session.visit('/with_js')
         @session.find(:css, '#blank_content_editable').set('WYSIWYG')
         expect(@session.find(:css, '#blank_content_editable').text).to eq('WYSIWYG')
+        @session.find(:css, '#blank_content_editable').set('')
+        expect(@session.find(:css, '#blank_content_editable').text).to eq('')
       end
 
       it 'should allow me to change the contents of a child element' do


### PR DESCRIPTION
cc @twalpole 