### PR TITLE
Add Capybara.touched_session_names method to retrieve used session names

### DIFF
--- a/lib/capybara.rb
+++ b/lib/capybara.rb
@@ -314,7 +314,7 @@ module Capybara
     # @return [Capybara::Session]     The currently used session
     #
     def current_session
-      specified_session || session_pool["#{current_driver}:#{session_name}:#{app.object_id}"]
+      specified_session || session_pool[build_session_key(session_name)]
     end
 
     ##
@@ -407,6 +407,19 @@ module Capybara
       end
     end
 
+    ##
+    #
+    # Returns a list of session names that have been actively used.
+    #
+    # @return [Array<Symbol>] A list of session names
+    #
+    def touched_session_names
+      session_pool.keys.filter_map do |key|
+        session_name = key.split(':')[1].to_sym
+        session_name if key == build_session_key(session_name) && session_pool[key].touched?
+      end
+    end
+
     def session_options
       config.session_options
     end
@@ -415,6 +428,10 @@ module Capybara
 
     def config
       @config ||= Capybara::Config.new
+    end
+
+    def build_session_key(session_name)
+      "#{current_driver}:#{session_name}:#{app.object_id}"
     end
 
     def session_pool

--- a/lib/capybara/session.rb
+++ b/lib/capybara/session.rb
@@ -111,6 +111,17 @@ module Capybara
 
     ##
     #
+    # Returns true if the current session has been touched, indicating it has been actively used.
+    # This returns true after a `visit` action and false after `quit` or `reset!`.
+    #
+    # @return [Boolean] true if the session has been used, false otherwise
+    #
+    def touched?
+      @touched
+    end
+
+    ##
+    #
     # Reset the session (i.e. remove cookies and navigate to blank page).
     #
     # This method does not:

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -257,6 +257,34 @@ RSpec.describe Capybara::DSL do
     end
   end
 
+  describe '#touched_session_names' do
+    before do
+      Capybara.send(:session_pool).clear
+    end
+
+    it 'returns available session names' do
+      Capybara.current_session.visit '/'
+      expect(Capybara.touched_session_names).to contain_exactly(:default)
+
+      Capybara.using_session(:administrator) do
+        Capybara.current_session.visit '/'
+      end
+      expect(Capybara.touched_session_names).to contain_exactly(:default, :administrator)
+    end
+
+    it "doesn't return unmatched app session names" do
+      old_app = Capybara.app
+
+      Capybara.current_session.visit '/'
+      expect(Capybara.touched_session_names).to contain_exactly(:default)
+
+      Capybara.app = Class.new(old_app)
+      expect(Capybara.touched_session_names).to be_empty
+    ensure
+      Capybara.app = old_app
+    end
+  end
+
   describe '#session_name' do
     it 'should default to :default' do
       expect(Capybara.session_name).to eq(:default)

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe Capybara::Session do
     end
   end
 
+  describe '#touched?' do
+    it 'returns state of modified session' do
+      session = described_class.new(:rack_test, TestApp)
+      expect(session.touched?).to eq(false)
+
+      session.visit '/'
+      expect(session.touched?).to eq(true)
+
+      session.reset!
+      expect(session.touched?).to eq(false)
+    end
+  end
+
   context 'current_driver' do
     around do |example|
       orig_driver = Capybara.current_driver


### PR DESCRIPTION
This method returns the names of all currently active sessions that have been used with `using_session`. Its primary purpose is to call `save_screenshot` for multiple sessions when a test fails.

Previously, it was difficult to retrieve session names during tests. With this addition, developers can now easily obtain all session names and save screenshots for each active session, enhancing debugging capabilities in multi-session test scenarios.

## Additional Information

For example, in Rails, the `take_failed_screenshot` method captures a screenshot when a test fails. https://github.com/rails/rails/blob/e6429269fd5a8a7d728557f4e7d7f82c0ad1478c/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L53-L58

Currently, this method only captures screenshots from the default session. However, when using multiple sessions with `using_session`, I would like to save screenshots for each active session. In Capybara’s current implementation, tracking the session names created with `using_session` is difficult, and the only workaround has been to override the method to achieve this functionality.