### PR TITLE
Use the new headless Chrome on the pre-registered driver

### DIFF
--- a/lib/capybara/registrations/drivers.rb
+++ b/lib/capybara/registrations/drivers.rb
@@ -32,7 +32,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   version = Capybara::Selenium::Driver.load_selenium
   options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
   browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    opts.add_argument('--headless')
+    opts.add_argument('--headless=new')
     opts.add_argument('--disable-gpu') if Gem.win_platform?
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.add_argument('--disable-site-isolation-trials')


### PR DESCRIPTION
Earlier this year (2023), Chrome released Chrome for Testing, a new Chrome flavor that targets testing and automation use cases. This flavor has been accessible using the `--headless=new` option since Chrome 109, released on January 1, 2023. This new mode supports the full browser capabilities, including running extensions.

The default headless mode is still pointed to `--headless=old` for now, but it's planned to be changed to `new` over time.

This commit explicitly chooses the `new` headless mode, that uses Chrome for Testing.

Solves #2725