### PR TITLE
Fix `assert_selector` support for `Hash` locator

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+### Fixed
+
+* `assert_selector` can accept `Hash` instance as locator [Sean Doyle]
+
 # Version 3.40.0
 Release date: 2024-01-26
 

--- a/lib/capybara/node/matchers.rb
+++ b/lib/capybara/node/matchers.rb
@@ -892,7 +892,7 @@ module Capybara
       def _set_query_session_options(*query_args)
         query_args, query_options = query_args.dup, {}
         # query_options = query_args.pop if query_options.empty? && query_args.last.is_a?(Hash)
-        query_options = query_args.pop if query_args.last.is_a?(Hash)
+        query_options = query_args.pop if query_args.last.is_a?(Hash) && query_args.last.keys.none?(String)
         query_options[:session_options] = session_options
         [query_args, query_options]
       end

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -107,6 +107,7 @@ class MinitestTest < Minitest::Test
     assert_table('agent_table')
     assert_no_table('not_on_form')
     refute_table('not_on_form')
+    assert_selector(:table_row, 'First Name' => 'Thomas')
   end
 
   def test_assert_all_of_selectors
@@ -170,6 +171,6 @@ RSpec.describe 'capybara/minitest' do
     reporter.start
     MinitestTest.run reporter, {}
     reporter.report
-    expect(output.string).to include('23 runs, 56 assertions, 0 failures, 0 errors, 1 skips')
+    expect(output.string).to include('23 runs, 57 assertions, 0 failures, 0 errors, 1 skips')
   end
 end


### PR DESCRIPTION
Prior to this commit, the following style of assertion fails:

```ruby
assert_selector :table_row, "First Name" => "John", "Last Name" => "Doe"
```

The assertion cites that the `"First Name"` is an invalid option, signaling that it's being treated as a filter rather than a locator value:

```
ArgumentError: Invalid option(s) "First Name", should be one of :above,
  :below, :left_of, :right_of, :near, :text, :id, :class, :style,
  :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait,
  :filter_set, :focused
```

To resolve this issue, modify the private
`Capybara::Node::Matchers#_set_query_session_options` to treat the last positional argument as a positional argument (rather than a pseudo keyword argument) if it's a `Hash` with any `String` keys.