### PR TITLE
Fix Node#assert_text assertion counting in Minitest

### DIFF
--- a/lib/capybara/minitest.rb
+++ b/lib/capybara/minitest.rb
@@ -2,9 +2,47 @@
 
 require 'minitest'
 require 'capybara/dsl'
+require 'capybara/node/matchers'
 
 module Capybara
   module Minitest
+    module NodeAssertionsCounter
+      def assert_text(...)
+        increment_minitest_assertions unless called_from_minitest_assertion_wrapper?
+        super
+      end
+
+      def assert_no_text(...)
+        increment_minitest_assertions unless called_from_minitest_assertion_wrapper?
+        super
+      end
+
+    private
+
+      def called_from_minitest_assertion_wrapper?
+        caller_locations(2, 5).any? do |loc|
+          loc.path&.end_with?("/capybara/minitest.rb")
+        end
+      end
+
+      def increment_minitest_assertions
+        test_context = Thread.current[:capybara_minitest_test_context]
+        return unless test_context&.respond_to?(:assertions) && test_context.respond_to?(:assertions=)
+
+        test_context.assertions += 1
+      end
+    end
+
+    module TestContextTracker
+      def run(...)
+        previous_context = Thread.current[:capybara_minitest_test_context]
+        Thread.current[:capybara_minitest_test_context] = self
+        super
+      ensure
+        Thread.current[:capybara_minitest_test_context] = previous_context
+      end
+    end
+
     module Assertions
       ##
       # Assert text exists
@@ -396,3 +434,7 @@ module Capybara
     end
   end
 end
+
+Capybara::Node::Matchers.prepend(Capybara::Minitest::NodeAssertionsCounter)
+
+::Minitest::Test.prepend(Capybara::Minitest::TestContextTracker)

--- a/spec/minitest_spec.rb
+++ b/spec/minitest_spec.rb
@@ -25,6 +25,14 @@ class MinitestTest < Minitest::Test
     refute_text('Also Not on the page')
   end
 
+  def test_node_assert_text_counts_assertions
+    before_assertions = assertions
+
+    find(:css, 'form', text: 'Title').assert_text('Customer Email')
+
+    assert_equal before_assertions + 2, assertions
+  end
+
   def test_assert_title
     visit('/with_title')
     assert_title('Test Title')
@@ -170,6 +178,6 @@ RSpec.describe 'capybara/minitest' do
     reporter.start
     MinitestTest.run reporter, {}
     reporter.report
-    expect(output.string).to include('23 runs, 56 assertions, 0 failures, 0 errors, 1 skips')
+    expect(output.string).to include('24 runs, 58 assertions, 0 failures, 0 errors, 1 skips')
   end
 end


### PR DESCRIPTION
## Summary
- fix issue #2828 by incrementing Minitest assertion count when `Capybara::Node::Matchers#assert_text`/`assert_no_text` are called directly on nodes
- keep existing behavior for `Capybara::Minitest::Assertions#assert_text` wrappers (no double count)
- add a regression test in `spec/minitest_spec.rb` covering node-level `assert_text` assertion counting

## Verification
- `docker run --rm -v "$PWD":/app -w /app ruby:3.3 bash -lc "bundle install >/dev/null && bundle exec ruby -I. -I./spec spec/minitest_spec.rb"`
- manual runtime verification via a temporary Minitest file, confirming assertion counters:
  - helper `assert_text` increments assertions
  - node `assert_text` now also increments assertions