### PR TITLE
`rackup` removed its dependency on webrick

### DIFF
--- a/capybara.gemspec
+++ b/capybara.gemspec
@@ -61,6 +61,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('selenium-webdriver', ['~>4.8'])
   s.add_development_dependency('sinatra', ['>= 1.4.0'])
   s.add_development_dependency('uglifier')
+  s.add_development_dependency('webrick')
   s.add_development_dependency('yard', ['>= 0.9.0'])
 
   if RUBY_ENGINE == 'rbx'


### PR DESCRIPTION
Show a error message telling the user what they must do to solve this problem.

```rb
require 'capybara'
Capybara.server = :webrick

app = proc { |_env| [200, {}, ['Hello Server!']] }
server = Capybara::Server.new(app)
server.boot
```

```
/home/user/code/capybara/lib/capybara/server.rb:77: warning: webrick was loaded from the standard library, but is not part of the default gems starting from Ruby 3.0.0.
You can add webrick to your Gemfile or gemspec to silence this warning.
#<Thread:0x00007f3b6bca31d8 /home/user/code/capybara/lib/capybara/server.rb:76 run> terminated with exception (report_on_exception is true):
/home/user/.rbenv/versions/3.3.6/lib/ruby/3.3.0/bundled_gems.rb:69:in `require': cannot load such file -- webrick (LoadError)
```

After:
```
#<Thread:0x00007fa56bb52fa8 /home/user/code/capybara/lib/capybara/server.rb:76 run> terminated with exception (report_on_exception is true):
/home/user/code/capybara/lib/capybara/registrations/servers.rb:21:in `rescue in rescue in block in <top (required)>': Capybara is unable to load `webrick` for its server, please add `webrick` to your project or specify a different server. (LoadError)
```

Ref: https://github.com/rack/rackup/pull/23