### PR TITLE
Install RSpecMatcherProxies via Object#extend as well

### DIFF
--- a/lib/capybara/rspec/matcher_proxies.rb
+++ b/lib/capybara/rspec/matcher_proxies.rb
@@ -52,6 +52,11 @@ else
         base.include(::Capybara::RSpecMatcherProxies) if defined?(::RSpec::Matchers) && base.include?(::RSpec::Matchers)
         super
       end
+
+      def extended(base)
+        base.extend(::Capybara::RSpecMatcherProxies) if defined?(::RSpec::Matchers) && base.is_a?(::RSpec::Matchers)
+        super
+      end
     end
 
     def self.prepended(base)


### PR DESCRIPTION
Here's a fix for the Capybara vs. Cucumber vs. Aruba's `all` method conflict problem described in #2761

Cucumber's implementation is that it creates a world by mixing-in various modules on top of an anonymous module:
https://github.com/cucumber/cucumber-ruby/blob/v9.2.0/lib/cucumber/glue/proto_world.rb#L176

and Capybara::DSL is mixed-in in this process via `Object#extend`. Not `Module#include` nor `Module#prepend`.

Thus, our DSLRSpecProxyInstaller module has to stand by for `self.extended` hook in addition to currently implemented ones.

I confirmed that this patch fixes @PragTob's reproduction case in https://github.com/PragTob/all_conflict

fixes #2761