### PR TITLE
Disable `Rack::Protection::HostAuthorization`

### DIFF
--- a/lib/capybara/spec/test_app.rb
+++ b/lib/capybara/spec/test_app.rb
@@ -19,6 +19,7 @@ class TestApp < Sinatra::Base
   set :static, true
   set :raise_errors, true
   set :show_exceptions, false
+  set :host_authorization, { permitted_hosts: [] }
 
   # Also check lib/capybara/spec/views/*.erb for pages not listed here
 


### PR DESCRIPTION
Rack::Protection 4.1.0 has introduced new `Rack::Protection::HostAuthorization` [[1]]. This makes `www.example.com` host to be rejected. The easiest solution is to disable this check for the TestApp.

The `permitted_hosts` could be more elaborated, e.g. `set :host_authorization, { permitted_hosts: [".example.com", "127.0.0.1"] }` also helped. While it seems weird to me, the `127.0.0.1` needs to be included to pass the test in [spec/session/current_url_spec.rb](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/spec/session/current_url_spec.rb)  🤷

I have also tested this PR against Sinatra / Rack::Protection 4.0.1 and the "unknown" `:host_authorization` does not seem to cause any troubles.

This should help address issues observed in #2811

[1]: https://github.com/sinatra/sinatra/pull/2053