### PR TITLE
Supporting tables that have both horizontal and vertical headers

### DIFF
--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -517,13 +517,13 @@ module Capybara
       #
       # @param [String] locator  The id or caption of a table
       # @option options [Array<Array<String>>] :rows
-      #   Text which should be contained in the tables `<td>` elements organized by row (`<td>` visibility is not considered)
+      #   Text which should be contained in the tables `<td>` and `<th>` elements organized by row (`<td>` and `<th>` visibility is not considered)
       # @option options [Array<Array<String>>, Array<Hash<String,String>>] :with_rows
-      #   Partial set of text which should be contained in the tables `<td>` elements organized by row (`<td>` visibility is not considered)
+      #   Partial set of text which should be contained in the tables `<td>` and `<th>` elements organized by row (`<td>` and `<th>` visibility is not considered)
       # @option options [Array<Array<String>>] :cols
-      #   Text which should be contained in the tables `<td>` elements organized by column (`<td>` visibility is not considered)
+      #   Text which should be contained in the tables `<td>` and `<th>` elements organized by row (`<td>` and `<th>` visibility is not considered)
       # @option options [Array<Array<String>>, Array<Hash<String,String>>] :with_cols
-      #   Partial set of text which should be contained in the tables `<td>` elements organized by column (`<td>` visibility is not considered)
+      #   Partial set of which should be contained in the tables `<td>` and `<th>` elements organized by row (`<td>` and `<th>` visibility is not considered)
       # @return [Boolean]        Whether it exists
       #
       def has_table?(locator = nil, **options, &optional_filter_block)

--- a/lib/capybara/spec/session/has_table_spec.rb
+++ b/lib/capybara/spec/session/has_table_spec.rb
@@ -59,6 +59,34 @@ Capybara::SpecHelper.spec '#has_table?' do
       ])
   end
 
+  context 'with a table that has both horizontal and vertical headers' do
+    it 'should accept arrays representing rows' do
+      expect(@session).to have_table('Horizontal and Vertical Headers', rows:
+      [
+        %w[Tim London 555-1234],
+        %w[Joe Berlin 555-5678],
+      ])
+    end
+
+    it 'should key rows by vertical headers' do
+      expect(@session).to have_table('Horizontal and Vertical Headers', with_rows:
+      [
+        { 'Name' => 'Tim', 'City' => 'London', 'Phone' => '555-1234' },
+        { 'Name' => 'Joe', 'City' => 'Berlin', 'Phone' => '555-5678' },
+      ])
+    end
+
+    it 'should match all cols with array of cell values' do
+      expect(@session).to have_table('Horizontal and Vertical Headers', cols:
+        [
+          %w[Tim Joe],
+          %w[London Berlin],
+          %w[555-1234 555-5678],
+        ]
+      )
+    end
+  end
+
   it 'should match with vertical headers' do
     expect(@session).to have_table('Vertical Headers', with_cols:
       [
@@ -112,6 +140,15 @@ Capybara::SpecHelper.spec '#has_table?' do
     expect(@session).not_to have_table('Vertical Headers', with_cols:
       [
         { 'Unmatched Header' => 'Thomas' }
+      ])
+  end
+
+  it "should accept arrays representing TDs of rows with THs" do
+    expect(@session).to have_table('Vertical Headers', with_rows:
+      [
+        ["Thomas", "Danilo", "Vern", "Ratke", "Palmer"],
+        ["Walpole", "Wilkinson", "Konopelski", "Lawrence", "Sawayn"],
+        ["Oceanside", "Johnsonville", "Everette", "East Sorayashire", "West Trinidad"]
       ])
   end
 

--- a/lib/capybara/spec/views/tables.erb
+++ b/lib/capybara/spec/views/tables.erb
@@ -63,6 +63,29 @@
 </form>
 
 <table>
+  <caption>Horizontal and Vertical Headers</caption>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>City</th>
+      <th>Phone</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Tim</th>
+      <td>London</td>
+      <td>555-1234</td>
+    </tr>
+    <tr>
+      <th>Joe</th>
+      <td>Berlin</td>
+      <td>555-5678</td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
   <caption>Horizontal Headers</caption>
   <thead>
     <tr>


### PR DESCRIPTION
Hi! 👋

Thank you for Capybara, I truly enjoy its neat-looking API!

Some time ago, while working on a project that had a table where both columns and rows were assigned some headers (like [this example from MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)), I ran into issues with `rows:`. I wanted to check whether all the expected rows were present on the page, but I couldn't verify the content of the cells that acted as the headers of the rows. 

I decided to contribute to this wonderful project by extending the behavior of "rows". Now it supports `TH` cells in `TR` rows.

Let me know what you think. 🙂