### PR TITLE
Remove unused `cgi` require for Ruby 3.5

### DIFF
--- a/lib/capybara/rack_test/driver.rb
+++ b/lib/capybara/rack_test/driver.rb
@@ -4,7 +4,6 @@ require 'rack/test'
 require 'rack/utils'
 require 'mini_mime'
 require 'nokogiri'
-require 'cgi'
 
 class Capybara::RackTest::Driver < Capybara::Driver::Base
   DEFAULT_OPTIONS = {


### PR DESCRIPTION
On Ruby 3.5, requiring `cgi` will emit a warning. `capybara` uses nothing from it, so just remove it.

https://bugs.ruby-lang.org/issues/21258