### PR TITLE
Consistently support passing a symbol as a test_id

### DIFF
--- a/lib/capybara/selector/definition/frame.rb
+++ b/lib/capybara/selector/definition/frame.rb
@@ -5,7 +5,7 @@ Capybara.add_selector(:frame, locator_type: [String, Symbol]) do
     xpath = XPath.descendant(:iframe).union(XPath.descendant(:frame))
     unless locator.nil?
       locator_matchers = (XPath.attr(:id) == locator.to_s) | (XPath.attr(:name) == locator.to_s)
-      locator_matchers |= XPath.attr(test_id) == locator if test_id
+      locator_matchers |= XPath.attr(test_id) == locator.to_s if test_id
       xpath = xpath[locator_matchers]
     end
     xpath[find_by_attr(:name, name)]

--- a/lib/capybara/selector/definition/label.rb
+++ b/lib/capybara/selector/definition/label.rb
@@ -6,7 +6,7 @@ Capybara.add_selector(:label, locator_type: [String, Symbol]) do
     xpath = XPath.descendant(:label)
     unless locator.nil?
       locator_matchers = XPath.string.n.is(locator.to_s) | (XPath.attr(:id) == locator.to_s)
-      locator_matchers |= XPath.attr(test_id) == locator if test_id
+      locator_matchers |= XPath.attr(test_id) == locator.to_s if test_id
       xpath = xpath[locator_matchers]
     end
     if options.key?(:for)

--- a/lib/capybara/selector/definition/table.rb
+++ b/lib/capybara/selector/definition/table.rb
@@ -5,7 +5,7 @@ Capybara.add_selector(:table, locator_type: [String, Symbol]) do
     xpath = XPath.descendant(:table)
     unless locator.nil?
       locator_matchers = (XPath.attr(:id) == locator.to_s) | XPath.descendant(:caption).is(locator.to_s)
-      locator_matchers |= XPath.attr(test_id) == locator if test_id
+      locator_matchers |= XPath.attr(test_id) == locator.to_s if test_id
       xpath = xpath[locator_matchers]
     end
     xpath = xpath[XPath.descendant(:caption) == caption] if caption


### PR DESCRIPTION
I found a few places where passing a symbol as a test ID doesn't work as expected. All of the other selector types support symbols as for test ID selectors.