### PR TITLE
Experiment with slow resources

### DIFF
--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -31,6 +31,10 @@ class TestApp < Sinatra::Base
     'Another World'
   end
 
+  get '/slow_resources' do
+    '<img src="https://httpstat.us/504?sleep=100000" />'
+  end
+
   get '/redirect' do
     redirect '/redirect_again'
   end

--- a/spec/selenium_spec_chrome.rb
+++ b/spec/selenium_spec_chrome.rb
@@ -149,6 +149,12 @@ RSpec.describe 'Capybara::Session with chrome' do
     it 'sets the http client read timeout' do
       expect(TestSessions::Chrome.driver.browser.send(:bridge).http.read_timeout).to eq 30
     end
+
+    it 'does NOT block on slow resources' do
+      expect {
+        TestSessions::Chrome.visit('/slow_resources')
+      }.to raise_error(Net::ReadTimeout)
+    end
   end
 
   describe 'filling in Chrome-specific date and time fields with keystrokes' do

--- a/spec/selenium_spec_firefox.rb
+++ b/spec/selenium_spec_firefox.rb
@@ -206,6 +206,12 @@ RSpec.describe Capybara::Selenium::Driver do
     it 'sets the http client read timeout' do
       expect(TestSessions::SeleniumFirefox.driver.browser.send(:bridge).http.read_timeout).to eq 31
     end
+
+    it 'does NOT block on slow resources' do
+      expect {
+        TestSessions::SeleniumFirefox.visit('/slow_resources')
+      }.to raise_error(Net::ReadTimeout)
+    end
   end
 end
 

--- a/spec/selenium_spec_safari.rb
+++ b/spec/selenium_spec_safari.rb
@@ -128,6 +128,12 @@ RSpec.describe 'Capybara::Session with safari' do
     it 'sets the http client read timeout' do
       expect(TestSessions::Safari.driver.browser.send(:bridge).http.read_timeout).to eq 30
     end
+
+    it 'does NOT block on slow resources' do
+      expect {
+        TestSessions::Safari.visit('/slow_resources')
+      }.to raise_error(Net::ReadTimeout)
+    end
   end
 
   describe 'filling in Safari-specific date and time fields with keystrokes' do


### PR DESCRIPTION
There were problems with images on a website not loading in time. Debugging was difficult and I asked myself how to improve Capybara in that regard. While playing around I found that Capybara can be completely blocked by slow resources. So I implemented these failing tests which I would like to further develop:

* Are these tests at the right place?
* Can I configure a lower timeout just for one single example?
* Is it worth to simulate slow resources in the `test_app` rather than calling httpstat.us?