### PR TITLE
Fix a rubocop offense for `Style/SuperArguments` cop

### DIFF
--- a/lib/capybara/rspec/matchers/match_style.rb
+++ b/lib/capybara/rspec/matchers/match_style.rb
@@ -8,7 +8,7 @@ module Capybara
       class MatchStyle < WrappedElementMatcher
         def initialize(styles = nil, **kw_args, &filter_block)
           styles, kw_args = kw_args, {} if styles.nil?
-          super(styles, **kw_args, &filter_block)
+          super
         end
 
         def element_matches?(el)


### PR DESCRIPTION
```
❯ bundle exec rubocop
Inspecting 258 files
............................................................C.....................................................................................................................................................................................................

Offenses:

lib/capybara/rspec/matchers/match_style.rb:11:11: C: [Correctable] Style/SuperArguments: Call super without arguments and parentheses when the signature is identical.
          super(styles, **kw_args, &filter_block)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

258 files inspected, 1 offense detected, 1 offense autocorrectable
```