### PR TITLE
Capybara::Minitest::Assertions: Expose definition helpers

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,11 @@ Release date: unreleased
 * Dropped support for Ruby 2.7, 3.0+ is now required
 * Dropped support for Selenium < 4.8
 
+### Added
+
+* `Capybara::Minitest::Assertions.{asserts,asserts_no}` and
+  `Capybara::Minitest::Assertions.{asserts_selector,asserts_no_selector}` [Sean Doyle]
+
 # Version 3.39.2
 Release date: 2023-06-10
 

--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -7,11 +7,142 @@ module Capybara
   module Minitest
     module Assertions
       ##
+      # Define a Minitest assertion that forwards its arguments to the provided
+      # subject:
+      #
+      #     asserts :text
+      #
+      #     test "Has an element with text" do
+      #       visit "/"
+      #
+      #       assert_text page.find(id: "the-element"), "The element's text"
+      #     end
+      #
+      # @param [Symbol] assertion_names Name of the underlying assertion
+      def self.asserts(*assertion_names)
+        assertion_names.each do |assertion_name|
+          method_name = "assert_#{assertion_name}"
+
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{method_name}(*args, **kwargs, &optional_filter_block)
+              self.assertions +=1
+              subject, args = determine_subject(args)
+              subject.#{method_name}(*args, **kwargs, &optional_filter_block)
+            rescue Capybara::ExpectationNotMet => e
+              raise ::Minitest::Assertion, e.message
+            end
+          RUBY
+          ruby2_keywords method_name if respond_to?(:ruby2_keywords)
+        end
+      end
+
+      ##
+      # Define a Minitest refutation that forwards its arguments to the provided
+      # subject:
+      #
+      #     asserts_no :text
+      #
+      #     test "Has an element without text" do
+      #       visit "/"
+      #
+      #       assert_no_text page.find(id: "the-element"), "Some other text"
+      #     end
+      #
+      # Also defines an alias for the assertion in the refute style:
+      #
+      #     test "Has an element without text" do
+      #       visit "/"
+      #
+      #       refute_text page.find(id: "the-element"), "Some other text"
+      #     end
+      #
+      # @param [Symbol] assertion_names Name of the underlying assertion
+      def self.asserts_no(*assertion_names)
+        assertion_names.each do |assertion_name|
+          method_name = "assert_no_#{assertion_name}"
+
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{method_name}(*args, **kwargs, &optional_filter_block)
+              self.assertions +=1
+              subject, args = determine_subject(args)
+              subject.#{method_name}(*args, **kwargs, &optional_filter_block)
+            rescue Capybara::ExpectationNotMet => e
+              raise ::Minitest::Assertion, e.message
+            end
+          RUBY
+          ruby2_keywords method_name if respond_to?(:ruby2_keywords)
+          alias_method "refute_#{assertion_name}", method_name
+        end
+      end
+
+      ##
+      # Define a Minitest selector assertion that forwards its arguments to the
+      # provided subject:
+      #
+      #     asserts_selector :element
+      #
+      #     test "Has an element with text" do
+      #       visit "/"
+      #
+      #       assert_element page.find(id: "parent"), "div", text: "The child's text"
+      #     end
+      #
+      # @param [Symbol] selector_types Name of the underlying selector
+      def self.asserts_selector(*selector_types)
+        selector_types.each do |selector_type|
+          method_name = "assert_#{selector_type}"
+
+          define_method method_name do |*args, &optional_filter_block|
+            subject, args = determine_subject(args)
+            locator, options = extract_locator(args)
+            assert_selector(subject, selector_type.to_sym, locator, **options, &optional_filter_block)
+          end
+          ruby2_keywords method_name if respond_to?(:ruby2_keywords)
+        end
+      end
+
+      ##
+      # Define a Minitest selector refutation that forwards its arguments to the
+      # provided subject:
+      #
+      #     asserts_no :text
+      #
+      #     test "Has an element without text" do
+      #       visit "/"
+      #
+      #       assert_no_element page.find(id: "parent"), "div", text: "The child's text"
+      #     end
+      #
+      # Also defines an alias for the assertion in the refute style:
+      #
+      #     test "Has an element without text" do
+      #       visit "/"
+      #
+      #       refute_element page.find(id: "parent"), "div", text: "The child's text"
+      #     end
+      #
+      def self.asserts_no_selector(*selector_types)
+        selector_types.each do |selector_type|
+          method_name = "assert_no_#{selector_type}"
+
+          define_method method_name do |*args, &optional_filter_block|
+            subject, args = determine_subject(args)
+            locator, options = extract_locator(args)
+            assert_no_selector(subject, selector_type.to_sym, locator, **options, &optional_filter_block)
+          end
+          ruby2_keywords method_name if respond_to?(:ruby2_keywords)
+          alias_method "refute_#{selector_type}", method_name
+        end
+      end
+
+      ##
       # Assert text exists
       #
       # @!method assert_content
       # @!method assert_text
       #   See {Capybara::Node::Matchers#assert_text}
+      asserts :text
+      alias_method :assert_content, :assert_text
 
       ##
       # Assert text does not exist
@@ -21,12 +152,16 @@ module Capybara
       # @!method refute_text
       # @!method assert_no_text
       #   See {Capybara::Node::Matchers#assert_no_text}
+      asserts_no :text
+      alias_method :refute_content, :refute_text
+      alias_method :assert_no_content, :refute_text
 
       ##
       # Assertion that page title does match
       #
       # @!method assert_title
       #   See {Capybara::Node::DocumentMatchers#assert_title}
+      asserts :title
 
       ##
       # Assertion that page title does not match
@@ -34,12 +169,14 @@ module Capybara
       # @!method refute_title
       # @!method assert_no_title
       #   See {Capybara::Node::DocumentMatchers#assert_no_title}
+      asserts_no :title
 
       ##
       # Assertion that current path matches
       #
       # @!method assert_current_path
       #   See {Capybara::SessionMatchers#assert_current_path}
+      asserts :current_path
 
       ##
       # Assertion that current page does not match
@@ -47,31 +184,14 @@ module Capybara
       # @!method refute_current_path
       # @!method assert_no_current_path
       #   See {Capybara::SessionMatchers#assert_no_current_path}
-
-      %w[text no_text title no_title current_path no_current_path].each do |assertion_name|
-        class_eval <<-ASSERTION, __FILE__, __LINE__ + 1
-          def assert_#{assertion_name}(*args, **kwargs, &optional_filter_block)
-            self.assertions +=1
-            subject, args = determine_subject(args)
-            subject.assert_#{assertion_name}(*args, **kwargs, &optional_filter_block)
-          rescue Capybara::ExpectationNotMet => e
-            raise ::Minitest::Assertion, e.message
-          end
-        ASSERTION
-      end
-
-      alias_method :refute_title, :assert_no_title
-      alias_method :refute_text, :assert_no_text
-      alias_method :refute_content, :refute_text
-      alias_method :refute_current_path, :assert_no_current_path
-      alias_method :assert_content, :assert_text
-      alias_method :assert_no_content, :refute_text
+      asserts_no :current_path
 
       ##
       # Assert selector exists on page
       #
       # @!method assert_selector
       #   See {Capybara::Node::Matchers#assert_selector}
+      asserts_selector :selector
 
       ##
       # Assert selector does not exist on page
@@ -79,12 +199,14 @@ module Capybara
       # @!method refute_selector
       # @!method assert_no_selector
       #   See {Capybara::Node::Matchers#assert_no_selector}
+      asserts_no_selector :selector
 
       ##
       # Assert element matches selector
       #
       # @!method assert_matches_selector
       #   See {Capybara::Node::Matchers#assert_matches_selector}
+      asserts_selector :matches_selector
 
       ##
       # Assert element does not match selector
@@ -92,36 +214,43 @@ module Capybara
       # @!method refute_matches_selector
       # @!method assert_not_matches_selector
       #   See {Capybara::Node::Matchers#assert_not_matches_selector}
+      asserts_selector :not_matches_selector
+      alias_method :refute_matches_selector, :assert_not_matches_selector
 
       ##
       # Assert all of the provided selectors exist on page
       #
       # @!method assert_all_of_selectors
       #   See {Capybara::Node::Matchers#assert_all_of_selectors}
+      asserts_selector :all_of_selectors
 
       ##
       # Assert none of the provided selectors exist on page
       #
       # @!method assert_none_of_selectors
       #   See {Capybara::Node::Matchers#assert_none_of_selectors}
+      asserts_selector :none_of_selectors
 
       ##
       # Assert any of the provided selectors exist on page
       #
       # @!method assert_any_of_selectors
       #   See {Capybara::Node::Matchers#assert_any_of_selectors}
+      asserts_selector :any_of_selectors
 
       ##
       # Assert element has the provided CSS styles
       #
       # @!method assert_matches_style
       #   See {Capybara::Node::Matchers#assert_matches_style}
+      asserts_selector :matches_style
 
       ##
       # Assert element has a matching sibling
       #
       # @!method assert_sibling
       #   See {Capybara::Node::Matchers#assert_sibling}
+      asserts_selector :sibling
 
       ##
       # Assert element does not have a matching sibling
@@ -129,12 +258,14 @@ module Capybara
       # @!method refute_sibling
       # @!method assert_no_sibling
       #   See {Capybara::Node::Matchers#assert_no_sibling}
+      asserts_no_selector :sibling
 
       ##
       # Assert element has a matching ancestor
       #
       # @!method assert_ancestor
       #   See {Capybara::Node::Matchers#assert_ancestor}
+      asserts_selector :ancestor
 
       ##
       # Assert element does not have a matching ancestor
@@ -142,33 +273,14 @@ module Capybara
       # @!method refute_ancestor
       # @!method assert_no_ancestor
       #   See {Capybara::Node::Matchers#assert_no_ancestor}
-
-      %w[selector no_selector matches_style
-         all_of_selectors none_of_selectors any_of_selectors
-         matches_selector not_matches_selector
-         sibling no_sibling ancestor no_ancestor].each do |assertion_name|
-        class_eval <<-ASSERTION, __FILE__, __LINE__ + 1
-          def assert_#{assertion_name} *args, &optional_filter_block
-            self.assertions +=1
-            subject, args = determine_subject(args)
-            subject.assert_#{assertion_name}(*args, &optional_filter_block)
-          rescue Capybara::ExpectationNotMet => e
-            raise ::Minitest::Assertion, e.message
-          end
-        ASSERTION
-        ruby2_keywords "assert_#{assertion_name}" if respond_to?(:ruby2_keywords)
-      end
-
-      alias_method :refute_selector, :assert_no_selector
-      alias_method :refute_matches_selector, :assert_not_matches_selector
-      alias_method :refute_ancestor, :assert_no_ancestor
-      alias_method :refute_sibling, :assert_no_sibling
+      asserts_no_selector :ancestor
 
       ##
       # Assert that provided xpath exists
       #
       # @!method assert_xpath
       #   See {Capybara::Node::Matchers#has_xpath?}
+      asserts_selector :xpath
 
       ##
       # Assert that provide xpath does not exist
@@ -176,12 +288,14 @@ module Capybara
       # @!method refute_xpath
       # @!method assert_no_xpath
       #   See {Capybara::Node::Matchers#has_no_xpath?}
+      asserts_no_selector :xpath
 
       ##
       # Assert that provided css exists
       #
       # @!method assert_css
       #   See {Capybara::Node::Matchers#has_css?}
+      asserts_selector :css
 
       ##
       # Assert that provided css does not exist
@@ -189,12 +303,14 @@ module Capybara
       # @!method refute_css
       # @!method assert_no_css
       #   See {Capybara::Node::Matchers#has_no_css?}
+      asserts_no_selector :css
 
       ##
       # Assert that provided link exists
       #
       # @!method assert_link
       #   See {Capybara::Node::Matchers#has_link?}
+      asserts_selector :link
 
       ##
       # Assert that provided link does not exist
@@ -202,12 +318,14 @@ module Capybara
       # @!method assert_no_link
       # @!method refute_link
       #   See {Capybara::Node::Matchers#has_no_link?}
+      asserts_no_selector :link
 
       ##
       # Assert that provided button exists
       #
       # @!method assert_button
       #   See {Capybara::Node::Matchers#has_button?}
+      asserts_selector :button
 
       ##
       # Assert that provided button does not exist
@@ -215,12 +333,14 @@ module Capybara
       # @!method refute_button
       # @!method assert_no_button
       #   See {Capybara::Node::Matchers#has_no_button?}
+      asserts_no_selector :button
 
       ##
       # Assert that provided field exists
       #
       # @!method assert_field
       #   See {Capybara::Node::Matchers#has_field?}
+      asserts_selector :field
 
       ##
       # Assert that provided field does not exist
@@ -228,6 +348,7 @@ module Capybara
       # @!method refute_field
       # @!method assert_no_field
       #   See {Capybara::Node::Matchers#has_no_field?}
+      asserts_no_selector :field
 
       ##
       # Assert that provided checked field exists
@@ -260,6 +381,7 @@ module Capybara
       #
       # @!method assert_select
       #   See {Capybara::Node::Matchers#has_select?}
+      asserts_selector :select
 
       ##
       # Assert that provided select does not exist
@@ -267,12 +389,14 @@ module Capybara
       # @!method refute_select
       # @!method assert_no_select
       #   See {Capybara::Node::Matchers#has_no_select?}
+      asserts_no_selector :select
 
       ##
       # Assert that provided table exists
       #
       # @!method assert_table
       #   See {Capybara::Node::Matchers#has_table?}
+      asserts_selector :table
 
       ##
       # Assert that provided table does not exist
@@ -280,23 +404,7 @@ module Capybara
       # @!method refute_table
       # @!method assert_no_table
       #   See {Capybara::Node::Matchers#has_no_table?}
-
-      %w[xpath css link button field select table].each do |selector_type|
-        define_method "assert_#{selector_type}" do |*args, &optional_filter_block|
-          subject, args = determine_subject(args)
-          locator, options = extract_locator(args)
-          assert_selector(subject, selector_type.to_sym, locator, **options, &optional_filter_block)
-        end
-        ruby2_keywords "assert_#{selector_type}" if respond_to?(:ruby2_keywords)
-
-        define_method "assert_no_#{selector_type}" do |*args, &optional_filter_block|
-          subject, args = determine_subject(args)
-          locator, options = extract_locator(args)
-          assert_no_selector(subject, selector_type.to_sym, locator, **options, &optional_filter_block)
-        end
-        ruby2_keywords "assert_no_#{selector_type}" if respond_to?(:ruby2_keywords)
-        alias_method "refute_#{selector_type}", "assert_no_#{selector_type}"
-      end
+      asserts_no_selector :table
 
       %w[checked unchecked].each do |field_type|
         define_method "assert_#{field_type}_field" do |*args, &optional_filter_block|


### PR DESCRIPTION
Define module-level `.asserts`, `.asserts_no`, `.assert_selector`, and `.asserts_no_selector` methods to abstract how assertions are defined.

Then, define the out-of-the-box assertions in terms of these new methods, while documenting how to invoke them from consumer-side applications for bespoke selectors.