### PR TITLE
Remove extra space in version string

### DIFF
--- a/lib/capybara/registrations/servers.rb
+++ b/lib/capybara/registrations/servers.rb
@@ -51,7 +51,7 @@ Capybara.register_server :puma do |app, port, host, **options| # rubocop:disable
   conf.options[:log_writer] = logger
 
   logger.log 'Capybara starting Puma...'
-  logger.log "* Version #{Puma::Const::PUMA_VERSION} , codename: #{Puma::Const::CODE_NAME}"
+  logger.log "* Version #{Puma::Const::PUMA_VERSION}, codename: #{Puma::Const::CODE_NAME}"
   logger.log "* Min threads: #{conf.options[:min_threads]}, max threads: #{conf.options[:max_threads]}"
 
   Puma::Server.new(


### PR DESCRIPTION
I had thought this might've been a "structural space", but it appears not.

The output for min threads has no space before the comma.

Just want to make them match.