### PR TITLE
Delegate `Capybara::Result#to_ary`

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,10 @@ Release date: unreleased
 * Dropped support for Ruby 2.7, 3.0+ is now required
 * Dropped support for Selenium < 4.8
 
+### Added
+
+* Add `Capybara::Result#to_ary` to support multiple assignment
+
 # Version 3.39.2
 Release date: 2023-06-10
 

--- a/lib/capybara/result.rb
+++ b/lib/capybara/result.rb
@@ -34,7 +34,7 @@ module Capybara
       @allow_reload = false
     end
 
-    def_delegators :full_results, :size, :length, :last, :values_at, :inspect, :sample
+    def_delegators :full_results, :size, :length, :last, :values_at, :inspect, :sample, :to_ary
 
     alias index find_index
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Capybara::Result do
     result.last.text == 'Delta'
   end
 
+  it 'splats into multiple assignment' do
+    first, *rest, last = result
+
+    expect(first).to have_text 'Alpha'
+    expect(rest.first).to have_text 'Beta'
+    expect(rest.last).to have_text 'Gamma'
+    expect(last).to have_text 'Delta'
+  end
+
   it 'can supports values_at method' do
     expect(result.values_at(0, 2).map(&:text)).to eq(%w[Alpha Gamma])
   end


### PR DESCRIPTION
Delegate to `Capybara::Result#full_results` in order to support Ruby's multiple assignment:

```ruby
node = Capybara.string <<~HTML
  <ul>
    <li>Alpha</li>
    <li>Beta</li>
    <li>Gamma</li>
    <li>Delta</li>
  </ul>
HTML

first, *rest, last = node.all("//li", minimum: 0)

expect(first).to have_text "Alpha"
expect(rest.first).to have_text "Beta"
expect(rest.last).to have_text "Gamma"
expect(last).to have_text "Delta"
```