### PR TITLE
Capybara.disable_animation also disables view transitions

### DIFF
--- a/lib/capybara/server/animation_disabler.rb
+++ b/lib/capybara/server/animation_disabler.rb
@@ -62,7 +62,7 @@ module Capybara
       end
 
       DISABLE_CSS_MARKUP_TEMPLATE = <<~CSS
-        %<selector>s, %<selector>s::before, %<selector>s::after {
+        %<selector>s, %<selector>s::before, %<selector>s::after, ::view-transition-group(*) {
            transition: none !important;
            animation-duration: 0s !important;
            animation-delay: 0s !important;

--- a/lib/capybara/spec/views/with_view_transition.erb
+++ b/lib/capybara/spec/views/with_view_transition.erb
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title>with_view_transition</title>
+    <script src="/jquery.js" type="text/javascript" charset="utf-8"></script>
+    <script language="javascript" type="text/javascript">
+      $(document).ready(function(){
+        const input = $("#button");
+        const message = $("#message");
+        input.hide();
+        message.hide();
+
+        $("#root").click(function(event){
+          document.startViewTransition(() => {
+            input.show();
+          });
+        });
+
+        input.click(function(event){
+          message.show();
+        });
+      });
+    </script>
+    <style>
+        ::view-transition-group(root) {
+            animation-duration: 5s;
+        }
+
+        @keyframes slide-in-from-right {
+            from {
+                transform: translateX(1000%);
+            }
+        }
+    </style>
+  </head>
+
+  <body id="with_view_transition">
+  <a id="root" href='#'>click me to show a form input</a>
+  <button id="button">Click me</button>
+  <span id="message">Button clicked</span>
+  </body>
+</html>

--- a/spec/shared_selenium_session.rb
+++ b/spec/shared_selenium_session.rb
@@ -383,6 +383,17 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
           @animation_session = Capybara::Session.new(session.mode, TestApp.new)
         end
 
+        it 'should disable view transitions' do
+          @animation_session.visit('with_view_transition')
+          sleep 1
+          @animation_session.click_link('click me to show a form input')
+
+          expect do
+            @animation_session.click_button("button")
+          end.not_to raise_error
+          expect(@animation_session).to have_content("Button clicked")
+        end
+
         it 'should add CSS to the <head> element' do
           @animation_session.visit('with_animation')
 
@@ -478,6 +489,17 @@ RSpec.shared_examples 'Capybara::Session' do |session, mode|
           sleep 1
           @animation_session_with_matching_css.click_link('animate me away')
           expect(@animation_session_with_matching_css).to have_no_link('animate me away', wait: 0.5)
+        end
+
+        it 'should disable view transitions' do
+          @animation_session_with_matching_css.visit('with_view_transition')
+          sleep 1
+          @animation_session_with_matching_css.click_link('click me to show a form input')
+
+          expect do
+            @animation_session_with_matching_css.click_button("button")
+          end.not_to raise_error
+          expect(@animation_session_with_matching_css).to have_content("Button clicked")
         end
       end
 


### PR DESCRIPTION
## Problem

Animations provided by the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) are not disabled when `Capybara.disable_animations` is set. This can lead to Capybara not being able to interact with certain elements before a view transition has completed.

For a personal project, this manifested as an `input` which could not be clicked until the transition completed, even though the page content could be ready.

## Potential Solution

I wanted to see what it would look like to do the simplest thing possible with `Capybara::Server::AnimationDisabler` to cover view transitions. While this works, it does betray the "selector" feature of `disable_animations`, as this behaves the same way even if a selector is supplied as if it were set to `true`.

As I understand it, the View Transition API's CSS pseudo-selectors do not allow animation characteristics (such as `animation-duration`) to be changed for individual elements in the normal DOM tree. Instead, they are controlled via named view transitions and pseudo-selectors that exist in their own tree. Transition names also cannot be applied to more than one element, so using a broad selector to assign dummy transition names would likely cause bugs. 

I'm curious what others think about this. I didn't want to add a lot of complexity to this API without getting some early feedback. But a couple of possibilities I'd considered:

1. Provide a new config option and extend the `AnimationDisabler` middleware to support it
2. Provide a new config option and add a new middleware which behaves similarly to `AnimationDisabler`

I may also be mistaken about not being able to use existing selector-driven approach. If this could be made to work, then that would simplify this problem quite a bit.
