### PR TITLE
Fix kwargs in `assert_*_of_selectors` methods in minitest

### DIFF
--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -48,7 +48,26 @@ module Capybara
       # @!method assert_no_current_path
       #   See {Capybara::SessionMatchers#assert_no_current_path}
 
-      %w[text no_text title no_title current_path no_current_path].each do |assertion_name|
+      ##
+      # Assert all of the provided selectors exist on page
+      #
+      # @!method assert_all_of_selectors
+      #   See {Capybara::Node::Matchers#assert_all_of_selectors}
+
+      ##
+      # Assert none of the provided selectors exist on page
+      #
+      # @!method assert_none_of_selectors
+      #   See {Capybara::Node::Matchers#assert_none_of_selectors}
+
+      ##
+      # Assert any of the provided selectors exist on page
+      #
+      # @!method assert_any_of_selectors
+      #   See {Capybara::Node::Matchers#assert_any_of_selectors}
+
+      %w[text no_text title no_title current_path no_current_path
+         all_of_selectors none_of_selectors any_of_selectors].each do |assertion_name|
         class_eval <<-ASSERTION, __FILE__, __LINE__ + 1
           def assert_#{assertion_name}(*args, **kwargs, &optional_filter_block)
             self.assertions +=1
@@ -94,24 +113,6 @@ module Capybara
       #   See {Capybara::Node::Matchers#assert_not_matches_selector}
 
       ##
-      # Assert all of the provided selectors exist on page
-      #
-      # @!method assert_all_of_selectors
-      #   See {Capybara::Node::Matchers#assert_all_of_selectors}
-
-      ##
-      # Assert none of the provided selectors exist on page
-      #
-      # @!method assert_none_of_selectors
-      #   See {Capybara::Node::Matchers#assert_none_of_selectors}
-
-      ##
-      # Assert any of the provided selectors exist on page
-      #
-      # @!method assert_any_of_selectors
-      #   See {Capybara::Node::Matchers#assert_any_of_selectors}
-
-      ##
       # Assert element has the provided CSS styles
       #
       # @!method assert_matches_style
@@ -144,7 +145,6 @@ module Capybara
       #   See {Capybara::Node::Matchers#assert_no_ancestor}
 
       %w[selector no_selector matches_style
-         all_of_selectors none_of_selectors any_of_selectors
          matches_selector not_matches_selector
          sibling no_sibling ancestor no_ancestor].each do |assertion_name|
         class_eval <<-ASSERTION, __FILE__, __LINE__ + 1

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -110,7 +110,7 @@ class MinitestTest < Minitest::Test
   end
 
   def test_assert_all_of_selectors
-    assert_all_of_selectors(:css, 'select#form_other_title', 'input#form_last_name')
+    assert_all_of_selectors(:css, 'select#form_other_title', 'input#form_super_secret', visible: false)
   end
 
   def test_assert_none_of_selectors

--- a/spec/minitest_spec_spec.rb
+++ b/spec/minitest_spec_spec.rb
@@ -95,7 +95,7 @@ class MinitestSpecTest < Minitest::Spec
   end
 
   it 'supports all_of_selectors expectations' do
-    _(page).must_have_all_of_selectors(:css, 'select#form_other_title', 'input#form_last_name')
+    _(page).must_have_all_of_selectors(:css, 'select#form_other_title', 'input#form_super_secret', visible: false)
   end
 
   it 'supports none_of_selectors expectations' do


### PR DESCRIPTION
When calling `assert_*_of_selectors` on self in minitest the kwargs get pushed to args.

To reproduce replace `assert_all_of_selectors(:css, 'select#form_other_title', 'input#form_last_name')` with `assert_all_of_selectors(:css, 'select#form_other_title', "input#form_super_secret", visible: false)` in [minitest_spec.rb](https://github.com/teamcapybara/capybara/blob/b3325b198464b806f07ec2011ceb532d6d5cf4ab/spec/minitest_spec.rb#L113).

The fix is to just use the right generator method in [minitest.rb](https://github.com/teamcapybara/capybara/blob/master/lib/capybara/minitest.rb)