### PR TITLE
RackTest nodes should not submit when disabled

### DIFF
--- a/lib/capybara/rack_test/node.rb
+++ b/lib/capybara/rack_test/node.rb
@@ -271,6 +271,7 @@ private
   end
 
   def submits?
+    return false if disabled?
     (tag_name == 'input' && %w[submit image].include?(type)) || (tag_name == 'button' && [nil, 'submit'].include?(type))
   end
 

--- a/lib/capybara/spec/views/form.erb
+++ b/lib/capybara/spec/views/form.erb
@@ -474,7 +474,6 @@ New line after and before textarea tag
       role=button within label element
       <span role="button">with other text</span>
     </label>
-    <input type="button" disabled="disabled" value="Disabled button"/>
     <span role="button">ARIA button</span>
   </p>
 
@@ -742,3 +741,7 @@ New line after and before textarea tag
     <div>Visual representation of the checkbox</div>
   </div>
 </label>
+
+<form action="/other_form" method="post">
+  <input type="submit" disabled="disabled" value="Disabled button"/>
+</form>

--- a/spec/rack_test_spec.rb
+++ b/spec/rack_test_spec.rb
@@ -149,6 +149,12 @@ RSpec.describe Capybara::Session do # rubocop:disable RSpec/MultipleDescribes
           expect(session).not_to have_current_path(/foo|bar/)
         end
       end
+
+      it 'does not click disabled inputs or buttons' do
+        session.visit('/form')
+        session.find(:css, 'input[value="Disabled button"]').click
+        expect(session).to have_current_path('/form')
+      end
     end
 
     describe '#send_keys' do


### PR DESCRIPTION
Ensures forms are not submitted in RackTest when the submit button or input is disabled.