### PR TITLE
Do not pass an explicit nil CONTENT_TYPE in the rack_test browser

### DIFF
--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -35,12 +35,13 @@ class Capybara::RackTest::Browser
     path = request_path if path.nil? || path.empty?
     uri = build_uri(path)
     uri.query = '' if method.to_s.casecmp('get').zero?
+    env = {'HTTP_REFERER' => referer_url}
+    env['CONTENT_TYPE'] = content_type if content_type
     process_and_follow_redirects(
       method,
       uri.to_s,
       attributes,
-      'HTTP_REFERER' => referer_url,
-      'CONTENT_TYPE' => content_type
+      env
     )
   end
 

--- a/lib/capybara/rack_test/browser.rb
+++ b/lib/capybara/rack_test/browser.rb
@@ -35,7 +35,7 @@ class Capybara::RackTest::Browser
     path = request_path if path.nil? || path.empty?
     uri = build_uri(path)
     uri.query = '' if method.to_s.casecmp('get').zero?
-    env = {'HTTP_REFERER' => referer_url}
+    env = { 'HTTP_REFERER' => referer_url }
     env['CONTENT_TYPE'] = content_type if content_type
     process_and_follow_redirects(
       method,


### PR DESCRIPTION
This violates the Rack SPEC and causes failures if the application you are testing uses Rack::Lint.

I could not find any existing specs that test the environment that capybara passes to rack-test, so this does not include specs.