### PR TITLE
CI: Use Ruby 3.2-3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.2", "3.3", "3.4"]
         task: ["rack_smoke", "cucumber"]
 
     steps:
@@ -47,7 +47,7 @@ jobs:
       # Ensure all jobs are run to completion
       fail-fast: false
       matrix:
-        ruby: ["3.2"]
+        ruby: ["3.4"]
         task: ["spec_chrome", "spec_firefox"]
 
     steps:
@@ -72,7 +72,7 @@ jobs:
       # Ensure all jobs are run to completion
       fail-fast: false
       matrix:
-        ruby: ["3.0"]
+        ruby: ["3.2"]
         task: ["spec_chrome", "spec_firefox"]
 
     steps:
@@ -95,7 +95,7 @@ jobs:
 
   #   strategy:
   #     matrix:
-  #       ruby: ["3.0"]
+  #       ruby: ["3.2"]
 
   #   steps:
   #     - uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
 
   #   strategy:
   #     matrix:
-  #       ruby: ["3.1"]
+  #       ruby: ["3.2"]
 
   #   steps:
   #     - uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
       # Ensure all jobs are run to completion
       fail-fast: false
       matrix:
-        ruby: ["3.0"]
+        ruby: ["3.2"]
         task: ["spec_chrome", "spec_firefox"]
 
     steps:
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2"]
+        ruby: ["3.4"]
         task: ["spec_rack"]
 
     steps:


### PR DESCRIPTION
This PR changes the build matrix in CI to test on Ruby versions that are currently in support (not EOL'd).