### PR TITLE
Introduce `data:` attribute filter

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ Release date: unreleased
 
 * Dropped support for Ruby 2.7, 3.0+ is now required
 * Dropped support for Selenium < 4.8
+* Support `:data` system filter option
 
 # Version 3.39.2
 Release date: 2023-06-10

--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -9,7 +9,7 @@ module Capybara
 
       SPATIAL_KEYS = %i[above below left_of right_of near].freeze
       VALID_KEYS = SPATIAL_KEYS + COUNT_KEYS +
-                   %i[text id class style visible obscured exact exact_text normalize_ws match wait filter_set focused]
+                   %i[text id class style visible obscured exact exact_text normalize_ws match wait filter_set focused data]
       VALID_MATCH = %i[first smart prefer_exact one].freeze
 
       def initialize(*args,
@@ -79,6 +79,7 @@ module Capybara
 
         desc << " with id #{options[:id]}" if options[:id]
         desc << " with classes [#{Array(options[:class]).join(',')}]" if options[:class]
+        desc << " with data #{options[:data]}" if options[:data]
         desc << ' that is focused' if options[:focused]
         desc << ' that is not focused' if options[:focused] == false
 
@@ -446,6 +447,7 @@ module Capybara
         matches_visibility_filters?(node) &&
           matches_id_filter?(node) &&
           matches_class_filter?(node) &&
+          matches_data_filter?(node) &&
           matches_style_filter?(node) &&
           matches_focused_filter?(node) &&
           matches_text_filter?(node) &&
@@ -511,6 +513,26 @@ module Capybara
         return true unless use_default_focused_filter?
 
         (node == node.session.active_element) == options[:focused]
+      end
+
+      def matches_data_filter?(node)
+        options[:data].to_h.all? do |key, filter|
+          value = node["data-#{key.to_s.tr('_', '-')}"]
+
+          case filter
+          when Hash, Array
+            begin
+              JSON.parse(value, symbolize_names: true) == filter
+            rescue JSON::ParserError, TypeError
+              false
+            end
+          when Regexp then filter.match?(value)
+          when true then !value.nil?
+          when false then value.nil?
+          else
+            value.to_s == filter.to_s
+          end
+        end
       end
 
       def need_to_process_classes?

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -8,6 +8,7 @@ require 'capybara/selector/definition'
 # All Selectors below support the listed selector specific filters in addition to the following system-wide filters
 #   * :id (String, Regexp, XPath::Expression) - Matches the id attribute
 #   * :class (String, Array<String | Regexp>, Regexp, XPath::Expression) - Matches the class(es) provided
+#   * :data (Hash<Symbol, Hash | Array | String | true | false>) - Matches the data-* attributes provided. Underscored keys will be transformed to dasherized counterparts (e.g. a `data: { value: 1 }` filter matches a `data-value="1"` attribute)
 #   * :style (String, Regexp, Hash<String, String>) - Match on elements style
 #   * :above (Element) - Match elements above the passed element on the page
 #   * :below (Element) - Match elements below the passed element on the page

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -81,7 +81,7 @@ Capybara::SpecHelper.spec '#has_button?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_button('A Button', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :value, :title, :type')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :data, :disabled, :name, :value, :title, :type')
   end
 end
 

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -42,7 +42,7 @@ Capybara::SpecHelper.spec '#has_link?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_link('labore', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :alt, :title, :target, :download')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :data, :href, :alt, :title, :target, :download')
   end
 end
 

--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -182,7 +182,7 @@ Capybara::SpecHelper.spec '#has_select?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_select('form_languages', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :placeholder, :options, :enabled_options, :disabled_options, :selected, :with_selected, :multiple, :with_options')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :data, :disabled, :name, :placeholder, :options, :enabled_options, :disabled_options, :selected, :with_selected, :multiple, :with_options')
   end
 
   it 'should support locator-less usage' do

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Capybara do
             <div class="some random words" id="random_words">
               Something
             </div>
+            <div data-one="1" data-two-words="2" data-json-object="{&quot;a&quot;:true}" data-json-array="[1,2,3]" data-boolean>
+            </div>
             <input id="2checkbox" class="2checkbox" type="checkbox"/>
             <input type="radio"/>
             <label for="my_text_input">My Text Input</label>
@@ -353,6 +355,38 @@ RSpec.describe Capybara do
 
         it 'accepts Regexp for CSS base selectors' do
           expect(string.find(:custom_css_selector, 'input', style: /30px/)[:title]).to eq 'Other button 1'
+        end
+      end
+
+      context 'with :data option' do
+        it 'works with compound css selectors' do
+          expect(string.all(:custom_css_selector, 'div, h1', data: { one: 1 }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div, h1', data: { one: '1' }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div, h1', data: { one: /1/ }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'h1, div', data: { one: 1 }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'h1, div', data: { one: '1' }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'h1, div', data: { one: /1/ }).size).to eq 1
+        end
+
+        it 'works with underscored multi-word names' do
+          expect(string.all(:custom_css_selector, 'div', data: { two_words: 2 }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div', data: { two_words: '2' }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div', data: { two_words: /2/ }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div', data: { two_words: 2 }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div', data: { two_words: '2' }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div', data: { two_words: /2/ }).size).to eq 1
+        end
+
+        it 'works with boolean attributes' do
+          expect(string.all(:custom_css_selector, 'div', data: { boolean: true }).size).to eq 1
+        end
+
+        it 'works with encoded JSON values' do
+          json_object = { a: true }
+          json_array = [1, 2, 3]
+
+          expect(string.all(:custom_css_selector, 'div', data: { json_object: json_object }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div', data: { json_array: json_array }).size).to eq 1
         end
       end
 


### PR DESCRIPTION
The Rails provided `tag` and `content_tag` methods will transform [`data:` options][rails-data-option] into `data-` prefixed counterparts.

For example:

```ruby
      tag.div data: { value: 1 }
 # => <div data-value="1"></div>
```

Rails will even JSON-encode `Hash` and `Array` instances:

```ruby
      tag.div data: { object: { value: 1 }, array: [1, 2] }
 # => <div data-object="{&quot;value&quot;:1}" data-array="[1, 2]"></div>
```

This commit introduces similar filter-level support for a global `data:` filter option to transform `Hash` instances into compound `String` keys:

```ruby
 #=> <div data-object="{&quot;value&quot;:1}" data-array="[1, 2]"></div>
 
 expect(page).to have_css "div", data: { object: { value: 1 }, array: [1, 2] } }
```

[rails-data-option]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Options