### PR TITLE
Remove calls to WebStorage JS methods, fixes #2772

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -353,29 +353,21 @@ private
   end
 
   def clear_session_storage
-    if false # && @browser.respond_to? :session_storage
-      @browser.session_storage.clear
-    else
-      begin
-        @browser&.execute_script('window.sessionStorage.clear()')
-      rescue # rubocop:disable Style/RescueStandardError
-        unless options[:clear_session_storage].nil?
-          warn 'sessionStorage clear requested but is not supported by this driver'
-        end
+    begin
+      @browser&.execute_script('window.sessionStorage.clear()')
+    rescue # rubocop:disable Style/RescueStandardError
+      unless options[:clear_session_storage].nil?
+        warn 'sessionStorage clear requested but is not supported by this driver'
       end
     end
   end
 
   def clear_local_storage
-    if false # && @browser.respond_to? :local_storage
-      @browser.local_storage.clear
-    else
-      begin
-        @browser&.execute_script('window.localStorage.clear()')
-      rescue # rubocop:disable Style/RescueStandardError
-        unless options[:clear_local_storage].nil?
-          warn 'localStorage clear requested but is not supported by this driver'
-        end
+    begin
+      @browser&.execute_script('window.localStorage.clear()')
+    rescue # rubocop:disable Style/RescueStandardError
+      unless options[:clear_local_storage].nil?
+        warn 'localStorage clear requested but is not supported by this driver'
       end
     end
   end

--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -353,7 +353,7 @@ private
   end
 
   def clear_session_storage
-    if @browser.respond_to? :session_storage
+    if false # && @browser.respond_to? :session_storage
       @browser.session_storage.clear
     else
       begin
@@ -367,7 +367,7 @@ private
   end
 
   def clear_local_storage
-    if @browser.respond_to? :local_storage
+    if false # && @browser.respond_to? :local_storage
       @browser.local_storage.clear
     else
       begin


### PR DESCRIPTION
Removed calls to deprecated methods. See

https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES

4.24.0 (2024-08-23)
=========================
* Deprecate WebStorage JS methods (#14276)

https://github.com/SeleniumHQ/selenium/pull/14276

https://github.com/SeleniumHQ/selenium/pull/14276/commits/fc6c070e713b02c8488850a0b7ae1d382a6275a6


