### PR TITLE
table_row selector matches cell values in order when passed an array …

### DIFF
--- a/lib/capybara/selector/definition/table_row.rb
+++ b/lib/capybara/selector/definition/table_row.rb
@@ -14,7 +14,7 @@ Capybara.add_selector(:table_row, locator_type: [Array, Hash]) do
     else
       initial_td = XPath.descendant(:td)[XPath.string.n.is(locator.shift)]
       tds = locator.reverse.map { |cell| XPath.following_sibling(:td)[XPath.string.n.is(cell)] }
-                   .reduce { |xp, cell| xp.where(cell) }
+                   .reduce { |xp, cell| cell.where(xp) }
       xpath[initial_td[tds]]
     end
   end

--- a/lib/capybara/spec/session/has_table_spec.rb
+++ b/lib/capybara/spec/session/has_table_spec.rb
@@ -116,7 +116,7 @@ Capybara::SpecHelper.spec '#has_table?' do
   end
 
   it 'should find row by cell values' do
-    expect(@session.find(:table, 'Horizontal Headers')).to have_selector(:table_row, %w[Thomas Walpole])
+    expect(@session.find(:table, 'Horizontal Headers')).to have_selector(:table_row, %w[Thomas Walpole Oceanside])
     expect(@session.find(:table, 'Horizontal Headers')).not_to have_selector(:table_row, %w[Walpole Thomas])
     expect(@session.find(:table, 'Horizontal Headers')).not_to have_selector(:table_row, %w[Other])
   end


### PR DESCRIPTION
…Fixes #2686

This corrects the shape of the generated xpath for matching against an array of values. 

If you look at how this is implemented for the :table, with_rows: [...] selector you can see that it builds a nested xpath here: https://github.com/teamcapybara/capybara/blob/5521da18729c3337d63351e7c4a59faf13538837/lib/capybara/selector/definition/table.rb#L106