### PR TITLE
fix(docs): use new RSpec docsite URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ require 'capybara/rspec'
 
 If you are using Rails, put your Capybara specs in `spec/features` or `spec/system` (only works
 if [you have it configured in
-RSpec](https://relishapp.com/rspec/rspec-rails/v/4-0/docs/directory-structure))
+RSpec](https://rspec.info/features/6-0/rspec-rails/directory-structure/))
 and if you have your Capybara specs in a different directory, then tag the
 example groups with `type: :feature` or `type: :system` depending on which type of test you're writing.
 
-If you are using Rails system specs please see [their documentation](https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec#system-specs-driven-by-selenium-chrome-headless) for selecting the driver you wish to use.
+If you are using Rails system specs please see [their documentation](https://rspec.info/features/6-0/rspec-rails/system-specs/system-specs/#system-specs-driven-by-selenium-chrome-headless) for selecting the driver you wish to use.
 
 If you are not using Rails, tag all the example groups in which you want to use
 Capybara with `type: :feature`.


### PR DESCRIPTION
the old `https://relishapp.com` don't resolve anymore. RSpec documentation has moved to `https://rspec.info`