### PR TITLE
Introduce `aria:` attribute filter

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ Release date: unreleased
 
 * Dropped support for Ruby 2.7, 3.0+ is now required
 * Dropped support for Selenium < 4.8
+* Support `:aria` system filter option
 
 # Version 3.39.2
 Release date: 2023-06-10

--- a/lib/capybara/selector.rb
+++ b/lib/capybara/selector.rb
@@ -8,6 +8,7 @@ require 'capybara/selector/definition'
 # All Selectors below support the listed selector specific filters in addition to the following system-wide filters
 #   * :id (String, Regexp, XPath::Expression) - Matches the id attribute
 #   * :class (String, Array<String | Regexp>, Regexp, XPath::Expression) - Matches the class(es) provided
+#   * :aria (Hash<Symbol, Array | String | true | false>) - Matches the aria-* prefixed attributes provided
 #   * :style (String, Regexp, Hash<String, String>) - Match on elements style
 #   * :above (Element) - Match elements above the passed element on the page
 #   * :below (Element) - Match elements below the passed element on the page

--- a/lib/capybara/spec/session/has_button_spec.rb
+++ b/lib/capybara/spec/session/has_button_spec.rb
@@ -81,7 +81,7 @@ Capybara::SpecHelper.spec '#has_button?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_button('A Button', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :value, :title, :type')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :aria, :disabled, :name, :value, :title, :type')
   end
 end
 

--- a/lib/capybara/spec/session/has_link_spec.rb
+++ b/lib/capybara/spec/session/has_link_spec.rb
@@ -42,7 +42,7 @@ Capybara::SpecHelper.spec '#has_link?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_link('labore', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :href, :alt, :title, :target, :download')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :aria, :href, :alt, :title, :target, :download')
   end
 end
 

--- a/lib/capybara/spec/session/has_select_spec.rb
+++ b/lib/capybara/spec/session/has_select_spec.rb
@@ -182,7 +182,7 @@ Capybara::SpecHelper.spec '#has_select?' do
   it 'should raise an error if an invalid option is passed' do
     expect do
       expect(@session).to have_select('form_languages', invalid: true)
-    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :placeholder, :options, :enabled_options, :disabled_options, :selected, :with_selected, :multiple, :with_options')
+    end.to raise_error(ArgumentError, 'Invalid option(s) :invalid, should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class, :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :aria, :disabled, :name, :placeholder, :options, :enabled_options, :disabled_options, :selected, :with_selected, :multiple, :with_options')
   end
 
   it 'should support locator-less usage' do

--- a/spec/selector_spec.rb
+++ b/spec/selector_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Capybara do
             <div class="some random words" id="random_words">
               Something
             </div>
+            <div aria-label="Label" aria-labelledby="content random_words" aria-selected="true">
+            </div>
             <input id="2checkbox" class="2checkbox" type="checkbox"/>
             <input type="radio"/>
             <label for="my_text_input">My Text Input</label>
@@ -353,6 +355,18 @@ RSpec.describe Capybara do
 
         it 'accepts Regexp for CSS base selectors' do
           expect(string.find(:custom_css_selector, 'input', style: /30px/)[:title]).to eq 'Other button 1'
+        end
+      end
+
+      context 'with :aria option' do
+        it 'works with compound css selectors' do
+          expect(string.all(:custom_css_selector, 'div, h1', aria: { label: 'Label' }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div, h1', aria: { label: /label/i }).size).to eq 1
+          expect(string.all(:custom_css_selector, 'div, h1', aria: { selected: 'true' }).size).to eq 1
+        end
+
+        it 'works with encoded array values' do
+          expect(string.all(:custom_css_selector, 'div', aria: { labelledby: ['content', 'random_words'] }).size).to eq 1
         end
       end
 


### PR DESCRIPTION
The Rails provided `tag` and `content_tag` methods will transform [`aria:` options][rails-aria-option] into `aria-` prefixed counterparts.

For example:

```ruby
      tag.div aria: { label: "Label" }
 # => <div aria-label="Label"></div>
```

Rails will even JSON-encode `Hash` and `Array` instances:

```ruby
      tag.div aria: { labelledby: ["an_id", "another_id"] }
 # => <div aria-labelledby="an_id another_id"></div>
```

This commit introduces similar filter-level support for a global `aria:` filter option to transform `Hash` instances into compound `String` keys.

```ruby
 # => <div aria-labelledby="an_id another_id" aria-selected="true"></div>

 expect(page).to have_css "div", aria: { labelledby: ["an_id", "another_id"], selected: "true" }
```

[rails-aria-option]: https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Options