### PR TITLE
Address `warning: URI::RFC3986_PARSER.make_regexp is obsoleted.` warning

### DIFF
--- a/lib/capybara/session/config.rb
+++ b/lib/capybara/session/config.rb
@@ -12,6 +12,9 @@ module Capybara
 
     attr_accessor(*OPTIONS)
 
+    URI_PARSER = defined?(::URI::RFC2396_PARSER) ? ::URI::RFC2396_PARSER : ::URI::DEFAULT_PARSER
+    private_constant :URI_PARSER
+
     ##
     # @!method always_include_port
     #   See {Capybara.configure}
@@ -83,7 +86,7 @@ module Capybara
 
     remove_method :app_host=
     def app_host=(url)
-      unless url.nil? || url.match?(URI::DEFAULT_PARSER.make_regexp)
+      unless url.nil? || url.match?(URI_PARSER.make_regexp)
         raise ArgumentError, "Capybara.app_host should be set to a url (http://www.example.com). Attempted to set #{url.inspect}."
       end
 
@@ -92,7 +95,7 @@ module Capybara
 
     remove_method :default_host=
     def default_host=(url)
-      unless url.nil? || url.match?(URI::DEFAULT_PARSER.make_regexp)
+      unless url.nil? || url.match?(URI_PARSER.make_regexp)
         raise ArgumentError, "Capybara.default_host should be set to a url (http://www.example.com). Attempted to set #{url.inspect}."
       end
 


### PR DESCRIPTION
This commit addresses `warning: URI::RFC3986_PARSER.make_regexp is obsoleted. Use URI::RFC2396_PARSER.make_regexp explicitly.` warning

Ruby 3.4 changes URI::DEFAULT_PARSER to URI::RFC3986_Parser and deprecates URI::RFC3986_PARSER.make_regexp.

This commit uses `URI::RFC2396_PARSER` only if it is available for these versions:

- `uri` v0.12.2 for Ruby 3.2/3.1
- `uri` v0.13.1 for Ruby 3.3
- Ruby 3.4.0dev

Fix #2778
Refer https://bugs.ruby-lang.org/issues/19266