### PR TITLE
table_row and with_rows ensure that the header matches locator for first column

### DIFF
--- a/lib/capybara/selector/definition/table.rb
+++ b/lib/capybara/selector/definition/table.rb
@@ -93,7 +93,7 @@ Capybara.add_selector(:table, locator_type: [String, Symbol]) do
     row.map do |header, cell|
       header_xp = XPath.ancestor(:table)[1].descendant(:tr)[1].descendant(:th)[XPath.string.n.is(header)]
       XPath.descendant(:td)[
-        XPath.string.n.is(cell) & XPath.position.equals(header_xp.preceding_sibling.count.plus(1))
+        XPath.string.n.is(cell) & header_xp.boolean & XPath.position.equals(header_xp.preceding_sibling.count.plus(1))
       ]
     end.reduce(:&)
   end

--- a/lib/capybara/selector/definition/table_row.rb
+++ b/lib/capybara/selector/definition/table_row.rb
@@ -7,7 +7,7 @@ Capybara.add_selector(:table_row, locator_type: [Array, Hash]) do
       locator.reduce(xpath) do |xp, (header, cell)|
         header_xp = XPath.ancestor(:table)[1].descendant(:tr)[1].descendant(:th)[XPath.string.n.is(header)]
         cell_xp = XPath.descendant(:td)[
-          XPath.string.n.is(cell) & XPath.position.equals(header_xp.preceding_sibling.count.plus(1))
+          XPath.string.n.is(cell) & header_xp.boolean & XPath.position.equals(header_xp.preceding_sibling.count.plus(1))
         ]
         xp.where(cell_xp)
       end

--- a/lib/capybara/spec/session/has_table_spec.rb
+++ b/lib/capybara/spec/session/has_table_spec.rb
@@ -19,11 +19,16 @@ Capybara::SpecHelper.spec '#has_table?' do
       ])
   end
 
-  it 'should accept rows with partial column header hashses' do
+  it 'should accept rows with partial column header hashes' do
     expect(@session).to have_table('Horizontal Headers', with_rows:
       [
         { 'First Name' => 'Thomas' },
         { 'Last Name' => 'Sawayn', 'City' => 'West Trinidad' }
+      ])
+
+    expect(@session).not_to have_table('Horizontal Headers', with_rows:
+      [
+        { 'Unmatched Header' => 'Thomas' }
       ])
   end
 
@@ -103,6 +108,11 @@ Capybara::SpecHelper.spec '#has_table?' do
         { 'First Name' => 'Danilo', 'Last Name' => 'Walpole', 'City' => 'Johnsonville' },
         { 'Last Name' => 'Sawayn', 'City' => 'West Trinidad' }
       ])
+
+    expect(@session).not_to have_table('Vertical Headers', with_cols:
+      [
+        { 'Unmatched Header' => 'Thomas' }
+      ])
   end
 
   it 'should be false if the table is not on the page' do
@@ -113,6 +123,7 @@ Capybara::SpecHelper.spec '#has_table?' do
     expect(@session.find(:table, 'Horizontal Headers')).to have_selector(:table_row, 'First Name' => 'Thomas', 'Last Name' => 'Walpole')
     expect(@session.find(:table, 'Horizontal Headers')).to have_selector(:table_row, 'Last Name' => 'Walpole')
     expect(@session.find(:table, 'Horizontal Headers')).not_to have_selector(:table_row, 'First Name' => 'Walpole')
+    expect(@session.find(:table, 'Horizontal Headers')).not_to have_selector(:table_row, 'Unmatched Header' => 'Thomas')
   end
 
   it 'should find row by cell values' do


### PR DESCRIPTION
Fixes #2685

This adds a check to ensure that the `header_xp` exists before checking the that the position of the cell matches the position of the header. If `header_xp` does not exist then `header_xp.preceding_sibling.count.plus(1)` will still equal 1 and `XPath.position.equals` will be true for the first column.