### PR TITLE
In RSpec switch drivers before executing the `around` block

### DIFF
--- a/lib/capybara/rspec.rb
+++ b/lib/capybara/rspec.rb
@@ -15,17 +15,18 @@ RSpec.configure do |config|
 
   # The before and after blocks must run instantaneously, because Capybara
   # might not actually be used in all examples where it's included.
-  config.after do
-    if self.class.include?(Capybara::DSL)
-      Capybara.reset_sessions!
-      Capybara.use_default_driver
-    end
-  end
-
-  config.before do |example|
+  config.around do |example|
     if self.class.include?(Capybara::DSL)
       Capybara.current_driver = Capybara.javascript_driver if example.metadata[:js]
       Capybara.current_driver = example.metadata[:driver] if example.metadata[:driver]
+    end
+
+    example.run
+
+  ensure
+    if self.class.include?(Capybara::DSL)
+      Capybara.reset_sessions!
+      Capybara.use_default_driver
     end
   end
 end

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -45,6 +45,17 @@ RSpec.describe 'capybara/rspec' do
       expect(Capybara.current_driver).to eq(:culerity)
     end
 
+    context 'switches to the javascript driver when giving it as metadata before executing the around block', :js do
+      around do |spec|
+        @current_driver = Capybara.current_driver
+        spec.run
+      end
+
+      it 'switches the current driver before executing the around block' do
+        expect(@current_driver).to eq(Capybara.javascript_driver)
+      end
+    end
+
     describe '#all' do
       it 'allows access to the Capybara finder' do
         visit('/with_html')


### PR DESCRIPTION
Currently in the RSpec integration the `current_driver` is switched, based on the metadata, in a `before` block.  That's too late for specs using an `around` block (as `around` is executed before `before`). 

This changes switching the `current_driver` to make it also available in `around` blocks.