### PR TITLE
Skip chrome search engine selection popup

### DIFF
--- a/lib/capybara/registrations/drivers.rb
+++ b/lib/capybara/registrations/drivers.rb
@@ -23,6 +23,8 @@ Capybara.register_driver :selenium_chrome do |app|
   browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.add_argument('--disable-site-isolation-trials')
+    # https://makandracards.com/makandra/621797-chrome-disable-choose-search-engine-popup-tests
+    opts.add_argument('--disable-search-engine-choice-screen')
   end
 
   Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })
@@ -36,6 +38,8 @@ Capybara.register_driver :selenium_chrome_headless do |app|
     opts.add_argument('--disable-gpu') if Gem.win_platform?
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.add_argument('--disable-site-isolation-trials')
+    # https://makandracards.com/makandra/621797-chrome-disable-choose-search-engine-popup-tests
+    opts.add_argument('--disable-search-engine-choice-screen')
   end
 
   Capybara::Selenium::Driver.new(app, **{ :browser => :chrome, options_key => browser_options })


### PR DESCRIPTION
Fix the search engine selection popup. More info:
https://makandracards.com/makandra/621797-chrome-disable-choose-search-engine-popup-tests
![image](https://github.com/user-attachments/assets/14fd2596-f888-4e24-a35f-1804fd92ce48)
