### PR TITLE
Use Addressable::URI.join to merge base_uri and visit_uri

### DIFF
--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -271,7 +271,7 @@ module Capybara
 
           # Useful to people deploying to a subdirectory
           # and/or single page apps where only the url fragment changes
-          visit_uri_parts[:path] = base_uri.path + visit_uri.path
+          visit_uri_parts[:path] = ::Addressable::URI.join(base_uri, visit_uri).path
 
           visit_uri = base_uri.merge(visit_uri_parts)
         end


### PR DESCRIPTION
## Description
If `Capybara.app_host`contains `/` at the end (eg. `http://www.google.com/`) and `visit_uri.path` exists,  `visit_uri_parts[:path]` return the path having `//` and the test fails like below.

```ruby
Capybara.app_host  = "http://localhost.local/"

it 'failed_test' do
    visit "/path"
    # page.current_path returns  '//path' and test fails
    expect(page).to have_current_path '/path'
end

```


So, I use `Addressable::URI.join`.


```ruby
path1 = '/'
path2 = '/path'

Addressable::URI.join(path1, path2).path
# => "/path"
```