### PR TITLE
beforeUnload prompt tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ RSpec::Core::RakeTask.new(:spec_firefox) do |t|
   t.pattern = './spec{,/*/**}/*{_spec.rb,_spec_firefox.rb}'
 end
 
-%w[chrome ie edge chrome_remote firefox_remote safari].each do |driver|
+%w[chrome ie edge chrome_remote firefox_remote safari multi_chrome].each do |driver|
   desc "Run tests using #{driver} driver"
   RSpec::Core::RakeTask.new(:"spec_#{driver}") do |t|
     t.rspec_opts = rspec_opts

--- a/lib/capybara/spec/views/with_unload_alert.erb
+++ b/lib/capybara/spec/views/with_unload_alert.erb
@@ -3,11 +3,16 @@
 <head>
   <script>
       window.onbeforeunload = function(e) {
+        e.preventDefault();
         return 'Unload?';
       };
   </script>
 </head>
 <body>
+  <form>
+    <label for="data">Data</label>
+    <input id="data" name="data" type="text">
+  </form>
   <div>This triggers an alert on unload</div>
 
   <a href="/">Go away</a>

--- a/spec/selenium_spec_multi_chrome.rb
+++ b/spec/selenium_spec_multi_chrome.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'selenium-webdriver'
+
+CHROME_VERSIONS = %w[135 136 138 139].freeze
+
+Selenium::WebDriver::Chrome.path = '/usr/bin/google-chrome-beta' if ENV.fetch('CI', nil) && ENV.fetch('CHROME_BETA', nil)
+
+Selenium::WebDriver.logger.ignore(:selenium_manager)
+
+def build_driver(chrome_version)
+  Capybara.register_driver :"chrome_#{chrome_version}" do |app|
+    browser_options = Selenium::WebDriver::Chrome::Options.new
+    browser_options.unhandled_prompt_behavior = :ignore
+    browser_options.browser_version = chrome_version
+    browser_options.web_socket_url = true
+
+    version = Capybara::Selenium::Driver.load_selenium
+    options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
+    driver_options = { browser: :chrome, timeout: 5 }
+    driver_options[options_key] = browser_options
+
+    Capybara::Selenium::Driver.new(app, **driver_options)
+  end
+end
+
+CHROME_VERSIONS.each do |version|
+  build_driver(version)
+end
+
+Capybara::SpecHelper.log_selenium_driver_version(Selenium::WebDriver::Chrome) if ENV['CI']
+
+RSpec.shared_examples 'beforeunload checks' do |session|
+  it "#{session.mode} should accept browser modal", requires: [:modals] do
+    session.visit('/with_unload_alert')
+    session.fill_in 'data', with: 'this is data'
+    session.accept_confirm do
+      session.click_link('Go away')
+    end
+    expect(session).to have_text('Hello world')
+  end
+end
+
+RSpec.describe 'testing with' do
+  include Capybara::SpecHelper
+
+  CHROME_VERSIONS.each do |version|
+    include_examples 'beforeunload checks', Capybara::Session.new(:"chrome_#{version}", TestApp)
+  end
+end


### PR DESCRIPTION
This PR adds tests to demonstate that handling browser beforeUnload prompts stopped working in Chrome 137 and later.

The test runs on chrome 135,136,138,139.

versions 135 & 136 pass
versions 138 & 139 fail.

```
$ bundle install
$ bundle exec rake spec_multi_chrome

Failures:

  1) testing with chrome_139 should accept browser modal
     Failure/Error: raise Capybara::ModalNotFound, "Unable to find modal dialog#{" with #{text}" if text}"

  2) testing with chrome_138 should accept browser modal
     Failure/Error: raise Capybara::ModalNotFound, "Unable to find modal dialog#{" with #{text}" if text}"

Finished in 10.22 seconds (files took 0.59535 seconds to load)
4 examples, 2 failures

Failed examples:

rspec './spec/selenium_spec_multi_chrome.rb[1:4]' # testing with chrome_139 should accept browser modal
rspec './spec/selenium_spec_multi_chrome.rb[1:3]' # testing with chrome_138 should accept browser modal
```

The test is simple:
```
    session.visit('/with_unload_alert')
    session.fill_in 'data', with: 'this is data'
    session.accept_confirm do
      session.click_link('Go away')
    end
    expect(session).to have_text('Hello world')
```

In chrome 137 and later the modal is never shown and instead the link is followed without prompting.
