### PR TITLE
Handle chromedriver sending devtools window as a distinct window handle

### DIFF
--- a/lib/capybara/selenium/driver.rb
+++ b/lib/capybara/selenium/driver.rb
@@ -233,7 +233,7 @@ class Capybara::Selenium::Driver < Capybara::Driver::Base
   end
 
   def close_window(handle)
-    raise ArgumentError, 'Not allowed to close the primary window' if handle == window_handles.first
+    raise ArgumentError, 'Not allowed to close the primary window' if handle == browser.window_handle
 
     within_given_window(handle) do
       browser.close

--- a/lib/capybara/selenium/driver_specializations/chrome_driver.rb
+++ b/lib/capybara/selenium/driver_specializations/chrome_driver.rb
@@ -37,8 +37,9 @@ module Capybara::Selenium::Driver::ChromeDriver
     # Use instance variable directly so we avoid starting the browser just to reset the session
     return unless @browser
 
-    switch_to_window(window_handles.first)
-    window_handles.slice(1..).each { |win| close_window(win) }
+    handle = browser.window_handle # Only fetch window handle once
+    switch_to_window(handle) # Should already be there, but ensure everything agrees
+    (window_handles - [handle]).each { |win| close_window(win) } # Close every window handle but the current one.
     return super if chromedriver_version < 73
 
     timer = Capybara::Helpers.timer(expire_in: 10)


### PR DESCRIPTION
Fixes https://github.com/teamcapybara/capybara/issues/2793

Chromedriver no longer always sends the current window handle as the first item in the `get_window_handles` response, so you need to check `window_handle` if you want to figure out which one is current.