### PR TITLE
Remove a has_element example with wrong usage.

### DIFF
--- a/lib/capybara/spec/session/has_element_spec.rb
+++ b/lib/capybara/spec/session/has_element_spec.rb
@@ -8,7 +8,6 @@ Capybara::SpecHelper.spec '#has_element?' do
   it 'should be true if the given element is on the page' do
     expect(@session).to have_element('a', id: 'foo')
     expect(@session).to have_element('a', text: 'A link', href: '/with_simple_html')
-    expect(@session).to have_element('a', text: :'A link', href: :'/with_simple_html')
     expect(@session).to have_element('a', text: 'A link', href: %r{/with_simple_html})
     expect(@session).to have_element('a', text: 'labore', target: '_self')
   end


### PR DESCRIPTION
https://github.com/teamcapybara/capybara/pull/2700 introduced a useful matcher.
However its spec have a wrong usage

```
expect(@session).to have_element('a', text: :'A link', href: :'/with_simple_html')
```

It generates a XPath query `(.//*[(local-name(.) = 'a')][(./@href = '/with_simple_html')])[]`.
**It doesn't have `text: A link` condition since `Capybara::Queries::SelectorQuery` assumes the text option to be a String or a Regexp**.

So I just removed the line because no other specs have `text: :xxx` (Symbol).