### PR TITLE
Add support for coordinates on `dragstart`, and related drag_to adjustments to work with react-dnd's HTML5 implementation

### DIFF
--- a/lib/capybara/node/element.rb
+++ b/lib/capybara/node/element.rb
@@ -407,7 +407,11 @@ module Capybara
       # @param [Capybara::Node::Element] node     The element to drag to
       # @param [Hash] options  Driver specific options for dragging. May not be supported by all drivers.
       # @option options [Numeric] :delay   (0.05) When using Chrome/Firefox with Selenium and HTML5 dragging this is the number
-      #                                    of seconds between each stage of the drag.
+      #                                    of seconds between each stage of the drag. Libraries that use
+      #                                    requestAnimationFrame for hover scheduling (e.g. react-dnd) may require
+      #                                    `delay: 0` to prevent RAF callbacks and React effects from running
+      #                                    between events, which can cause listeners to be removed and reattached
+      #                                    mid-sequence.
       # @option options [Boolean] :html5   When using Chrome/Firefox with Selenium enables to force the use of HTML5
       #                                    (true) or legacy (false) dragging. If not specified the driver will attempt to
       #                                    detect the correct method to use.

--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -103,13 +103,15 @@ class Capybara::Selenium::Node
 
     LEGACY_DRAG_CHECK = <<~JS
       (function(el){
+        var originalEl = el;
         if ([true, null].indexOf(window.capybara_mousedown_prevented) >= 0){
           return true;
         }
 
         do {
           if (el.draggable) return false;
-        } while (el = el.parentElement );
+        } while (el = el.parentElement);
+        if (originalEl.querySelector && originalEl.querySelector('[draggable="true"]')) return false;
         return true;
       })(arguments[0])
     JS
@@ -166,11 +168,12 @@ class Capybara::Selenium::Node
           opts[key + 'Key'] = true;
         }
 
-        var dragEnterEvent = new DragEvent('dragenter', opts);
+        var entryPoint = pointOnRect(sourceCenter, targetRect)
+        var enterOpts = Object.assign({clientX: entryPoint.x, clientY: entryPoint.y}, opts);
+        var dragEnterEvent = new DragEvent('dragenter', enterOpts);
         target.dispatchEvent(dragEnterEvent);
 
         // fire 2 dragover events to simulate dragging with a direction
-        var entryPoint = pointOnRect(sourceCenter, targetRect)
         var dragOverOpts = Object.assign({clientX: entryPoint.x, clientY: entryPoint.y}, opts);
         var dragOverEvent = new DragEvent('dragover', dragOverOpts);
         target.dispatchEvent(dragOverEvent);
@@ -207,8 +210,15 @@ class Capybara::Selenium::Node
       var dt = new DataTransfer();
       var opts = { cancelable: true, bubbles: true, dataTransfer: dt };
 
-      while (source && !source.draggable) {
-        source = source.parentElement;
+      if (!source.draggable) {
+        var child = source.querySelector('[draggable="true"]');
+        if (child) {
+          source = child;
+        } else {
+          while (source && !source.draggable) {
+            source = source.parentElement;
+          }
+        }
       }
 
       if (source.tagName == 'A'){
@@ -220,7 +230,9 @@ class Capybara::Selenium::Node
         dt.setData('text', source.src);
       }
 
-      var dragEvent = new DragEvent('dragstart', opts);
+      var srcCenter = rectCenter(source.getBoundingClientRect());
+      var dragStartOpts = Object.assign({clientX: srcCenter.x, clientY: srcCenter.y}, opts);
+      var dragEvent = new DragEvent('dragstart', dragStartOpts);
       source.dispatchEvent(dragEvent);
 
       window.setTimeout(dragEnterTarget, step_delay);

--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -155,6 +155,12 @@ class Capybara::Selenium::Node
         return new DOMPoint(pt.x,pt.y);
       }
 
+      function dispatchOnElement(pt, event) {
+        var el = document.elementFromPoint(pt.x, pt.y);
+        if (!el || !target.contains(el)) el = target;
+        el.dispatchEvent(event);
+      }
+
       function dragEnterTarget() {
         target.scrollIntoView({behavior: 'instant', block: 'center', inline: 'center'});
         var targetRect = target.getBoundingClientRect();
@@ -171,12 +177,12 @@ class Capybara::Selenium::Node
         var entryPoint = pointOnRect(sourceCenter, targetRect)
         var enterOpts = Object.assign({clientX: entryPoint.x, clientY: entryPoint.y}, opts);
         var dragEnterEvent = new DragEvent('dragenter', enterOpts);
-        target.dispatchEvent(dragEnterEvent);
+        dispatchOnElement(entryPoint, dragEnterEvent);
 
         // fire 2 dragover events to simulate dragging with a direction
         var dragOverOpts = Object.assign({clientX: entryPoint.x, clientY: entryPoint.y}, opts);
         var dragOverEvent = new DragEvent('dragover', dragOverOpts);
-        target.dispatchEvent(dragOverEvent);
+        dispatchOnElement(entryPoint, dragOverEvent);
         window.setTimeout(dragOnTarget, step_delay);
       }
 
@@ -184,18 +190,19 @@ class Capybara::Selenium::Node
         var targetCenter = rectCenter(target.getBoundingClientRect());
         var dragOverOpts = Object.assign({clientX: targetCenter.x, clientY: targetCenter.y}, opts);
         var dragOverEvent = new DragEvent('dragover', dragOverOpts);
-        target.dispatchEvent(dragOverEvent);
+        dispatchOnElement(targetCenter, dragOverEvent);
         window.setTimeout(dragLeave, step_delay, dragOverEvent.defaultPrevented, dragOverOpts);
       }
 
       function dragLeave(drop, dragOverOpts) {
         var dragLeaveOptions = Object.assign({}, opts, dragOverOpts);
+        var pt = {x: dragOverOpts.clientX, y: dragOverOpts.clientY};
         if (drop) {
           var dropEvent = new DragEvent('drop', dragLeaveOptions);
-          target.dispatchEvent(dropEvent);
+          dispatchOnElement(pt, dropEvent);
         } else {
           var dragLeaveEvent = new DragEvent('dragleave', dragLeaveOptions);
-          target.dispatchEvent(dragLeaveEvent);
+          dispatchOnElement(pt, dragLeaveEvent);
         }
         var dragEndEvent = new DragEvent('dragend', dragLeaveOptions);
         source.dispatchEvent(dragEndEvent);

--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -190,11 +190,12 @@ class Capybara::Selenium::Node
 
       function dragLeave(drop, dragOverOpts) {
         var dragLeaveOptions = Object.assign({}, opts, dragOverOpts);
-        var dragLeaveEvent = new DragEvent('dragleave', dragLeaveOptions);
-        target.dispatchEvent(dragLeaveEvent);
         if (drop) {
           var dropEvent = new DragEvent('drop', dragLeaveOptions);
           target.dispatchEvent(dropEvent);
+        } else {
+          var dragLeaveEvent = new DragEvent('dragleave', dragLeaveOptions);
+          target.dispatchEvent(dragLeaveEvent);
         }
         var dragEndEvent = new DragEvent('dragend', dragLeaveOptions);
         source.dispatchEvent(dragEndEvent);

--- a/lib/capybara/selenium/extensions/html5_drag.rb
+++ b/lib/capybara/selenium/extensions/html5_drag.rb
@@ -243,7 +243,12 @@ class Capybara::Selenium::Node
       var dragEvent = new DragEvent('dragstart', dragStartOpts);
       source.dispatchEvent(dragEvent);
 
-      window.setTimeout(dragEnterTarget, step_delay);
+      // Yield once to the event loop so libraries that defer work after
+      // dragstart (e.g. react-dnd's publishDragSource via setTimeout(0))
+      // can complete before we dispatch dragenter.
+      window.setTimeout(function() {
+        window.setTimeout(dragEnterTarget, step_delay);
+      }, 0);
     JS
   end
 end

--- a/lib/capybara/spec/public/test.js
+++ b/lib/capybara/spec/public/test.js
@@ -26,7 +26,7 @@ $(function() {
       );
     }
   });
-  $('#drag_html5, #drag_html5_scroll').on('dragstart', function(ev){
+  $('#drag_html5, #drag_html5_scroll, #drag_html5_wrapped').on('dragstart', function(ev){
     $(document.body).append(
         "<div class='drag_start'>HTML5 Dragged!" +
           (event.altKey ? "-alt" : "") +
@@ -37,7 +37,10 @@ $(function() {
     );
     ev.originalEvent.dataTransfer.setData("text", ev.target.id);
   });
-  $('#drag_html5, #drag_html5_scroll').on('dragend', function(ev){
+  $('#drag_html5, #drag_html5_scroll, #drag_html5_wrapped').on('dragstart', function(ev){
+    $(this).after('<div class="log">DragStart with client position: ' + ev.originalEvent.clientX + ',' + ev.originalEvent.clientY)
+  });
+  $('#drag_html5, #drag_html5_scroll, #drag_html5_wrapped').on('dragend', function(ev){
     $(this).after('<div class="log">DragEnd with client position: ' + ev.clientX + ',' + ev.clientY)
   });
   $('#drop_html5, #drop_html5_scroll').on('dragover', function(ev){
@@ -45,7 +48,7 @@ $(function() {
     if ($(this).hasClass('drop')) { ev.preventDefault(); }
   });
   $('#drop_html5, #drop_html5_scroll').on('dragenter', function(ev){
-    $(this).after('<div class="log">DragEnter')
+    $(this).after('<div class="log">DragEnter with client position: ' + ev.clientX + ',' + ev.clientY)
     if ($(this).hasClass('drop')) { ev.preventDefault(); }
   });
   $('#drop_html5, #drop_html5_scroll').on('dragleave', function(ev){

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -583,7 +583,7 @@ Capybara::SpecHelper.spec 'node' do
         target = @session.find('//div[@id="drop_html5"]')
         element.drag_to(target)
 
-        conditions = %w[DragLeave Drop DragEnd].map do |text|
+        conditions = %w[Drop DragEnd].map do |text|
           have_css('div.log', text: text)
         end
         expect(@session).to(conditions.reduce { |memo, cond| memo.and(cond) })
@@ -592,7 +592,6 @@ Capybara::SpecHelper.spec 'node' do
         drag_over_div = @session.first('//div[@class="log" and starts-with(text(), "DragOver")]')
         position = drag_over_div.text.sub('DragOver ', '')
 
-        expect(@session).to have_css('div.log', text: /DragLeave #{position}/, count: 1)
         expect(@session).to have_css('div.log', text: /Drop #{position}/, count: 1)
         expect(@session).to have_css('div.log', text: /DragEnd #{position}/, count: 1)
       end

--- a/lib/capybara/spec/session/node_spec.rb
+++ b/lib/capybara/spec/session/node_spec.rb
@@ -690,6 +690,34 @@ Capybara::SpecHelper.spec 'node' do
         # Events are listed in reverse chronological order
         expect(@session).to have_text(/DragOver.*DragEnter/m)
       end
+
+      it 'should set clientX/Y in dragstart events' do
+        @session.visit('/with_js')
+        element = @session.find('//div[@id="drag_html5"]')
+        target = @session.find('//div[@id="drop_html5"]')
+        element.drag_to(target)
+        expect(@session).to have_css('div.log',
+                                     text: /DragStart with client position: [1-9]\d*,[1-9]\d*/)
+      end
+
+      it 'should set clientX/Y in dragenter events' do
+        @session.visit('/with_js')
+        element = @session.find('//div[@id="drag_html5"]')
+        target = @session.find('//div[@id="drop_html5"]')
+        element.drag_to(target)
+        expect(@session).to have_css('div.log',
+                                     text: /DragEnter with client position: [1-9]\d*,[1-9]\d*/)
+      end
+
+      it 'should HTML5 drag and drop when selecting a wrapper of a draggable' do
+        @session.visit('/with_js')
+        wrapper = @session.find('//div[@id="drag_html5_wrapper"]')
+        target = @session.find('//div[@id="drop_html5"]')
+        wrapper.drag_to(target)
+        expect(@session).to have_xpath(
+          '//div[contains(., "HTML5 Dropped string: text/plain drag_html5_wrapped")]'
+        )
+      end
     end
   end
 

--- a/lib/capybara/spec/views/with_js.erb
+++ b/lib/capybara/spec/views/with_js.erb
@@ -32,6 +32,11 @@
     <div id="drop_html5" class="drop">
       <p>It should be dropped here.</p>
     </div>
+    <div id="drag_html5_wrapper">
+      <div id="drag_html5_wrapped" draggable="true">
+        <p>This is a wrapped HTML5 draggable element.</p>
+      </div>
+    </div>
 
     <p><a href="#" id="clickable">Click me</a></p>
     <p><a href="#" id="slow-click">Slowly</a></p>


### PR DESCRIPTION
I've had some drag-and-drop capybara specs in my test suite for https://github.com/WikiEducationFoundation/WikiEduDashboard that I had to disable years ago when we upgraded `react-dnd` to a version that uses HTML5. At the time, I couldn't find a way to make those specs work. I took a pass with Claude Code today to see if I could find a way to get the specs working, and ended up with a [drag helper](https://github.com/WikiEducationFoundation/WikiEduDashboard/commit/6707e1f1cd510fa9b512c402278101fd498cf596) that worked, in place of Capybara's `drag_to`.

I'm happy to keep that, but I figured since I had a good test case, I would try implementing an upstream fix to make Capybara's `drag_to` compatible with how my app uses `react-dnd`. Here's where I ended up. (Happy to squash these if you'd prefer, but I thought it better to start with the full history of the AI-written commits to be as transparent about the process for getting here as possible.)

I've tested this change locally, and I'm able to successfully run my long-disabled drag-and-drop spec, as long as `delay: 0` is added to the `drag_to` calls. It tool several iterations going between making changes to Capybara, making sure the old and new Capyabara specs still worked, and testing the changes against the spec in my project.

I think this fixes #2662, which was part of the root problem (but not all of it) for why my spec didn't work with HTML5 react-dnd.

Note the potential breaking change in the second commit: https://github.com/teamcapybara/capybara/commit/b305e2946cb12b0ee6b159954a71f366fa166ead

I don't know enough about Capybara or drag-and-drop to be confident about whether this is safe or reasonable, but it seems to make sense and I've watched both my own tests and the affected parts of the Capybara test suite run successfully with these changes.
