### PR TITLE
Ensure puma config load process is respected

### DIFF
--- a/lib/capybara/registrations/servers.rb
+++ b/lib/capybara/registrations/servers.rb
@@ -38,9 +38,11 @@ Capybara.register_server :puma do |app, port, host, **options| # rubocop:disable
   # Therefore construct and run the Server instance ourselves.
   # puma_rack_handler.run(app, { Host: host, Port: port, Threads: "0:4", workers: 0, daemon: false }.merge(options))
   default_options = { Host: host, Port: port, Threads: '0:4', workers: 0, daemon: false }
-  options = default_options.merge(options)
+  override_options = { config_files: ['-'] }
+  options = default_options.merge(options).merge(override_options)
 
   conf = puma_rack_handler.config(app, options)
+  conf.load
   conf.clamp
 
   puma_ver = Gem::Version.new(Puma::Const::PUMA_VERSION)


### PR DESCRIPTION
Ref: https://github.com/puma/puma/pull/3616

In v7, puma will be validating that its config objects are both loaded (loads config files) and clamped (resolves config procs and finalizes defaults) before its options are accessed to begin the launch process. This will be a breaking change for users utilising capybara as it builds its own puma config, but only clamps it. This change ensures a future version of capybara can be compatible with puma v7, while also being backward compatible with previous versions.

**Note:** The side effect of this change is that options specified in users' puma config files that are not specified in capybara's [user options](https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/servers.rb#L40-L41) will be [taken into account](https://github.com/puma/puma/blob/ca201ef69757f8830b636251b0af7a51270eb68a/lib/puma/server.rb#L87-L100) when capybara boots its server. ~A workaround would be to only pass in the user options hash [here](https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/servers.rb#L61) (`conf.options.user_options`) so only those options will be picked up by puma and [merged with its default options](https://github.com/puma/puma/blob/ca201ef69757f8830b636251b0af7a51270eb68a/lib/puma/server.rb#L84). Let me know what you think.~ See https://github.com/teamcapybara/capybara/pull/2794#issuecomment-2661172136.