### PR TITLE
Fix deprecation warning when booting puma using rack 3

### DIFF
--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -118,6 +118,18 @@ RSpec.describe Capybara::Server do
     Capybara.server = :default
   end
 
+  it 'should not emit any warnings when booting puma' do
+    Capybara.server = :puma
+    app_proc = proc { |_env| [200, {}, ['Hello Puma!']] }
+    require 'puma'
+
+    expect {
+      described_class.new(app_proc).boot
+    }.not_to output.to_stderr
+  ensure
+    Capybara.server = :default
+  end
+
   it 'should support SSL' do
     key = File.join(Dir.pwd, 'spec', 'fixtures', 'key.pem')
     cert = File.join(Dir.pwd, 'spec', 'fixtures', 'certificate.pem')


### PR DESCRIPTION
Before, using capybara on a project with rack 3 would emit the following warning:

> Rack::Handler is deprecated and replaced by Rackup::Handler

This was because the capybara server registration code for `:puma` was referencing the deprecated `Rack::Handler::Puma` constant.

Fix by detecting and preferring the `Rackup::Handler::Puma` constant, if present.

Fixes #2705