### PR TITLE
Do not auto-submit forms if they have multiple inputs

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -225,7 +225,7 @@ private
       native.remove
     else
       value.to_s.tap do |set_value|
-        if set_value.end_with?("\n") && form&.css('input, textarea')&.count
+        if set_value.end_with?("\n") && form&.css('input, textarea')&.count == 1
           native['value'] = set_value.to_s.chop
           Capybara::RackTest::Form.new(driver, form).submit(self)
         else

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -163,6 +163,12 @@ Capybara::SpecHelper.spec 'node' do
       @session.find(:css, '#single_input').set("my entry\n")
       expect(extract_results(@session)['single_input']).to eq('my entry')
     end
+
+    it 'should not submit single text input forms if ended with \n and has multiple values' do
+      @session.visit('/form')
+      @session.find(:css, '#two_input_1').set("my entry\n")
+      expect(@session.find(:css, '#two_input_1').value).to eq("my entry\n")
+    end
   end
 
   describe '#tag_name' do

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -699,6 +699,11 @@ New line after and before textarea tag
   <input type="text" name="form[single_input]" id="single_input"/>
 </form>
 
+<form id="two_input_form" action="/form" method="post">
+  <input type="text" name="form[two_input_1]" id="two_input_1"/>
+  <input type="text" name="form[two_input_2]" id="two_input_2"/>
+</form>
+
 <label>Confusion
   <input type="checkbox" id="confusion_checkbox" class="confusion-checkbox confusion"/>
 </label>


### PR DESCRIPTION
Thanks for capybara!

I am attempting to update to the latest version, but am having some test failures from the change in https://github.com/teamcapybara/capybara/commit/6b05e5cb30e9807483c2641e9a60d89692bb0487 as I have forms where I set multiple inputs in the same form to values that end with `\n`.

I think ideally I'd be able to opt-out of the auto-submit behavior, but I'm unsure what the preferred path is. I'm happy to make updates to the branch here as well. Thanks again for all the work that goes into capybara!