### PR TITLE
Support `:table_row` without locator argument

### DIFF
--- a/lib/capybara/selector/definition/table_row.rb
+++ b/lib/capybara/selector/definition/table_row.rb
@@ -11,11 +11,13 @@ Capybara.add_selector(:table_row, locator_type: [Array, Hash]) do
         ]
         xp.where(cell_xp)
       end
-    else
+    elsif locator.is_a? Array
       initial_td = XPath.descendant(:td)[XPath.string.n.is(locator.shift)]
       tds = locator.reverse.map { |cell| XPath.following_sibling(:td)[XPath.string.n.is(cell)] }
                    .reduce { |xp, cell| cell.where(xp) }
       xpath[initial_td[tds]]
+    else
+      xpath
     end
   end
 end

--- a/lib/capybara/spec/session/has_table_spec.rb
+++ b/lib/capybara/spec/session/has_table_spec.rb
@@ -131,6 +131,13 @@ Capybara::SpecHelper.spec '#has_table?' do
     expect(@session.find(:table, 'Horizontal Headers')).not_to have_selector(:table_row, %w[Walpole Thomas])
     expect(@session.find(:table, 'Horizontal Headers')).not_to have_selector(:table_row, %w[Other])
   end
+
+  it 'should find row by all rows without locator values' do
+    table = @session.find(:table, 'Horizontal Headers')
+
+    expect(table).to have_selector(:table_row)
+    expect(table).to have_selector(:table_row, count: 6)
+  end
 end
 
 Capybara::SpecHelper.spec '#has_no_table?' do


### PR DESCRIPTION
The `:table_row` selector supports both `Hash` and `Array` arguments. Many other selectors support omitting the `locator` argument, so this commit adds support for omitting the `locator` from `:table_row`.

This can be useful when grabbing all rows and making assertions about sort order:

```ruby
table = find :table, "My Table"

header, first, second, third = table.all :table_row

header.assert_text "Header"
first.assert_text "First row"
second.assert_text "Second row"
third.assert_text "Third row"
```