### PR TITLE
Update Rack::Test::Driver#submit signature

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -50,8 +50,8 @@ class Capybara::RackTest::Driver < Capybara::Driver::Base
     browser.refresh
   end
 
-  def submit(method, path, attributes)
-    browser.submit(method, path, attributes)
+  def submit(method, path, attributes, content_type: nil)
+    browser.submit(method, path, attributes, content_type: content_type)
   end
 
   def follow(method, path, **attributes)


### PR DESCRIPTION
This gets called from https://github.com/teamcapybara/capybara/blob/52eaecea6d154b7d664b0032cd1cbcad4788fe65/lib/capybara/rack_test/form.rb#L57C43-L57C43 with the extra argument.

It produces an error like this:

```
ArgumentError:
  wrong number of arguments (given 4, expected 3)
# ./vendor/bundle/ruby/3.3.0/gems/capybara-3.39.2/lib/capybara/rack_test/driver.rb:53:in `submit'
# ./vendor/bundle/ruby/3.3.0/gems/capybara-3.39.2/lib/capybara/rack_test/form.rb:57:in `submit'
```

This seems to have been an oversight as part of this change https://github.com/teamcapybara/capybara/commit/a3ff5514f40f3af0ec6655354d3596f6d9ea8964