### PR TITLE
Remove locator from query description if nil

### DIFF
--- a/lib/capybara/queries/selector_query.rb
+++ b/lib/capybara/queries/selector_query.rb
@@ -70,7 +70,8 @@ module Capybara
           desc << 'non-visible ' if visible == :hidden
         end
 
-        desc << "#{label} #{locator.inspect}"
+        desc << label.to_s
+        desc << " #{locator.inspect}" unless locator.nil?
 
         if show_for[:any]
           desc << " with#{' exact' if exact_text == true} text #{options[:text].inspect}" if options[:text]

--- a/lib/capybara/spec/session/find_spec.rb
+++ b/lib/capybara/spec/session/find_spec.rb
@@ -233,6 +233,14 @@ Capybara::SpecHelper.spec '#find' do
     end.to raise_error(Capybara::ElementNotFound, 'Unable to find xpath "//div[@id=\\"nosuchthing\\"]"')
   end
 
+  context 'without locator' do
+    it 'should not output `nil` in the ElementNotFound message if nothing was found' do
+      expect do
+        @session.find(:label, text: 'no such thing').to be_nil
+      end.to raise_error(Capybara::ElementNotFound, 'Unable to find label')
+    end
+  end
+
   it 'should accept an XPath instance' do
     @session.visit('/form')
     @xpath = Capybara::Selector.new(:fillable_field, config: {}, format: :xpath).call('First Name')

--- a/lib/capybara/spec/session/node_wrapper_spec.rb
+++ b/lib/capybara/spec/session/node_wrapper_spec.rb
@@ -34,6 +34,6 @@ Capybara::SpecHelper.spec '#to_capybara_node' do
     end.to raise_error(/^expected to find css "#second" within #<Capybara::Node::Element/)
     expect do
       expect(para).to have_link(href: %r{/without_simple_html})
-    end.to raise_error(%r{^expected to find link nil with href matching /\\/without_simple_html/ within #<Capybara::Node::Element})
+    end.to raise_error(%r{^expected to find link with href matching /\\/without_simple_html/ within #<Capybara::Node::Element})
   end
 end


### PR DESCRIPTION
While using some custom selectors, I was annoyed by the error description when not using a locator as the message would include "nil" in it which seems a bit off.

For instance:
```
expect(page).to have_list_item(text: 'Admin User', position: 2) }
=> expected to find visible list_item nil with text "Admin User" but there were no matches. Also found [...] which matched the selector but not all filters.
```

This PR removes the `locator.inspect` from the description if `locator` is `nil`.