### PR TITLE
Add `Capybara::Minitest::Assertions#within`

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,10 @@ Release date: unreleased
 * Dropped support for Ruby 2.7, 3.0+ is now required
 * Dropped support for Selenium < 4.8
 
+### Added
+
+* Introduce `Capybara::Scoping` to share `#within` between `Capybara::Session` and `Capybara::Minitest::Assertions`
+
 # Version 3.39.2
 Release date: 2023-06-10
 

--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -2,10 +2,17 @@
 
 require 'minitest'
 require 'capybara/dsl'
+require 'capybara/scoping'
 
 module Capybara
   module Minitest
     module Assertions
+      include Capybara::Scoping
+
+      def root_scope
+        page
+      end
+
       ##
       # Assert text exists
       #
@@ -384,7 +391,7 @@ module Capybara
         when ->(arg) { arg.respond_to?(:to_capybara_node) }
           [args.shift.to_capybara_node, args]
         else
-          [page, args]
+          [current_scope, args]
         end
       end
 

--- a/lib/capybara/scoping.rb
+++ b/lib/capybara/scoping.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Capybara
+  module Scoping
+    ##
+    #
+    # Executes the given block within the context of a node. {#within} takes the
+    # same options as {Capybara::Node::Finders#find #find}, as well as a block. For the duration of the
+    # block, any command to Capybara will be handled as though it were scoped
+    # to the given element.
+    #
+    #     within(:xpath, './/div[@id="delivery-address"]') do
+    #       fill_in('Street', with: '12 Main Street')
+    #     end
+    #
+    # Just as with `#find`, if multiple elements match the selector given to
+    # {#within}, an error will be raised, and just as with `#find`, this
+    # behaviour can be controlled through the `:match` and `:exact` options.
+    #
+    # It is possible to omit the first parameter, in that case, the selector is
+    # assumed to be of the type set in {Capybara.configure default_selector}.
+    #
+    #     within('div#delivery-address') do
+    #       fill_in('Street', with: '12 Main Street')
+    #     end
+    #
+    # @overload within(*find_args)
+    #   @param (see Capybara::Node::Finders#all)
+    #
+    # @overload within(a_node)
+    #   @param [Capybara::Node::Base] a_node   The node in whose scope the block should be evaluated
+    #
+    # @raise  [Capybara::ElementNotFound]      If the scope can't be found before time expires
+    #
+    def within(*args, **kw_args)
+      new_scope = args.first.respond_to?(:to_capybara_node) ? args.first.to_capybara_node : current_scope.find(*args, **kw_args)
+      begin
+        scopes.push(new_scope)
+        yield new_scope if block_given?
+      ensure
+        scopes.pop
+      end
+    end
+    alias_method :within_element, :within
+
+    ##
+    #
+    # Execute the given block within the a specific fieldset given the id or legend of that fieldset.
+    #
+    # @param [String] locator    Id or legend of the fieldset
+    #
+    def within_fieldset(locator, &block)
+      within(:fieldset, locator, &block)
+    end
+
+    ##
+    #
+    # Execute the given block within the a specific table given the id or caption of that table.
+    #
+    # @param [String] locator    Id or caption of the table
+    #
+    def within_table(locator, &block)
+      within(:table, locator, &block)
+    end
+
+    def root_capybara_scope
+      raise NotImplementedError
+    end
+
+    def current_scope
+      scope = scopes.last
+      [nil, :frame].include?(scope) ? root_scope : scope
+    end
+
+  private
+
+    def scopes
+      @scopes ||= [nil]
+    end
+  end
+end

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'capybara/minitest'
 
-class MinitestTest < Minitest::Test
+class MinitestDSLTest < Minitest::Test
   include Capybara::DSL
   include Capybara::Minitest::Assertions
 
@@ -154,6 +154,261 @@ class MinitestTest < Minitest::Test
   end
 end
 
+class MinitestAssertionsTest < Minitest::Test
+  include Capybara::Minitest::Assertions
+
+  attr_reader :page
+
+  def self.test_order
+    :sorted
+  end
+
+  def render(html)
+    @page = Capybara.string(html)
+  end
+
+  def test_assert_text
+    render <<~HTML
+      Form
+    HTML
+
+    assert_text('Form', normalize_ws: false)
+    assert_no_text('Not on the page')
+    refute_text('Also Not on the page')
+  end
+
+  def test_assert_title
+    render <<~HTML
+      <html>
+        <head><title>Test Title</title></head>
+      </html>
+    HTML
+
+    assert_title('Test Title')
+    assert_no_title('Not the title')
+    refute_title('Not the title')
+  end
+
+  def test_assert_xpath
+    render <<~HTML
+      <select id="form_title"></select>
+    HTML
+
+    assert_xpath('.//select[@id="form_title"]')
+    assert_xpath('.//select', count: 1) { |el| el[:id] == 'form_title' }
+    assert_no_xpath('.//select[@id="not_form_title"]')
+    assert_no_xpath('.//select') { |el| el[:id] == 'not_form_title' }
+    refute_xpath('.//select[@id="not_form_title"]')
+  end
+
+  def test_assert_css
+    render <<~HTML
+      <select id="form_title"></select>
+    HTML
+
+    assert_css('select#form_title')
+    assert_no_css('select#not_form_title')
+  end
+
+  def test_assert_selector
+    render <<~HTML
+      <select id="form_title"></select>
+    HTML
+
+    assert_selector(:css, 'select#form_title')
+    assert_selector(:xpath, './/select[@id="form_title"]')
+    assert_no_selector(:css, 'select#not_form_title')
+    assert_no_selector(:xpath, './/select[@id="not_form_title"]')
+    refute_selector(:css, 'select#not_form_title')
+  end
+
+  def test_assert_element
+    render <<~HTML
+      <a href="with_html">A link</a>
+    HTML
+
+    assert_element('a', text: 'A link')
+    assert_element(count: 1) { |el| el.text == 'A link' }
+    assert_no_element(text: 'Not on page')
+  end
+
+  def test_assert_link
+    render <<~HTML
+      <a href="with_html">A link</a>
+    HTML
+
+    assert_link('A link')
+    assert_link(count: 1) { |el| el.text == 'A link' }
+    assert_no_link('Not on page')
+  end
+
+  def test_assert_button
+    render <<~HTML
+      <input type="button" id="fresh_btn">
+    HTML
+
+    assert_button('fresh_btn')
+    assert_button(count: 1) { |el| el[:id] == 'fresh_btn' }
+    assert_no_button('not_btn')
+  end
+
+  def test_assert_field
+    render <<~HTML
+      <input id="customer_email">
+    HTML
+
+    assert_field('customer_email')
+    assert_no_field('not_on_the_form')
+  end
+
+  def test_assert_select
+    render <<~HTML
+      <select id="form_title"></select>
+    HTML
+
+    assert_select('form_title')
+    assert_no_select('not_form_title')
+  end
+
+  def test_assert_checked_field
+    render <<~HTML
+      <input type="checkbox" id="form_pets_dog" checked="checked">
+      <input type="checkbox" id="form_pets_cat">
+    HTML
+
+    assert_checked_field('form_pets_dog')
+    assert_no_checked_field('form_pets_cat')
+    refute_checked_field('form_pets_snake')
+  end
+
+  def test_assert_unchecked_field
+    render <<~HTML
+      <input type="checkbox" id="form_pets_dog" checked="checked">
+      <input type="checkbox" id="form_pets_cat">
+    HTML
+
+    assert_unchecked_field('form_pets_cat')
+    assert_no_unchecked_field('form_pets_dog')
+    refute_unchecked_field('form_pets_snake')
+  end
+
+  def test_assert_table
+    render <<~HTML
+      <table id="agent_table"></table>
+    HTML
+
+    assert_table('agent_table')
+    assert_no_table('not_on_form')
+    refute_table('not_on_form')
+  end
+
+  def test_assert_all_of_selectors
+    render <<~HTML
+      <select id="form_other_title"></select>
+      <input id="form_last_name">
+    HTML
+
+    assert_all_of_selectors(:css, 'select#form_other_title', 'input#form_last_name')
+  end
+
+  def test_assert_none_of_selectors
+    render('')
+
+    assert_none_of_selectors(:css, 'input#not_on_page', 'input#also_not_on_page')
+  end
+
+  def test_assert_any_of_selectors
+    render <<~HTML
+      <select id="form_other_title"></select>
+    HTML
+
+    assert_any_of_selectors(:css, 'input#not_on_page', 'select#form_other_title')
+  end
+
+  def test_assert_matches_selector
+    render <<~HTML
+      <select id="form_title"></select>
+      <input id="customer_email">
+    HTML
+
+    assert_matches_selector(page.find(:field, 'customer_email'), :field, 'customer_email')
+    assert_not_matches_selector(page.find(:select, 'form_title'), :field, 'customer_email')
+    refute_matches_selector(page.find(:select, 'form_title'), :field, 'customer_email')
+  end
+
+  def test_assert_matches_css
+    render <<~HTML
+      <select id="form_title"></select>
+      <select id="form_other_title"></select>
+    HTML
+
+    assert_matches_css(page.find(:select, 'form_title'), 'select#form_title')
+    refute_matches_css(page.find(:select, 'form_title'), 'select#form_other_title')
+  end
+
+  def test_assert_matches_xpath
+    render <<~HTML
+      <select id="form_title"></select>
+      <select id="form_other_title"></select>
+    HTML
+
+    assert_matches_xpath(page.find(:select, 'form_title'), './/select[@id="form_title"]')
+    refute_matches_xpath(page.find(:select, 'form_title'), './/select[@id="form_other_title"]')
+  end
+
+  def test_assert_ancestor
+    render <<~HTML
+      <select id="form_locale">
+        <option>Finnish</option>
+      </select>
+    HTML
+
+    option = page.find(:option, 'Finnish')
+    assert_ancestor(option, :css, '#form_locale')
+  end
+
+  def test_assert_sibling
+    render <<~HTML
+      <select id="form_title">
+        <option class="title">Mrs</option>
+        <option class="title">Mr</option>
+      </select>
+    HTML
+
+    option = page.find(:css, '#form_title').find(:option, 'Mrs')
+    assert_sibling(option, :option, 'Mr')
+  end
+
+  def test_within
+    render <<~HTML
+      <div id="outside">Outside</div>
+      <div id="parent">
+        Inside
+        <div id="child">Child</div>
+        <div id="sibling">Sibling</div>
+      </div>
+    HTML
+
+    within :element, id: 'parent' do
+      assert_text 'Inside'
+      assert_text 'Child'
+      assert_text 'Sibling'
+      assert_no_text 'Outside'
+
+      within :element, id: 'child' do
+        assert_text 'Child'
+        assert_no_text 'Inside'
+        assert_no_text 'Outside'
+        assert_no_text 'Sibling'
+      end
+
+      assert_raises Capybara::ElementNotFound do
+        within :element, id: 'outside'
+      end
+    end
+  end
+end
+
 RSpec.describe 'capybara/minitest' do
   before do
     Capybara.current_driver = :rack_test
@@ -164,12 +419,21 @@ RSpec.describe 'capybara/minitest' do
     Capybara.use_default_driver
   end
 
-  it 'should support minitest' do
+  it 'should support minitest with DSL' do
     output = StringIO.new
     reporter = Minitest::SummaryReporter.new(output)
     reporter.start
-    MinitestTest.run reporter, {}
+    MinitestDSLTest.run reporter, {}
     reporter.report
     expect(output.string).to include('23 runs, 56 assertions, 0 failures, 0 errors, 1 skips')
+  end
+
+  it 'should support minitest with assertions' do
+    output = StringIO.new
+    reporter = Minitest::SummaryReporter.new(output)
+    reporter.start
+    MinitestAssertionsTest.run reporter, {}
+    reporter.report
+    expect(output.string).to include('22 runs, 61 assertions, 0 failures, 0 errors, 0 skips')
   end
 end


### PR DESCRIPTION
Introduce support for `#within` inside the
`Capybara::Minitest::Assertions` module.

This method brings support for scoping assertions when included in tests
without `Capybara::DSL` and outside of a `Capybara.current_session`
context.

```ruby
class MinitestAssertionsTest < Minitest::Test
  include Capybara::Minitest::Assertions

  attr_reader :page

  def test_within
    @page = Capybara.string <<~HTML
      <div id="outside">Outside</div>
      <div id="parent">
        Inside
        <div id="child">Child</div>
        <div id="sibling">Sibling</div>
      </div>
    HTML

    within :element, id: "parent" do
      assert_text "Inside"
      assert_text "Child"
      assert_text "Sibling"
      assert_no_text "Outside"

      within :element, id: "child" do
        assert_text "Child"
        assert_no_text "Inside"
        assert_no_text "Outside"
        assert_no_text "Sibling"
      end

      assert_raises Capybara::ElementNotFound do
        within :element, id: "outside"
      end
    end
  end
end
```

