### PR TITLE
Disable the Chrome search engine selector by default

### DIFF
--- a/lib/capybara/registrations/drivers.rb
+++ b/lib/capybara/registrations/drivers.rb
@@ -23,6 +23,7 @@ Capybara.register_driver :selenium_chrome do |app|
   browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.add_argument('--disable-site-isolation-trials')
+    opts.add_argument('--disable-search-engine-choice-screen')
   end
 
   Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
@@ -36,6 +37,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument('--disable-gpu') if Gem.win_platform?
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.add_argument('--disable-site-isolation-trials')
+    opts.add_argument('--disable-search-engine-choice-screen')
   end
 
   Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })


### PR DESCRIPTION
In recent versions of Chrome, a search engine selection modal is shown when first opening the browser, which causes specs to fail  with errors like this:

    Selenium::WebDriver::Error::UnknownError:
            unknown error: failed to close window in 20 seconds
              (Session info: chrome=128.0.6613.36)

Presumably this is because the spec is trying to interact with the browser but can't get past the selection screen.

This seems to be a common issue:

- https://stackoverflow.com/questions/78831994/how-to-skip-choose-search-engine-with-capybara-selenium-chrome
- https://www.reddit.com/r/learnpython/comments/1eoapcb/selenium_dosent_find_google_search_engine_option/

Adding this option appears to fix it, but I've only tested by defining my own driver locally with this argument - not sure how I'd write a spec for this driver definition?

Also I'm not sure if this option is defined for older versions of Chrome (or is it chromedriver?) - would this result in errors when using a version where this option isn't supported?